### PR TITLE
feat: pass config structs to agent instead of json

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -15,7 +15,7 @@ import (
 
 var ErrCloudConfigNotUpdated = errors.New("cloud config was not updated")
 
-func Init(initJSON string) (initOk bool) {
+func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) (initOk bool) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Warn("Recovered from panic:", r)
@@ -25,7 +25,7 @@ func Init(initJSON string) (initOk bool) {
 
 	log.Init()
 	machine.Init()
-	if !config.Init(initJSON) {
+	if !config.Init(environmentConfig, aikidoConfig) {
 		return false
 	}
 

--- a/internal/agent/aikido_types/init_data.go
+++ b/internal/agent/aikido_types/init_data.go
@@ -11,7 +11,6 @@ type MachineData struct {
 }
 
 type EnvironmentConfigData struct {
-	SocketPath      string `json:"socket_path"`               // '/run/aikido-{version}/aikido-{datetime}-{randint}.sock'
 	PlatformName    string `json:"platform_name"`             // Platform name (fpm-fcgi, cli-server, ...)
 	PlatformVersion string `json:"platform_version"`          // Language version
 	Endpoint        string `json:"endpoint,omitempty"`        // default: 'https://guard.aikido.dev/'

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -1,21 +1,16 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 	"github.com/AikidoSec/firewall-go/internal/agent/log"
 )
 
-func setConfigFromJSON(jsonString []byte) bool {
-	if err := json.Unmarshal(jsonString, &globals.EnvironmentConfig); err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal JSON to EnvironmentConfig: %v", err))
-	}
-
-	if err := json.Unmarshal(jsonString, &globals.AikidoConfig); err != nil {
-		panic(fmt.Sprintf("Failed to unmarshal JSON to AikidoConfig: %v", err))
-	}
+func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
+	globals.EnvironmentConfig = environmentConfig
+	globals.AikidoConfig = aikidoConfig
 
 	if globals.AikidoConfig.LogLevel != "" {
 		if err := log.SetLogLevel(globals.AikidoConfig.LogLevel); err != nil {
@@ -25,20 +20,11 @@ func setConfigFromJSON(jsonString []byte) bool {
 
 	log.Infof("Loaded local config: %+v", globals.EnvironmentConfig)
 
-	if globals.EnvironmentConfig.SocketPath == "" {
-		log.Errorf("No socket path set! Aikido agent will not load!")
-		return false
-	}
-
 	if globals.AikidoConfig.Token == "" {
-		log.Infof("No token set! Aikido agent will load and wait for the token to be passed via gRPC!")
+		log.Infof("No token set!")
 	}
 
 	return true
-}
-
-func Init(initJSON string) bool {
-	return setConfigFromJSON([]byte(initJSON))
 }
 
 func Uninit() {

--- a/internal/agent/globals/globals.go
+++ b/internal/agent/globals/globals.go
@@ -7,10 +7,10 @@ import (
 )
 
 // Local config that contains info about socket path, platform, library version...
-var EnvironmentConfig EnvironmentConfigData
+var EnvironmentConfig *EnvironmentConfigData
 
 // Aikido config that contains info about endpoint, log_level, token, ...
-var AikidoConfig AikidoConfigData
+var AikidoConfig *AikidoConfigData
 
 // Cloud config that is obtain as a result from sending events to cloud or pulling the config when it changes
 var CloudConfig CloudConfigData

--- a/zen/main.go
+++ b/zen/main.go
@@ -3,7 +3,6 @@ package zen
 // This is the main module users will interact with : SetUser, ShouldBlockRequest, middleware, ...
 
 import (
-	"encoding/json"
 	"os"
 	"runtime"
 
@@ -13,11 +12,6 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/config"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
-
-type combined struct {
-	aikido_types.EnvironmentConfigData
-	aikido_types.AikidoConfigData
-}
 
 // Init needs to be called in the user's app to start the background process
 func Init() error {
@@ -44,7 +38,7 @@ func Init() error {
 }
 
 func initAgent(collectAPISchema bool, logLevel string, token string) error {
-	environmentConfig := aikido_types.EnvironmentConfigData{
+	environmentConfig := &aikido_types.EnvironmentConfigData{
 		PlatformName:    "golang",
 		PlatformVersion: runtime.Version(),
 		Library:         "firewall-go",
@@ -52,16 +46,12 @@ func initAgent(collectAPISchema bool, logLevel string, token string) error {
 		ConfigEndpoint:  "https://runtime.aikido.dev/",
 		Version:         config.Version, // firewall-go version
 	}
-	aikidoConfig := aikido_types.AikidoConfigData{
+	aikidoConfig := &aikido_types.AikidoConfigData{
 		LogLevel:         logLevel,
 		Token:            token,
 		CollectAPISchema: collectAPISchema,
 	}
-	jsonBytes, err := json.Marshal(combined{environmentConfig, aikidoConfig})
-	if err != nil {
-		return err
-	}
 
-	go agent.Init(string(jsonBytes))
+	go agent.Init(environmentConfig, aikidoConfig)
 	return nil
 }


### PR DESCRIPTION
Left over from removing gRPC, passing config structs directly instead of using JSON.
Removed socket path config as no longer used.