### PR TITLE
feat: use streaming for tryExtractJSON

### DIFF
--- a/instrumentation/sources/gingonic/body.go
+++ b/instrumentation/sources/gingonic/body.go
@@ -1,21 +1,18 @@
 package gingonic
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
+	zenhttp "github.com/AikidoSec/firewall-go/internal/http"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/gin-gonic/gin"
 )
 
 func tryExtractBody(c *gin.Context) any {
 	// Try extracting JSON from the raw request :
-	bodyFromJSON := tryExtractJSON(c)
+	bodyFromJSON := zenhttp.TryExtractJSON(c.Request)
 	if bodyFromJSON != nil {
 		return bodyFromJSON
 	}
@@ -26,25 +23,6 @@ func tryExtractBody(c *gin.Context) any {
 	}
 
 	// No use-able data found, returning nil :
-	return nil
-}
-
-func tryExtractJSON(c *gin.Context) any {
-	// Read the raw body
-	body, err := io.ReadAll(c.Request.Body)
-	// Restore body after read
-	c.Request.Body = io.NopCloser(bytes.NewBuffer(body))
-	if err == nil && len(body) > 0 {
-		trimmedBody := strings.TrimSpace(string(body))
-		if !strings.HasPrefix(trimmedBody, "{") && !strings.HasPrefix(trimmedBody, "[") {
-			return nil
-		}
-		var data any
-		err = json.Unmarshal(body, &data)
-		if err == nil {
-			return data
-		}
-	}
 	return nil
 }
 

--- a/instrumentation/sources/labstackecho/body.go
+++ b/instrumentation/sources/labstackecho/body.go
@@ -1,21 +1,18 @@
 package labstackecho
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
+	zenhttp "github.com/AikidoSec/firewall-go/internal/http"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/labstack/echo/v4"
 )
 
 func tryExtractBody(c echo.Context) any {
 	// Try extracting JSON from the raw request :
-	bodyFromJSON := tryExtractJSON(c)
+	bodyFromJSON := zenhttp.TryExtractJSON(c.Request())
 	if bodyFromJSON != nil {
 		return bodyFromJSON
 	}
@@ -26,26 +23,6 @@ func tryExtractBody(c echo.Context) any {
 	}
 
 	// No use-able data found, returning nil :
-	return nil
-}
-
-func tryExtractJSON(c echo.Context) any {
-	// Read the raw body
-	body, err := io.ReadAll(c.Request().Body)
-	// Restore body after read
-	c.Request().Body = io.NopCloser(bytes.NewBuffer(body))
-	if err == nil && len(body) > 0 {
-		trimmedBody := strings.TrimSpace(string(body))
-		if !strings.HasPrefix(trimmedBody, "{") && !strings.HasPrefix(trimmedBody, "[") {
-			return nil
-		}
-		// Parse :
-		var data any
-		err = json.Unmarshal(body, &data)
-		if err == nil {
-			return data
-		}
-	}
 	return nil
 }
 

--- a/internal/http/json.go
+++ b/internal/http/json.go
@@ -1,0 +1,27 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func TryExtractJSON(r *http.Request) any {
+	var buf bytes.Buffer
+	tee := io.TeeReader(r.Body, &buf)
+
+	var data any
+	err := json.NewDecoder(tee).Decode(&data)
+
+	// Drain any remaining bytes to ensure full body is available in request
+	io.Copy(io.Discard, tee)
+
+	r.Body = io.NopCloser(&buf)
+
+	if err != nil {
+		return nil
+	}
+
+	return data
+}

--- a/internal/http/json_test.go
+++ b/internal/http/json_test.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTryExtractJSON(t *testing.T) {
+	t.Run("good", func(t *testing.T) {
+		body := `{"key": "value"}`
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+
+		got := TryExtractJSON(r)
+
+		if got == nil {
+			t.Error("expected valid JSON to be parsed, got nil")
+		}
+
+		// Verify body is restored
+		restoredBody, _ := io.ReadAll(r.Body)
+		if string(restoredBody) != body {
+			t.Errorf("body not restored: got %q, want %q", string(restoredBody), body)
+		}
+	})
+
+	t.Run("bad", func(t *testing.T) {
+		body := `not json`
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+
+		got := TryExtractJSON(r)
+
+		if got != nil {
+			t.Errorf("expected invalid JSON to return nil, got %v", got)
+		}
+
+		// Verify body is still restored even on failure
+		restoredBody, _ := io.ReadAll(r.Body)
+		if string(restoredBody) != body {
+			t.Errorf("body not restored: got %q, want %q", string(restoredBody), body)
+		}
+	})
+}
+
+func BenchmarkSmallBody(b *testing.B) {
+	body := generateString(1 * 1024) // 1KB
+	for b.Loop() {
+		r := httptest.NewRequest("GET", "/route", strings.NewReader(body))
+		TryExtractJSON(r)
+	}
+}
+
+func BenchmarkLargeBody(b *testing.B) {
+	body := generateString(5 * 1024 * 1024) // 5MB
+	for b.Loop() {
+		r := httptest.NewRequest("GET", "/route", strings.NewReader(body))
+		TryExtractJSON(r)
+	}
+}
+
+func generateString(targetSize int) string {
+	var b strings.Builder
+	b.Grow(targetSize) // Pre-allocate memory for efficiency
+
+	// Start with "{"
+	b.WriteString("{")
+
+	// Fill the rest with content to reach 5MB
+	chunk := strings.Repeat("a", 1024) // 1KB chunks
+	for b.Len() < targetSize {
+		remaining := targetSize - b.Len()
+		if remaining < len(chunk) {
+			b.WriteString(chunk[:remaining])
+		} else {
+			b.WriteString(chunk)
+		}
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
Added shared method for attempting to parse JSON from body, using streaming rather than reading whole string. This allows for less copying, and for it to fail immediately if the JSON isn't valid.

### Benchmark
SmallBody = 1KB, LargeBody = 5MB

Before:
```
BenchmarkSmallBody-12             681278              1755 ns/op            9334 B/op         24 allocs/op
BenchmarkLargeBody-12               1010           1204512 ns/op        31757813 B/op         58 allocs/op
```
After:
```
BenchmarkSmallBody-12             715946              1674 ns/op            7790 B/op         24 allocs/op
BenchmarkLargeBody-12               2227            557196 ns/op        10483609 B/op         37 allocs/op
```