### PR TITLE
chore: use temp cloud config in fetching lists and updating rate limiter

### DIFF
--- a/internal/agent/cloud/config.go
+++ b/internal/agent/cloud/config.go
@@ -30,5 +30,5 @@ func CheckConfigUpdatedAt() {
 		return
 	}
 
-	StoreCloudConfig(configResponse)
+	storeCloudConfig(configResponse)
 }

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -130,5 +130,5 @@ func SendHeartbeatEvent() {
 		LogCloudRequestError("Error in sending heartbeat event: ", err)
 		return
 	}
-	StoreCloudConfig(response)
+	storeCloudConfig(response)
 }

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -18,5 +18,5 @@ func SendStartEvent() {
 		LogCloudRequestError("Error in sending start event: ", err)
 		return
 	}
-	StoreCloudConfig(response)
+	storeCloudConfig(response)
 }

--- a/internal/agent/globals/globals.go
+++ b/internal/agent/globals/globals.go
@@ -13,7 +13,7 @@ var EnvironmentConfig *aikido_types.EnvironmentConfigData
 var AikidoConfig *aikido_types.AikidoConfigData
 
 // Cloud config that is obtain as a result from sending events to cloud or pulling the config when it changes
-var CloudConfig aikido_types.CloudConfigData
+var CloudConfig *aikido_types.CloudConfigData
 
 // Config mutex used to sync access to configuration data across the multiple go routines that we run in parallel
 var CloudConfigMutex sync.Mutex


### PR DESCRIPTION
Small step towards not having to store the cloud config, relying on passed config/values instead of the global cloud config variable.