### PR TITLE
feat: use shared http client with timeout

### DIFF
--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -14,7 +14,7 @@ import (
 )
 
 var httpClient = &http.Client{
-	Timeout: 5 * time.Second,
+	Timeout: 30 * time.Second,
 }
 
 func SendCloudRequest(endpoint string, route string, method string, payload any) ([]byte, error) {

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -7,12 +7,17 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/log"
 )
 
-func SendCloudRequest(endpoint string, route string, method string, payload interface{}) ([]byte, error) {
+var httpClient = &http.Client{
+	Timeout: 5 * time.Second,
+}
+
+func SendCloudRequest(endpoint string, route string, method string, payload any) ([]byte, error) {
 	token := config.GetToken()
 	if token == "" {
 		return nil, fmt.Errorf("no token set")
@@ -24,20 +29,18 @@ func SendCloudRequest(endpoint string, route string, method string, payload inte
 	}
 
 	var req *http.Request
+	var body io.Reader
+
 	if payload != nil {
-		var jsonData []byte
-		jsonData, err = json.Marshal(payload)
+		jsonData, err := json.Marshal(payload)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal payload: %v", err)
 		}
-
-		log.Infof("Sending %s request to %s with content %s", method, apiEndpoint, jsonData)
-
-		req, err = http.NewRequest(method, apiEndpoint, bytes.NewBuffer(jsonData))
-	} else {
-		log.Infof("Sending %s request to %s", method, apiEndpoint)
-		req, err = http.NewRequest(method, apiEndpoint, nil)
+		body = bytes.NewBuffer(jsonData)
 	}
+
+	log.Infof("Sending %s request to %s", method, apiEndpoint)
+	req, err = http.NewRequest(method, apiEndpoint, body)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
@@ -45,8 +48,7 @@ func SendCloudRequest(endpoint string, route string, method string, payload inte
 	req.Header.Set("Authorization", token)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %v", err)
 	}
@@ -56,11 +58,10 @@ func SendCloudRequest(endpoint string, route string, method string, payload inte
 		return nil, fmt.Errorf("received non-OK response: %s", resp.Status)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	log.Info("Got response: ", string(body))
-	return body, nil
+	return responseBody, nil
 }

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -52,7 +52,11 @@ func SendCloudRequest(endpoint string, route string, method string, payload any)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Warnf("failed to close response body: %v", err)
+		}
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("received non-OK response: %s", resp.Status)

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -39,9 +39,8 @@ func SendCloudRequest(endpoint string, route string, method string, payload any)
 		body = bytes.NewBuffer(jsonData)
 	}
 
-	log.Infof("Sending %s request to %s", method, apiEndpoint)
+	log.Debugf("Sending %s request to %s", method, apiEndpoint)
 	req, err = http.NewRequest(method, apiEndpoint, body)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}

--- a/internal/http/json.go
+++ b/internal/http/json.go
@@ -15,7 +15,8 @@ func TryExtractJSON(r *http.Request) any {
 	err := json.NewDecoder(tee).Decode(&data)
 
 	// Drain any remaining bytes to ensure full body is available in request
-	io.Copy(io.Discard, tee)
+	// Ignore error - we still need to restore the request body
+	_, _ = io.Copy(io.Discard, tee)
 
 	r.Body = io.NopCloser(&buf)
 


### PR DESCRIPTION
Default `http.Client` doesn't have a timeout, should make sure one is always set.
