### PR TITLE
feat: update service config directly instead of polling cloud config

### DIFF
--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -104,7 +104,7 @@ func storeCloudConfig(configReponse []byte) bool {
 		log.Warnf("Failed to unmarshal cloud config!")
 		return false
 	}
-	if tempCloudConfig.ConfigUpdatedAt <= globals.CloudConfig.ConfigUpdatedAt {
+	if globals.CloudConfig != nil && tempCloudConfig.ConfigUpdatedAt <= globals.CloudConfig.ConfigUpdatedAt {
 		log.Debugf("ConfigUpdatedAt is the same!")
 		return true
 	}

--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/log"
 	"github.com/AikidoSec/firewall-go/internal/agent/ratelimiting"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
+	"github.com/AikidoSec/firewall-go/internal/config"
 )
 
 func GetAgentInfo() aikido_types.AgentInfo {
@@ -112,6 +113,8 @@ func storeCloudConfig(configReponse []byte) bool {
 	globals.CloudConfig = tempCloudConfig
 
 	applyCloudConfig(tempCloudConfig)
+
+	config.UpdateServiceConfig(tempCloudConfig)
 	return true
 }
 

--- a/internal/agent/request.go
+++ b/internal/agent/request.go
@@ -113,6 +113,10 @@ func getCloudConfig(configUpdatedAt int64) *aikido_types.CloudConfigData {
 	globals.CloudConfigMutex.Lock()
 	defer globals.CloudConfigMutex.Unlock()
 
+	if globals.CloudConfig == nil {
+		return nil
+	}
+
 	if globals.CloudConfig.ConfigUpdatedAt <= configUpdatedAt {
 		log.Debugf("CloudConfig.ConfigUpdatedAt was not updated... Returning nil!")
 		return nil

--- a/internal/agent/utils/utils.go
+++ b/internal/agent/utils/utils.go
@@ -31,7 +31,7 @@ func IsBlockingEnabled() bool {
 	globals.CloudConfigMutex.Lock()
 	defer globals.CloudConfigMutex.Unlock()
 
-	if globals.CloudConfig.Block == nil {
+	if globals.CloudConfig == nil || globals.CloudConfig.Block == nil {
 		return config.GetBlocking()
 	}
 	return *globals.CloudConfig.Block

--- a/zen/main.go
+++ b/zen/main.go
@@ -30,8 +30,6 @@ func Init() error {
 		return err
 	}
 
-	config.Init()
-
 	internal.Init()
 
 	return nil


### PR DESCRIPTION
Removed service cloud polling and just calling method to update service config directly when a new cloud config is received.