### PR TITLE
Add API spec types instead of using protobuf

### DIFF
--- a/agent/aikido_types/api_spec.go
+++ b/agent/aikido_types/api_spec.go
@@ -1,0 +1,27 @@
+package aikido_types
+
+type APIAuthType struct {
+	Type         string `json:"type,omitempty"`
+	Scheme       string `json:"scheme,omitempty"`
+	In           string `json:"in,omitempty"`
+	Name         string `json:"name,omitempty"`
+	BearerFormat string `json:"bearerFormat,omitempty"`
+}
+
+type DataSchema struct {
+	Type       []string               `json:"type"`
+	Properties map[string]*DataSchema `json:"properties,omitempty"`
+	Items      *DataSchema            `json:"items,omitempty"`
+	Optional   bool                   `json:"optional,omitempty"`
+}
+
+type APIBodyInfo struct {
+	Type   string      `json:"type,omitempty"`
+	Schema *DataSchema `json:"schema,omitempty"`
+}
+
+type APISpec struct {
+	Body  *APIBodyInfo   `json:"body,omitempty"`
+	Query *DataSchema    `json:"query,omitempty"`
+	Auth  []*APIAuthType `json:"auth,omitempty"`
+}

--- a/agent/aikido_types/events.go
+++ b/agent/aikido_types/events.go
@@ -1,7 +1,5 @@
 package aikido_types
 
