### PR TITLE
Load Zen internals only once

### DIFF
--- a/instrumentation/sources/gingonic/middleware.go
+++ b/instrumentation/sources/gingonic/middleware.go
@@ -1,7 +1,6 @@
 package gingonic
 
 import (
-	"github.com/AikidoSec/firewall-go/internal"
 	"github.com/AikidoSec/firewall-go/internal/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/gin-gonic/gin"
@@ -14,7 +13,7 @@ func GetMiddleware() gin.HandlerFunc {
 		if c == nil {
 			return // Don't investigate empty requests.
 		}
-		internal.Init()
+
 		ip := c.ClientIP()
 
 		reqCtx := request.SetContext(c.Request.Context(), c.Request, c.FullPath(), "gin", &ip, tryExtractBody(c))

--- a/instrumentation/sources/gingonic/middleware_test.go
+++ b/instrumentation/sources/gingonic/middleware_test.go
@@ -31,3 +31,19 @@ func TestMiddlewareAddsContext(t *testing.T) {
 
 	router.ServeHTTP(w, r)
 }
+
+func BenchmarkMiddleware(b *testing.B) {
+	router := gin.New()
+	router.ContextWithFallback = true
+	router.Use(GetMiddleware())
+
+	router.GET("/route", func(c *gin.Context) {})
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := httptest.NewRequest("GET", "/route", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+		}
+	})
+}

--- a/instrumentation/sources/labstackecho/middleware.go
+++ b/instrumentation/sources/labstackecho/middleware.go
@@ -3,7 +3,6 @@ package labstackecho
 import (
 	"errors"
 
-	"github.com/AikidoSec/firewall-go/internal"
 	"github.com/AikidoSec/firewall-go/internal/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/labstack/echo/v4"
@@ -18,8 +17,6 @@ func GetMiddleware() echo.MiddlewareFunc {
 			if httpRequest == nil {
 				return next(c) // Do not continue.
 			}
-
-			internal.Init()
 
 			ip := c.RealIP()
 			reqCtx := request.SetContext(httpRequest.Context(), httpRequest, c.Path(), "echo", &ip, tryExtractBody(c))

--- a/instrumentation/sources/labstackecho/middleware_test.go
+++ b/instrumentation/sources/labstackecho/middleware_test.go
@@ -31,3 +31,18 @@ func TestMiddlewareAddsContext(t *testing.T) {
 
 	router.ServeHTTP(w, r)
 }
+
+func BenchmarkMiddleware(b *testing.B) {
+	router := echo.New()
+	router.Use(GetMiddleware())
+
+	router.GET("/route", func(e echo.Context) error { return nil })
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := httptest.NewRequest("GET", "/route", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+		}
+	})
+}

--- a/zen/main.go
+++ b/zen/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/AikidoSec/firewall-go/internal"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/config"
@@ -36,6 +37,8 @@ func Init() error {
 	}
 
 	config.Init()
+
+	internal.Init()
 
 	return nil
 }


### PR DESCRIPTION
`internal.Init` loads the Zen internals library which was being run every request instead of just once.

## Benchmarks for `gin` source
Before:
```
BenchmarkMiddleware-12 48856             21646 ns/op            9136 B/op         64 allocs/op
```

After:
```
BenchmarkMiddleware-12 468408              2536 ns/op            8808 B/op         63 allocs/op
```