-import "github.com/AikidoSec/firewall-go/agent/ipc/protos"
-
 type OsInfo struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -19,10 +17,10 @@ type Hostname struct {
 }
 
 type Route struct {
-	Path    string          `json:"path"`
-	Method  string          `json:"method"`
-	Hits    int64           `json:"hits"`
-	ApiSpec *protos.APISpec `json:"apispec"`
+	Path    string   `json:"path"`
+	Method  string   `json:"method"`
+	Hits    int64    `json:"hits"`
+	APISpec *APISpec `json:"apispec"`
 }
 
 type User struct {

--- a/agent/api_discovery/get_data_schema.go
+++ b/agent/api_discovery/get_data_schema.go
@@ -3,17 +3,19 @@ package api_discovery
 import (
 	"reflect"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
-const maxDepth = 20
-const maxProperties = 100
+const (
+	maxDepth      = 20
+	maxProperties = 100
+)
 
 // GetDataSchema returns the schema of the given data as a DataSchema
-func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
+func GetDataSchema(data any, depth int) *aikido_types.DataSchema {
 	// If the data is not an object (or an array), return the type
 	if data == nil {
-		return &protos.DataSchema{Type: []string{"null"}}
+		return &aikido_types.DataSchema{Type: []string{"null"}}
 	}
 
 	dataType := reflect.TypeOf(data)
@@ -23,18 +25,18 @@ func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
 		// If the data is an array/slice, return an array schema
 		v := reflect.ValueOf(data)
 		if v.Len() > 0 {
-			return &protos.DataSchema{
+			return &aikido_types.DataSchema{
 				Type:  []string{"array"},
 				Items: GetDataSchema(v.Index(0).Interface(), depth+1),
 			}
 		} else {
-			return &protos.DataSchema{Type: []string{"array"}}
+			return &aikido_types.DataSchema{Type: []string{"array"}}
 		}
 	case reflect.Map:
 		// Create an object schema with properties
-		schema := protos.DataSchema{
+		schema := aikido_types.DataSchema{
 			Type:       []string{"object"},
-			Properties: make(map[string]*protos.DataSchema),
+			Properties: make(map[string]*aikido_types.DataSchema),
 		}
 
 		// Traverse properties if within depth
@@ -53,16 +55,16 @@ func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return &protos.DataSchema{Type: []string{"number"}}
+		return &aikido_types.DataSchema{Type: []string{"number"}}
 
 	case reflect.Float32, reflect.Float64:
-		return &protos.DataSchema{Type: []string{"number"}}
+		return &aikido_types.DataSchema{Type: []string{"number"}}
 
 	case reflect.Bool:
-		return &protos.DataSchema{Type: []string{"boolean"}}
+		return &aikido_types.DataSchema{Type: []string{"boolean"}}
 
 	default:
 		// If the data is not an object or array, return its type
-		return &protos.DataSchema{Type: []string{dataType.Kind().String()}}
+		return &aikido_types.DataSchema{Type: []string{dataType.Kind().String()}}
 	}
 }

--- a/agent/api_discovery/get_data_schema_test.go
+++ b/agent/api_discovery/get_data_schema_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
 // Helper function for comparing two DataSchema structs
-func compareSchemas(t *testing.T, got, expected *protos.DataSchema) {
+func compareSchemas(t *testing.T, got, expected *aikido_types.DataSchema) {
 	gotJson, _ := json.Marshal(got)
 	expectedJson, _ := json.Marshal(expected)
 
@@ -21,31 +21,31 @@ func compareSchemas(t *testing.T, got, expected *protos.DataSchema) {
 
 func TestGetDataSchema(t *testing.T) {
 	t.Run("it works", func(t *testing.T) {
-		compareSchemas(t, GetDataSchema("test", 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema("test", 0), &aikido_types.DataSchema{
 			Type: []string{"string"},
 		})
 
-		compareSchemas(t, GetDataSchema([]string{"test"}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema([]string{"test"}, 0), &aikido_types.DataSchema{
 			Type: []string{"array"},
-			Items: &protos.DataSchema{
+			Items: &aikido_types.DataSchema{
 				Type: []string{"string"},
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": "abc"}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": "abc"}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"string"}},
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": 123, "arr": []int{1, 2, 3}}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": 123, "arr": []int{1, 2, 3}}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"number"}},
 				"arr": {
 					Type: []string{"array"},
-					Items: &protos.DataSchema{
+					Items: &aikido_types.DataSchema{
 						Type: []string{"number"},
 					},
 				},
@@ -56,15 +56,15 @@ func TestGetDataSchema(t *testing.T) {
 			"test": 123,
 			"arr":  []interface{}{map[string]interface{}{"sub": true}},
 			"x":    nil,
-		}, 0), &protos.DataSchema{
+		}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"number"}},
 				"arr": {
 					Type: []string{"array"},
-					Items: &protos.DataSchema{
+					Items: &aikido_types.DataSchema{
 						Type: []string{"object"},
-						Properties: map[string]*protos.DataSchema{
+						Properties: map[string]*aikido_types.DataSchema{
 							"sub": {Type: []string{"boolean"}},
 						},
 					},
@@ -82,18 +82,18 @@ func TestGetDataSchema(t *testing.T) {
 				},
 			},
 			"arr": []interface{}{},
-		}, 0), &protos.DataSchema{
+		}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {
 					Type: []string{"object"},
-					Properties: map[string]*protos.DataSchema{
+					Properties: map[string]*aikido_types.DataSchema{
 						"x": {
 							Type: []string{"object"},
-							Properties: map[string]*protos.DataSchema{
+							Properties: map[string]*aikido_types.DataSchema{
 								"y": {
 									Type: []string{"object"},
-									Properties: map[string]*protos.DataSchema{
+									Properties: map[string]*aikido_types.DataSchema{
 										"z": {Type: []string{"number"}},
 									},
 								},

--- a/agent/api_discovery/is_primitive_type.go
+++ b/agent/api_discovery/is_primitive_type.go
@@ -1,6 +1,6 @@
 package api_discovery
 
-func onlyContainsPrimitiveTypes(types interface{}) bool {
+func onlyContainsPrimitiveTypes(types any) bool {
 	switch t := types.(type) {
 	case string:
 		return isPrimitiveType(t)

--- a/agent/api_discovery/merge_api_auth_types.go
+++ b/agent/api_discovery/merge_api_auth_types.go
@@ -1,12 +1,12 @@
 package api_discovery
 
 import (
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
-// Merge two APIAuthType slices into one without duplicates.
+// MergeAPIAuthTypes slices into one without duplicates.
 // It can return nil if both parameters are not slices.
-func MergeApiAuthTypes(existing, newAuth []*protos.APIAuthType) []*protos.APIAuthType {
+func MergeAPIAuthTypes(existing, newAuth []*aikido_types.APIAuthType) []*aikido_types.APIAuthType {
 	if len(newAuth) == 0 {
 		return existing
 	}
@@ -15,7 +15,7 @@ func MergeApiAuthTypes(existing, newAuth []*protos.APIAuthType) []*protos.APIAut
 		return newAuth
 	}
 
-	result := make([]*protos.APIAuthType, len(existing))
+	result := make([]*aikido_types.APIAuthType, len(existing))
 	copy(result, existing)
 
 	for _, auth := range newAuth {
@@ -28,12 +28,12 @@ func MergeApiAuthTypes(existing, newAuth []*protos.APIAuthType) []*protos.APIAut
 }
 
 // Compare two APIAuthType objects for equality.
-func isEqualAPIAuthType(a, b *protos.APIAuthType) bool {
+func isEqualAPIAuthType(a, b *aikido_types.APIAuthType) bool {
 	return a.Type == b.Type && a.In == b.In && a.Name == b.Name && a.Scheme == b.Scheme
 }
 
 // Check if the slice contains an APIAuthType
-func containsAPIAuthType(slice []*protos.APIAuthType, auth *protos.APIAuthType) bool {
+func containsAPIAuthType(slice []*aikido_types.APIAuthType, auth *aikido_types.APIAuthType) bool {
 	for _, a := range slice {
 		if isEqualAPIAuthType(a, auth) {
 			return true

--- a/agent/api_discovery/merge_api_auth_types_test.go
+++ b/agent/api_discovery/merge_api_auth_types_test.go
@@ -4,25 +4,25 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
 // TestMergeApiAuthTypes tests the mergeApiAuthTypes function.
 func TestMergeApiAuthTypes(t *testing.T) {
 	// Test case 1: Merge two valid arrays
-	result := MergeApiAuthTypes(
-		[]*protos.APIAuthType{
+	result := MergeAPIAuthTypes(
+		[]*aikido_types.APIAuthType{
 			{Type: "http", Scheme: ("bearer")},
 			{Type: "apiKey", In: ("header"), Name: ("x-api-key")},
 		},
-		[]*protos.APIAuthType{
+		[]*aikido_types.APIAuthType{
 			{Type: "http", Scheme: ("bearer")},
 			{Type: "http", Scheme: ("basic")},
 			{Type: "apiKey", In: ("header"), Name: ("x-api-key-v2")},
 		},
 	)
 
-	expected := []*protos.APIAuthType{
+	expected := []*aikido_types.APIAuthType{
 		{Type: "http", Scheme: ("bearer")},
 		{Type: "apiKey", In: ("header"), Name: ("x-api-key")},
 		{Type: "http", Scheme: ("basic")},
@@ -34,20 +34,20 @@ func TestMergeApiAuthTypes(t *testing.T) {
 	}
 
 	// Test case 2: Both arguments are nil, should return nil
-	result = MergeApiAuthTypes(nil, nil)
+	result = MergeAPIAuthTypes(nil, nil)
 	if result != nil {
 		t.Errorf("Expected nil, but got %v", result)
 	}
 
 	// Test case 3: Existing array is provided, newAuth is nil
-	result = MergeApiAuthTypes(
-		[]*protos.APIAuthType{
+	result = MergeAPIAuthTypes(
+		[]*aikido_types.APIAuthType{
 			{Type: "http", Scheme: ("bearer")},
 		},
 		nil,
 	)
 
-	expected = []*protos.APIAuthType{
+	expected = []*aikido_types.APIAuthType{
 		{Type: "http", Scheme: ("bearer")},
 	}
 
@@ -56,14 +56,14 @@ func TestMergeApiAuthTypes(t *testing.T) {
 	}
 
 	// Test case 4: Existing array is nil, newAuth is provided
-	result = MergeApiAuthTypes(
+	result = MergeAPIAuthTypes(
 		nil,
-		[]*protos.APIAuthType{
+		[]*aikido_types.APIAuthType{
 			{Type: "http", Scheme: ("digest")},
 		},
 	)
 
-	expected = []*protos.APIAuthType{
+	expected = []*aikido_types.APIAuthType{
 		{Type: "http", Scheme: ("digest")},
 	}
 

--- a/agent/api_discovery/merge_data_schemas.go
+++ b/agent/api_discovery/merge_data_schemas.go
@@ -3,11 +3,11 @@ package api_discovery
 import (
 	"reflect"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
-// mergeDataSchemas merges two DataSchema objects.
-func MergeDataSchemas(first *protos.DataSchema, second *protos.DataSchema) *protos.DataSchema {
+// MergeDataSchemas merges two DataSchema objects.
+func MergeDataSchemas(first *aikido_types.DataSchema, second *aikido_types.DataSchema) *aikido_types.DataSchema {
 	if first == nil {
 		return second
 	}
@@ -19,10 +19,10 @@ func MergeDataSchemas(first *protos.DataSchema, second *protos.DataSchema) *prot
 		return mergeTypes(first, second)
 	}
 
-	result := protos.DataSchema{Type: first.Type}
+	result := aikido_types.DataSchema{Type: first.Type}
 
 	if first.Properties != nil && second.Properties != nil {
-		result.Properties = make(map[string]*protos.DataSchema)
+		result.Properties = make(map[string]*aikido_types.DataSchema)
 		for key, value := range first.Properties {
 			result.Properties[key] = value
 		}
@@ -89,7 +89,7 @@ func doTypeArraysMatch(first, second []string) bool {
 }
 
 // mergeTypes merges two DataSchema objects of different types.
-func mergeTypes(first *protos.DataSchema, second *protos.DataSchema) *protos.DataSchema {
+func mergeTypes(first *aikido_types.DataSchema, second *aikido_types.DataSchema) *aikido_types.DataSchema {
 	// Cannot merge arrays and objects or primitives with non-primitives
 	if !onlyContainsPrimitiveTypes(first.Type) || !onlyContainsPrimitiveTypes(second.Type) {
 		// Prefer non-null type
@@ -99,11 +99,11 @@ func mergeTypes(first *protos.DataSchema, second *protos.DataSchema) *protos.Dat
 		return first
 	}
 
-	return &protos.DataSchema{Type: mergeTypeArrays(first.Type, second.Type)}
+	return &aikido_types.DataSchema{Type: mergeTypeArrays(first.Type, second.Type)}
 }
 
 // mergeTypeArrays merges two types into a single array of unique types.
-func mergeTypeArrays(first, second interface{}) []string {
+func mergeTypeArrays(first, second any) []string {
 	var firstArr, secondArr []string
 
 	switch v := first.(type) {

--- a/agent/api_discovery/merge_data_schemas_test.go
+++ b/agent/api_discovery/merge_data_schemas_test.go
@@ -3,7 +3,7 @@ package api_discovery
 import (
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,11 +12,11 @@ func TestMergeDataSchemas(t *testing.T) {
 	assert := assert.New(t)
 
 	// Example 1
-	schema1 := GetDataSchema(map[string]interface{}{"test": "abc"}, 0)
-	schema2 := GetDataSchema(map[string]interface{}{"test2": "abc"}, 0)
-	expected1 := &protos.DataSchema{
+	schema1 := GetDataSchema(map[string]any{"test": "abc"}, 0)
+	schema2 := GetDataSchema(map[string]any{"test2": "abc"}, 0)
+	expected1 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type:     []string{"string"},
 				Optional: true,
@@ -30,17 +30,17 @@ func TestMergeDataSchemas(t *testing.T) {
 	assert.Equal(expected1, MergeDataSchemas(schema1, schema2))
 
 	// Example 2
-	schema3 := GetDataSchema(map[string]interface{}{"test": "abc", "x": map[string]interface{}{"a": 1}}, 0)
-	schema4 := GetDataSchema(map[string]interface{}{"test": "abc", "x": map[string]interface{}{"b": 2}}, 0)
-	expected2 := &protos.DataSchema{
+	schema3 := GetDataSchema(map[string]any{"test": "abc", "x": map[string]any{"a": 1}}, 0)
+	schema4 := GetDataSchema(map[string]any{"test": "abc", "x": map[string]any{"b": 2}}, 0)
+	expected2 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string"},
 			},
 			"x": {
 				Type: []string{"object"},
-				Properties: map[string]*protos.DataSchema{
+				Properties: map[string]*aikido_types.DataSchema{
 					"a": {
 						Type:     []string{"number"},
 						Optional: true,
@@ -56,17 +56,17 @@ func TestMergeDataSchemas(t *testing.T) {
 	assert.Equal(expected2, MergeDataSchemas(schema3, schema4))
 
 	// Example 3
-	schema5 := GetDataSchema(map[string]interface{}{"test": "abc", "x": map[string]interface{}{"a": 1}, "arr": []int{1, 2}}, 0)
-	schema6 := GetDataSchema(map[string]interface{}{"test": "abc", "x": map[string]interface{}{"a": 1, "b": 2}, "arr": []int{1, 2, 3}}, 0)
-	expected3 := &protos.DataSchema{
+	schema5 := GetDataSchema(map[string]any{"test": "abc", "x": map[string]any{"a": 1}, "arr": []int{1, 2}}, 0)
+	schema6 := GetDataSchema(map[string]any{"test": "abc", "x": map[string]any{"a": 1, "b": 2}, "arr": []int{1, 2, 3}}, 0)
+	expected3 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string"},
 			},
 			"x": {
 				Type: []string{"object"},
-				Properties: map[string]*protos.DataSchema{
+				Properties: map[string]*aikido_types.DataSchema{
 					"a": {
 						Type: []string{"number"},
 					},
@@ -78,7 +78,7 @@ func TestMergeDataSchemas(t *testing.T) {
 			},
 			"arr": {
 				Type: []string{"array"},
-				Items: &protos.DataSchema{
+				Items: &aikido_types.DataSchema{
 					Type: []string{"number"},
 				},
 			},
@@ -90,11 +90,11 @@ func TestMergeDataSchemas(t *testing.T) {
 func TestPreferNonNullType(t *testing.T) {
 	assert := assert.New(t)
 
-	schema1 := GetDataSchema(map[string]interface{}{"test": "abc"}, 0)
+	schema1 := GetDataSchema(map[string]any{"test": "abc"}, 0)
 	schema2 := GetDataSchema(nil, 0)
-	expected1 := &protos.DataSchema{
+	expected1 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string"},
 			},
@@ -107,8 +107,8 @@ func TestPreferNonNullType(t *testing.T) {
 func TestEmptyArray(t *testing.T) {
 	assert := assert.New(t)
 
-	schema1 := GetDataSchema([]interface{}{}, 0)
-	expected := &protos.DataSchema{
+	schema1 := GetDataSchema([]any{}, 0)
+	expected := &aikido_types.DataSchema{
 		Type:  []string{"array"},
 		Items: nil,
 	}
@@ -121,17 +121,17 @@ func TestMergeTypes(t *testing.T) {
 	// Example 1
 	schema1 := GetDataSchema("str", 0)
 	schema2 := GetDataSchema(15, 0)
-	expected := &protos.DataSchema{
+	expected := &aikido_types.DataSchema{
 		Type: []string{"string", "number"},
 	}
 	assert.Equal(expected, MergeDataSchemas(schema1, schema2))
 
 	// Example 2: Cannot merge object with primitive type
-	schema3 := GetDataSchema(map[string]interface{}{"test": "abc"}, 0)
+	schema3 := GetDataSchema(map[string]any{"test": "abc"}, 0)
 	schema4 := GetDataSchema(15, 0)
-	expected2 := &protos.DataSchema{
+	expected2 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string"},
 			},
@@ -140,11 +140,11 @@ func TestMergeTypes(t *testing.T) {
 	assert.Equal(expected2, MergeDataSchemas(schema3, schema4))
 
 	// Example 3: Merge string and boolean types
-	schema5 := GetDataSchema(map[string]interface{}{"test": "abc"}, 0)
-	schema6 := GetDataSchema(map[string]interface{}{"test": true}, 0)
-	expected3 := &protos.DataSchema{
+	schema5 := GetDataSchema(map[string]any{"test": "abc"}, 0)
+	schema6 := GetDataSchema(map[string]any{"test": true}, 0)
+	expected3 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string", "boolean"},
 			},
@@ -155,23 +155,23 @@ func TestMergeTypes(t *testing.T) {
 	// Additional nested merges
 	assert.Equal(expected3, MergeDataSchemas(schema5, MergeDataSchemas(schema5, schema6)))
 
-	expected4 := &protos.DataSchema{
+	expected4 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"boolean", "string"},
 			},
 		},
 	}
-	assert.Equal(expected4, MergeDataSchemas(MergeDataSchemas(GetDataSchema(map[string]interface{}{"test": true}, 0), GetDataSchema(map[string]interface{}{"test": "test"}, 0)), GetDataSchema(map[string]interface{}{"test": "abc"}, 0)))
+	assert.Equal(expected4, MergeDataSchemas(MergeDataSchemas(GetDataSchema(map[string]any{"test": true}, 0), GetDataSchema(map[string]any{"test": "test"}, 0)), GetDataSchema(map[string]any{"test": "abc"}, 0)))
 
-	expected5 := &protos.DataSchema{
+	expected5 := &aikido_types.DataSchema{
 		Type: []string{"object"},
-		Properties: map[string]*protos.DataSchema{
+		Properties: map[string]*aikido_types.DataSchema{
 			"test": {
 				Type: []string{"string", "number", "boolean"},
 			},
 		},
 	}
-	assert.Equal(expected5, MergeDataSchemas(schema5, MergeDataSchemas(GetDataSchema(map[string]interface{}{"test": 123}, 0), GetDataSchema(map[string]interface{}{"test": true}, 0))))
+	assert.Equal(expected5, MergeDataSchemas(schema5, MergeDataSchemas(GetDataSchema(map[string]any{"test": 123}, 0), GetDataSchema(map[string]any{"test": true}, 0))))
 }

--- a/agent/request.go
+++ b/agent/request.go
@@ -45,13 +45,13 @@ func storeSinkStats(sink string, stats *aikido_types.MonitoredSinkTimings) {
 	globals.StatsData.MonitoredSinkTimings[sink] = monitoredSinkTimings
 }
 
-func getApiSpecData(apiSpec *protos.APISpec) (*protos.DataSchema, string, *protos.DataSchema, []*protos.APIAuthType) {
+func getAPISpecData(apiSpec *aikido_types.APISpec) (*aikido_types.DataSchema, string, *aikido_types.DataSchema, []*aikido_types.APIAuthType) {
 	if apiSpec == nil {
 		return nil, "", nil, nil
 	}
 
-	var bodyDataSchema *protos.DataSchema = nil
-	var bodyType string = ""
+	var bodyDataSchema *aikido_types.DataSchema = nil
+	bodyType := ""
 	if apiSpec.Body != nil {
 		bodyDataSchema = apiSpec.Body.Schema
 		bodyType = apiSpec.Body.Type
@@ -60,20 +60,20 @@ func getApiSpecData(apiSpec *protos.APISpec) (*protos.DataSchema, string, *proto
 	return bodyDataSchema, bodyType, apiSpec.Query, apiSpec.Auth
 }
 
-func getMergedApiSpec(currentApiSpec *protos.APISpec, newApiSpec *protos.APISpec) *protos.APISpec {
-	if newApiSpec == nil {
-		return currentApiSpec
+func getMergedAPISpec(currentAPISpec *aikido_types.APISpec, newAPISpec *aikido_types.APISpec) *aikido_types.APISpec {
+	if newAPISpec == nil {
+		return currentAPISpec
 	}
-	if currentApiSpec == nil {
-		return newApiSpec
+	if currentAPISpec == nil {
+		return newAPISpec
 	}
 
-	currentBodySchema, currentBodyType, currentQuerySchema, currentAuth := getApiSpecData(currentApiSpec)
-	newBodySchema, newBodyType, newQuerySchema, newAuth := getApiSpecData(newApiSpec)
+	currentBodySchema, currentBodyType, currentQuerySchema, currentAuth := getAPISpecData(currentAPISpec)
+	newBodySchema, newBodyType, newQuerySchema, newAuth := getAPISpecData(newAPISpec)
 
 	mergedBodySchema := api_discovery.MergeDataSchemas(currentBodySchema, newBodySchema)
 	mergedQuerySchema := api_discovery.MergeDataSchemas(currentQuerySchema, newQuerySchema)
-	mergedAuth := api_discovery.MergeApiAuthTypes(currentAuth, newAuth)
+	mergedAuth := api_discovery.MergeAPIAuthTypes(currentAuth, newAuth)
 	if mergedBodySchema == nil && mergedQuerySchema == nil && mergedAuth == nil {
 		return nil
 	}
@@ -83,8 +83,8 @@ func getMergedApiSpec(currentApiSpec *protos.APISpec, newApiSpec *protos.APISpec
 		mergedBodyType = currentBodyType
 	}
 
-	return &protos.APISpec{
-		Body: &protos.APIBodyInfo{
+	return &aikido_types.APISpec{
+		Body: &aikido_types.APIBodyInfo{
 			Type:   mergedBodyType,
 			Schema: mergedBodySchema,
 		},
@@ -93,7 +93,7 @@ func getMergedApiSpec(currentApiSpec *protos.APISpec, newApiSpec *protos.APISpec
 	}
 }
 
-func storeRoute(method string, route string, apiSpec *protos.APISpec) {
+func storeRoute(method string, route string, apiSpec *aikido_types.APISpec) {
 	globals.RoutesMutex.Lock()
 	defer globals.RoutesMutex.Unlock()
 
@@ -107,7 +107,7 @@ func storeRoute(method string, route string, apiSpec *protos.APISpec) {
 	}
 
 	routeData.Hits++
-	routeData.ApiSpec = getMergedApiSpec(routeData.ApiSpec, apiSpec)
+	routeData.APISpec = getMergedAPISpec(routeData.APISpec, apiSpec)
 }
 
 func incrementRateLimitingCounts(m map[string]*aikido_types.RateLimitingCounts, key string) {

--- a/agent/request.go
+++ b/agent/request.go
@@ -4,7 +4,6 @@ import (
 	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/agent/api_discovery"
 	"github.com/AikidoSec/firewall-go/agent/globals"
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
 	"github.com/AikidoSec/firewall-go/agent/log"
 	"github.com/AikidoSec/firewall-go/agent/utils"
 )

--- a/internal/apidiscovery/get_api_auth_type.go
+++ b/internal/apidiscovery/get_api_auth_type.go
@@ -3,7 +3,7 @@ package apidiscovery
 import (
 	"strings"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
 // Common API key header and cookie names
@@ -29,8 +29,8 @@ var commonAuthCookieNames = append([]string{
 
 // GetApiAuthType returns the authentication type of the API request.
 // Returns nil if the authentication type could not be determined.
-func GetApiAuthType(headers map[string][]string, cookies map[string]string) []*protos.APIAuthType {
-	var result []*protos.APIAuthType
+func GetApiAuthType(headers map[string][]string, cookies map[string]string) []*aikido_types.APIAuthType {
+	var result []*aikido_types.APIAuthType
 
 	// Check the Authorization header
 	if _, exists := headers["authorization"]; exists && len(headers["authorization"]) > 0 {
@@ -45,7 +45,7 @@ func GetApiAuthType(headers map[string][]string, cookies map[string]string) []*p
 }
 
 // getAuthorizationHeaderType returns the authentication type from the Authorization header.
-func getAuthorizationHeaderType(authHeader string) *protos.APIAuthType {
+func getAuthorizationHeaderType(authHeader string) *aikido_types.APIAuthType {
 	if len(authHeader) == 0 {
 		return nil
 	}
@@ -55,7 +55,7 @@ func getAuthorizationHeaderType(authHeader string) *protos.APIAuthType {
 			authType := parts[0]
 			if isHTTPAuthScheme(authType) {
 				scheme := strings.ToLower(authType)
-				return &protos.APIAuthType{
+				return &aikido_types.APIAuthType{
 					Type:   "http",
 					Scheme: scheme,
 				}
@@ -65,7 +65,7 @@ func getAuthorizationHeaderType(authHeader string) *protos.APIAuthType {
 
 	// Default to apiKey if the auth type is not recognized
 	name := "Authorization"
-	return &protos.APIAuthType{
+	return &aikido_types.APIAuthType{
 		Type: "apiKey",
 		In:   "header",
 		Name: name,
@@ -77,12 +77,12 @@ func getPhpHttpHeaderEquivalent(apiKey string) string {
 }
 
 // findApiKeys searches for API keys in headers and cookies.
-func findApiKeys(headers map[string][]string, cookies map[string]string) []*protos.APIAuthType {
-	var result []*protos.APIAuthType
+func findApiKeys(headers map[string][]string, cookies map[string]string) []*aikido_types.APIAuthType {
+	var result []*aikido_types.APIAuthType
 
 	for headerIndex, header := range commonApiKeyHeaderNames {
 		if value, exists := headers[getPhpHttpHeaderEquivalent(header)]; exists && len(value) > 0 && value[0] != "" {
-			result = append(result, &protos.APIAuthType{
+			result = append(result, &aikido_types.APIAuthType{
 				Type: "apiKey",
 				In:   "header",
 				Name: commonApiKeyHeaderNames[headerIndex],
@@ -94,7 +94,7 @@ func findApiKeys(headers map[string][]string, cookies map[string]string) []*prot
 		for cookieName := range cookies {
 			lowerCookieName := strings.ToLower(cookieName)
 			if contains(commonAuthCookieNames, lowerCookieName) {
-				result = append(result, &protos.APIAuthType{
+				result = append(result, &aikido_types.APIAuthType{
 					Type: "apiKey",
 					In:   "cookie",
 					Name: cookieName,

--- a/internal/apidiscovery/get_api_auth_type_test.go
+++ b/internal/apidiscovery/get_api_auth_type_test.go
@@ -3,7 +3,7 @@ package apidiscovery
 import (
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,21 +15,21 @@ func TestDetectAuthorizationHeader(t *testing.T) {
 		"authorization": {"Bearer token"},
 	}
 	cookies := map[string]string{}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "http", Scheme: "bearer"},
 	}, GetApiAuthType(headers, cookies))
 
 	headers = map[string][]string{
 		"authorization": {"Basic base64"},
 	}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "http", Scheme: "basic"},
 	}, GetApiAuthType(headers, cookies))
 
 	headers = map[string][]string{
 		"authorization": {"custom"},
 	}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "apiKey", In: "header", Name: "Authorization"},
 	}, GetApiAuthType(headers, cookies))
 }
@@ -42,14 +42,14 @@ func TestDetectApiKeys(t *testing.T) {
 		"x_api_key": {"token"},
 	}
 	cookies := map[string]string{}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("header"), Name: ("x-api-key")},
 	}, GetApiAuthType(headers, cookies))
 
 	headers = map[string][]string{
 		"api_key": {"token"},
 	}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("header"), Name: ("api-key")},
 	}, GetApiAuthType(headers, cookies))
 }
@@ -63,14 +63,14 @@ func TestDetectAuthCookies(t *testing.T) {
 		"api-key": "token",
 	}
 
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("cookie"), Name: ("api-key")},
 	}, GetApiAuthType(headers, cookies))
 
 	cookies = map[string]string{
 		"session": "test",
 	}
-	assert.Equal([]*protos.APIAuthType{
+	assert.Equal([]*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("cookie"), Name: ("session")},
 	}, GetApiAuthType(headers, cookies))
 }

--- a/internal/apidiscovery/get_api_info.go
+++ b/internal/apidiscovery/get_api_info.go
@@ -3,19 +3,19 @@ package apidiscovery
 import (
 	"reflect"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/config"
 	"github.com/AikidoSec/firewall-go/internal/context"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
-func GetAPIInfo(ctx context.Context) *protos.APISpec {
+func GetAPIInfo(ctx context.Context) *aikido_types.APISpec {
 	if !config.CollectAPISchema {
 		log.Debug("Collection of API Discovery was disabled.")
 		return nil
 	}
-	var bodyInfo *protos.APIBodyInfo
-	var queryInfo *protos.DataSchema
+	var bodyInfo *aikido_types.APIBodyInfo
+	var queryInfo *aikido_types.DataSchema
 
 	body := ctx.Body
 	query := ctx.Query
@@ -28,7 +28,7 @@ func GetAPIInfo(ctx context.Context) *protos.APISpec {
 		}
 		bodySchema := GetDataSchema(body, 0)
 
-		bodyInfo = &protos.APIBodyInfo{
+		bodyInfo = &aikido_types.APIBodyInfo{
 			Type:   string(bodyType),
 			Schema: bodySchema,
 		}
@@ -47,7 +47,7 @@ func GetAPIInfo(ctx context.Context) *protos.APISpec {
 		return nil
 	}
 
-	return &protos.APISpec{
+	return &aikido_types.APISpec{
 		Body:  bodyInfo,
 		Query: queryInfo,
 		Auth:  authInfo,

--- a/internal/apidiscovery/get_api_info_test.go
+++ b/internal/apidiscovery/get_api_info_test.go
@@ -11,11 +11,10 @@ func TestIsObject(t *testing.T) {
 		assert.Equal(t, false, isObject(""))
 		assert.Equal(t, false, isObject([]string{"1"}))
 
-		assert.Equal(t, true, isObject(map[string]interface{}{"1": "2"}))
+		assert.Equal(t, true, isObject(map[string]any{"1": "2"}))
 		assert.Equal(t, true, isObject(map[string]string{"1": "2"}))
 		assert.Equal(t, true, isObject(map[string]int{"1": 500}))
 		assert.Equal(t, true, isObject(map[string][]string{"1": {"2"}}))
-		assert.Equal(t, true, isObject(map[string][]interface{}{"1": {"2"}}))
-
+		assert.Equal(t, true, isObject(map[string][]any{"1": {"2"}}))
 	})
 }

--- a/internal/apidiscovery/get_body_data_type_test.go
+++ b/internal/apidiscovery/get_body_data_type_test.go
@@ -1,25 +1,8 @@
 package apidiscovery
 
 import (
-	"strings"
 	"testing"
 )
-
-func determineType(contentType string) string {
-	contentType = strings.ToLower(contentType)
-	switch {
-	case strings.Contains(contentType, "json"):
-		return "json"
-	case contentType == "application/x-www-form-urlencoded":
-		return "form-urlencoded"
-	case contentType == "multipart/form-data":
-		return "form-data"
-	case strings.HasPrefix(contentType, "text/xml"):
-		return "xml"
-	default:
-		return ""
-	}
-}
 
 func TestGetBodyDataType(t *testing.T) {
 	tests := []struct {

--- a/internal/apidiscovery/get_data_schema.go
+++ b/internal/apidiscovery/get_data_schema.go
@@ -3,17 +3,19 @@ package apidiscovery
 import (
 	"reflect"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
-const maxDepth = 20
-const maxProperties = 100
+const (
+	maxDepth      = 20
+	maxProperties = 100
+)
 
 // GetDataSchema returns the schema of the given data as a DataSchema
-func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
+func GetDataSchema(data any, depth int) *aikido_types.DataSchema {
 	// If the data is not an object (or an array), return the type
 	if data == nil {
-		return &protos.DataSchema{Type: []string{"null"}}
+		return &aikido_types.DataSchema{Type: []string{"null"}}
 	}
 
 	dataType := reflect.TypeOf(data)
@@ -23,18 +25,18 @@ func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
 		// If the data is an array/slice, return an array schema
 		v := reflect.ValueOf(data)
 		if v.Len() > 0 {
-			return &protos.DataSchema{
+			return &aikido_types.DataSchema{
 				Type:  []string{"array"},
 				Items: GetDataSchema(v.Index(0).Interface(), depth+1),
 			}
 		} else {
-			return &protos.DataSchema{Type: []string{"array"}}
+			return &aikido_types.DataSchema{Type: []string{"array"}}
 		}
 	case reflect.Map:
 		// Create an object schema with properties
-		schema := protos.DataSchema{
+		schema := aikido_types.DataSchema{
 			Type:       []string{"object"},
-			Properties: make(map[string]*protos.DataSchema),
+			Properties: make(map[string]*aikido_types.DataSchema),
 		}
 
 		// Traverse properties if within depth
@@ -53,16 +55,16 @@ func GetDataSchema(data interface{}, depth int) *protos.DataSchema {
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return &protos.DataSchema{Type: []string{"number"}}
+		return &aikido_types.DataSchema{Type: []string{"number"}}
 
 	case reflect.Float32, reflect.Float64:
-		return &protos.DataSchema{Type: []string{"number"}}
+		return &aikido_types.DataSchema{Type: []string{"number"}}
 
 	case reflect.Bool:
-		return &protos.DataSchema{Type: []string{"boolean"}}
+		return &aikido_types.DataSchema{Type: []string{"boolean"}}
 
 	default:
 		// If the data is not an object or array, return its type
-		return &protos.DataSchema{Type: []string{dataType.Kind().String()}}
+		return &aikido_types.DataSchema{Type: []string{dataType.Kind().String()}}
 	}
 }

--- a/internal/apidiscovery/get_data_schema_test.go
+++ b/internal/apidiscovery/get_data_schema_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 )
 
 // Helper function for comparing two DataSchema structs
-func compareSchemas(t *testing.T, got, expected *protos.DataSchema) {
+func compareSchemas(t *testing.T, got, expected *aikido_types.DataSchema) {
 	gotJson, _ := json.Marshal(got)
 	expectedJson, _ := json.Marshal(expected)
 
@@ -21,50 +21,50 @@ func compareSchemas(t *testing.T, got, expected *protos.DataSchema) {
 
 func TestGetDataSchema(t *testing.T) {
 	t.Run("it works", func(t *testing.T) {
-		compareSchemas(t, GetDataSchema("test", 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema("test", 0), &aikido_types.DataSchema{
 			Type: []string{"string"},
 		})
 
-		compareSchemas(t, GetDataSchema([]string{"test"}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema([]string{"test"}, 0), &aikido_types.DataSchema{
 			Type: []string{"array"},
-			Items: &protos.DataSchema{
+			Items: &aikido_types.DataSchema{
 				Type: []string{"string"},
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": "abc"}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema(map[string]any{"test": "abc"}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"string"}},
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{"test": 123, "arr": []int{1, 2, 3}}, 0), &protos.DataSchema{
+		compareSchemas(t, GetDataSchema(map[string]any{"test": 123, "arr": []int{1, 2, 3}}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"number"}},
 				"arr": {
 					Type: []string{"array"},
-					Items: &protos.DataSchema{
+					Items: &aikido_types.DataSchema{
 						Type: []string{"number"},
 					},
 				},
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{
+		compareSchemas(t, GetDataSchema(map[string]any{
 			"test": 123,
-			"arr":  []interface{}{map[string]interface{}{"sub": true}},
+			"arr":  []any{map[string]any{"sub": true}},
 			"x":    nil,
-		}, 0), &protos.DataSchema{
+		}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {Type: []string{"number"}},
 				"arr": {
 					Type: []string{"array"},
-					Items: &protos.DataSchema{
+					Items: &aikido_types.DataSchema{
 						Type: []string{"object"},
-						Properties: map[string]*protos.DataSchema{
+						Properties: map[string]*aikido_types.DataSchema{
 							"sub": {Type: []string{"boolean"}},
 						},
 					},
@@ -73,27 +73,27 @@ func TestGetDataSchema(t *testing.T) {
 			},
 		})
 
-		compareSchemas(t, GetDataSchema(map[string]interface{}{
-			"test": map[string]interface{}{
-				"x": map[string]interface{}{
-					"y": map[string]interface{}{
+		compareSchemas(t, GetDataSchema(map[string]any{
+			"test": map[string]any{
+				"x": map[string]any{
+					"y": map[string]any{
 						"z": 123,
 					},
 				},
 			},
-			"arr": []interface{}{},
-		}, 0), &protos.DataSchema{
+			"arr": []any{},
+		}, 0), &aikido_types.DataSchema{
 			Type: []string{"object"},
-			Properties: map[string]*protos.DataSchema{
+			Properties: map[string]*aikido_types.DataSchema{
 				"test": {
 					Type: []string{"object"},
-					Properties: map[string]*protos.DataSchema{
+					Properties: map[string]*aikido_types.DataSchema{
 						"x": {
 							Type: []string{"object"},
-							Properties: map[string]*protos.DataSchema{
+							Properties: map[string]*aikido_types.DataSchema{
 								"y": {
 									Type: []string{"object"},
-									Properties: map[string]*protos.DataSchema{
+									Properties: map[string]*aikido_types.DataSchema{
 										"z": {Type: []string{"number"}},
 									},
 								},
@@ -110,13 +110,13 @@ func TestGetDataSchema(t *testing.T) {
 	})
 
 	t.Run("test max depth", func(t *testing.T) {
-		var generateTestObjectWithDepth func(depth int) interface{}
+		var generateTestObjectWithDepth func(depth int) any
 
-		generateTestObjectWithDepth = func(depth int) interface{} {
+		generateTestObjectWithDepth = func(depth int) any {
 			if depth == 0 {
 				return "testValue"
 			}
-			return map[string]interface{}{
+			return map[string]any{
 				"prop": generateTestObjectWithDepth(depth - 1),
 			}
 		}
@@ -138,8 +138,8 @@ func TestGetDataSchema(t *testing.T) {
 	})
 
 	t.Run("test max properties", func(t *testing.T) {
-		generateObjectWithProperties := func(count int) map[string]interface{} {
-			obj := make(map[string]interface{})
+		generateObjectWithProperties := func(count int) map[string]any {
+			obj := make(map[string]any)
 			for i := 0; i < count; i++ {
 				obj[fmt.Sprintf("prop%d", i)] = i
 			}

--- a/internal/grpc/client.go
+++ b/internal/grpc/client.go
@@ -1,12 +1,8 @@
 package grpc
 
 import (
-	"context"
-	"time"
-
 	agent "github.com/AikidoSec/firewall-go/agent"
 	"github.com/AikidoSec/firewall-go/agent/aikido_types"
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
 	"github.com/AikidoSec/firewall-go/internal/config"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
@@ -30,17 +26,8 @@ func GetRateLimitingStatus(method string, route string, user string, ip string) 
 }
 
 // OnRequestShutdown sends request metadata (route, method & status code) to Aikido Agent
-func OnRequestShutdown(method string, route string, statusCode int, user string, ip string, apiSpec *protos.APISpec) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	_, err := agent.OnRequestShutdown(ctx, &protos.RequestMetadataShutdown{Method: method, Route: route, StatusCode: int32(statusCode), User: user, Ip: ip, ApiSpec: apiSpec})
-	if err != nil {
-		log.Warnf("Could not send request metadata %v %v %v: %v", method, route, statusCode, err)
-		return
-	}
-
-	log.Debugf("Request metadata sent via socket (%v %v %v)", method, route, statusCode)
+func OnRequestShutdown(method string, route string, statusCode int, user string, ip string, apiSpec *aikido_types.APISpec) {
+	agent.OnRequestShutdown(method, route, statusCode, user, ip, apiSpec)
 }
 
 func GetCloudConfig() {

--- a/internal/http/on_post_request.go
+++ b/internal/http/on_post_request.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/AikidoSec/firewall-go/agent/ipc/protos"
+	"github.com/AikidoSec/firewall-go/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/apidiscovery"
 	"github.com/AikidoSec/firewall-go/internal/context"
 	"github.com/AikidoSec/firewall-go/internal/grpc"
@@ -9,7 +9,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
-func OnRequestShutdownReporting(method string, route string, statusCode int, user string, ip string, apiSpec *protos.APISpec) {
+func OnRequestShutdownReporting(method string, route string, statusCode int, user string, ip string, apiSpec *aikido_types.APISpec) {
 	if method == "" || route == "" || statusCode == 0 {
 		return
 	}


### PR DESCRIPTION
To keep the PR focused on removing protobuf, just added the types to `aikido_types` for now.
Will need to look at merging the two `apidiscovery` packages.