### PR TITLE
Configurable endpoints through envvars

### DIFF
--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
@@ -9,9 +10,45 @@ import (
 )
 
 const (
-	DefaultEndpoint       = "https://guard.aikido.dev/"
-	DefaultConfigEndpoint = "https://runtime.aikido.dev/"
+	GuardEndpointEU = "https://guard.aikido.dev/"
+	GuardEndpointUS = "https://guard.us.aikido.dev/"
+	GuardEndpointME = "https://guard.me.aikido.dev/"
+	RuntimeEndpoint = "https://runtime.aikido.dev/"
 )
+
+// extractRegionFromToken extracts the region from an Aikido token.
+// New format: AIK_RUNTIME_{sys_group_id}_{service_id}_{region}_{random}
+// Old format: AIK_RUNTIME_{sys_group_id}_{service_id}_{random}
+// Returns "EU" by default for old format or invalid tokens.
+func extractRegionFromToken(token string) string {
+	if token == "" || !strings.HasPrefix(token, "AIK_RUNTIME_") {
+		return "EU"
+	}
+
+	tokenWithoutPrefix := strings.TrimPrefix(token, "AIK_RUNTIME_")
+	parts := strings.Split(tokenWithoutPrefix, "_")
+
+	// New format has 4 parts, region is at index 2
+	if len(parts) == 4 {
+		return parts[2]
+	}
+
+	return "EU"
+}
+
+// getEndpointURL returns the appropriate endpoint URL based on the region extracted from the token.
+func getEndpointURL(token string) string {
+	region := extractRegionFromToken(token)
+
+	switch region {
+	case "US":
+		return GuardEndpointUS
+	case "ME":
+		return GuardEndpointME
+	default:
+		return GuardEndpointEU
+	}
+}
 
 func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
 	globals.EnvironmentConfig = environmentConfig
@@ -24,11 +61,11 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 	}
 
 	if globals.EnvironmentConfig.Endpoint == "" {
-		globals.EnvironmentConfig.Endpoint = DefaultEndpoint
+		globals.EnvironmentConfig.Endpoint = getEndpointURL(aikidoConfig.Token)
 	}
 
 	if globals.EnvironmentConfig.ConfigEndpoint == "" {
-		globals.EnvironmentConfig.ConfigEndpoint = DefaultConfigEndpoint
+		globals.EnvironmentConfig.ConfigEndpoint = RuntimeEndpoint
 	}
 
 	log.Infof("Loaded local config: %+v", globals.EnvironmentConfig)

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -8,6 +8,11 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/log"
 )
 
+const (
+	DefaultEndpoint       = "https://guard.aikido.dev/"
+	DefaultConfigEndpoint = "https://runtime.aikido.dev/"
+)
+
 func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
 	globals.EnvironmentConfig = environmentConfig
 	globals.AikidoConfig = aikidoConfig
@@ -16,6 +21,14 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 		if err := log.SetLogLevel(globals.AikidoConfig.LogLevel); err != nil {
 			panic(fmt.Sprintf("Error setting log level: %s", err))
 		}
+	}
+
+	if globals.EnvironmentConfig.Endpoint == "" {
+		globals.EnvironmentConfig.Endpoint = DefaultEndpoint
+	}
+
+	if globals.EnvironmentConfig.ConfigEndpoint == "" {
+		globals.EnvironmentConfig.ConfigEndpoint = DefaultConfigEndpoint
 	}
 
 	log.Infof("Loaded local config: %+v", globals.EnvironmentConfig)

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/globals"
+)
+
+// TestInitWithEmptyEndpoints tests that Init applies default values when endpoints are empty.
+func TestInitWithEmptyEndpoints(t *testing.T) {
+	environmentConfig := &aikido_types.EnvironmentConfigData{
+		PlatformName:    "test-platform",
+		PlatformVersion: "1.0.0",
+		Library:         "test-lib",
+		Endpoint:        "", // Empty endpoint
+		ConfigEndpoint:  "", // Empty config endpoint
+		Version:         "1.0.0",
+	}
+
+	aikidoConfig := &aikido_types.AikidoConfigData{
+		LogLevel:         "INFO",
+		Token:            "test-token",
+		CollectAPISchema: true,
+	}
+
+	Init(environmentConfig, aikidoConfig)
+
+	// Verify defaults were applied
+	if globals.EnvironmentConfig.Endpoint != "https://guard.aikido.dev/" {
+		t.Errorf("Expected Endpoint to be https://guard.aikido.dev/, but got %q", globals.EnvironmentConfig.Endpoint)
+	}
+
+	if globals.EnvironmentConfig.ConfigEndpoint != "https://runtime.aikido.dev/" {
+		t.Errorf("Expected ConfigEndpoint to be https://runtime.aikido.dev/, but got %q", globals.EnvironmentConfig.ConfigEndpoint)
+	}
+}
+
+// TestInitWithProvidedEndpoints tests that Init preserves provided endpoint values.
+func TestInitWithProvidedEndpoints(t *testing.T) {
+	customEndpoint := "https://custom.example.com/"
+	customConfigEndpoint := "https://custom-config.example.com/"
+
+	environmentConfig := &aikido_types.EnvironmentConfigData{
+		PlatformName:    "test-platform",
+		PlatformVersion: "1.0.0",
+		Library:         "test-lib",
+		Endpoint:        customEndpoint,
+		ConfigEndpoint:  customConfigEndpoint,
+		Version:         "1.0.0",
+	}
+
+	aikidoConfig := &aikido_types.AikidoConfigData{
+		LogLevel:         "INFO",
+		Token:            "test-token",
+		CollectAPISchema: true,
+	}
+
+	Init(environmentConfig, aikidoConfig)
+
+	// Verify custom values were preserved
+	if globals.EnvironmentConfig.Endpoint != customEndpoint {
+		t.Errorf("Expected Endpoint to be %q, but got %q", customEndpoint, globals.EnvironmentConfig.Endpoint)
+	}
+
+	if globals.EnvironmentConfig.ConfigEndpoint != customConfigEndpoint {
+		t.Errorf("Expected ConfigEndpoint to be %q, but got %q", customConfigEndpoint, globals.EnvironmentConfig.ConfigEndpoint)
+	}
+}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -7,36 +7,197 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 )
 
+// TestExtractRegionFromToken tests the extractRegionFromToken function.
+func TestExtractRegionFromToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		{
+			name:     "should return EU for empty token",
+			token:    "",
+			expected: "EU",
+		},
+		{
+			name:     "should return EU for invalid token",
+			token:    "invalid-token",
+			expected: "EU",
+		},
+		{
+			name:     "should return EU for token not starting with AIK_RUNTIME_",
+			token:    "SOME_OTHER_TOKEN_123_456_US_abc",
+			expected: "EU",
+		},
+		{
+			name:     "should return EU for old format token without region",
+			token:    "AIK_RUNTIME_123_456_randomstring",
+			expected: "EU",
+		},
+		{
+			name:     "should return US for new format token with US region",
+			token:    "AIK_RUNTIME_123_456_US_randomstring",
+			expected: "US",
+		},
+		{
+			name:     "should return ME for new format token with ME region",
+			token:    "AIK_RUNTIME_123_456_ME_randomstring",
+			expected: "ME",
+		},
+		{
+			name:     "should return EU for new format token with EU region",
+			token:    "AIK_RUNTIME_123_456_EU_randomstring",
+			expected: "EU",
+		},
+		{
+			name:     "should return whatever prefix is there (CUSTOM)",
+			token:    "AIK_RUNTIME_123_456_CUSTOM_randomstring",
+			expected: "CUSTOM",
+		},
+		{
+			name:     "should return whatever prefix is there (123)",
+			token:    "AIK_RUNTIME_123_456_123_randomstring",
+			expected: "123",
+		},
+		{
+			name:     "should return EU if region part is missing (3 parts)",
+			token:    "AIK_RUNTIME_123_456",
+			expected: "EU",
+		},
+		{
+			name:     "should return EU if region part is missing (2 parts)",
+			token:    "AIK_RUNTIME_123",
+			expected: "EU",
+		},
+		{
+			name:     "should return EU if region part is missing (prefix only)",
+			token:    "AIK_RUNTIME_",
+			expected: "EU",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractRegionFromToken(tt.token)
+			if result != tt.expected {
+				t.Errorf("Expected %q, but got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestGetEndpointURL tests the getEndpointURL function.
+func TestGetEndpointURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		{
+			name:     "US region token returns US endpoint",
+			token:    "AIK_RUNTIME_123_456_US_789",
+			expected: "https://guard.us.aikido.dev/",
+		},
+		{
+			name:     "ME region token returns ME endpoint",
+			token:    "AIK_RUNTIME_123_456_ME_789",
+			expected: "https://guard.me.aikido.dev/",
+		},
+		{
+			name:     "EU region token returns default endpoint",
+			token:    "AIK_RUNTIME_123_456_EU_789",
+			expected: "https://guard.aikido.dev/",
+		},
+		{
+			name:     "Old format token returns default endpoint",
+			token:    "AIK_RUNTIME_123_456_789",
+			expected: "https://guard.aikido.dev/",
+		},
+		{
+			name:     "Empty token returns default endpoint",
+			token:    "",
+			expected: "https://guard.aikido.dev/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getEndpointURL(tt.token)
+			if result != tt.expected {
+				t.Errorf("Expected %q, but got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
 // TestInitWithEmptyEndpoints tests that Init applies default values when endpoints are empty.
 func TestInitWithEmptyEndpoints(t *testing.T) {
-	environmentConfig := &aikido_types.EnvironmentConfigData{
-		PlatformName:    "test-platform",
-		PlatformVersion: "1.0.0",
-		Library:         "test-lib",
-		Endpoint:        "", // Empty endpoint
-		ConfigEndpoint:  "", // Empty config endpoint
-		Version:         "1.0.0",
+	tests := []struct {
+		name             string
+		token            string
+		expectedEndpoint string
+	}{
+		{
+			name:             "Old format token defaults to EU endpoint",
+			token:            "AIK_RUNTIME_123_456_789",
+			expectedEndpoint: "https://guard.aikido.dev/",
+		},
+		{
+			name:             "US region token uses US endpoint",
+			token:            "AIK_RUNTIME_123_456_US_789",
+			expectedEndpoint: "https://guard.us.aikido.dev/",
+		},
+		{
+			name:             "ME region token uses ME endpoint",
+			token:            "AIK_RUNTIME_123_456_ME_789",
+			expectedEndpoint: "https://guard.me.aikido.dev/",
+		},
+		{
+			name:             "EU region token uses default endpoint",
+			token:            "AIK_RUNTIME_123_456_EU_789",
+			expectedEndpoint: "https://guard.aikido.dev/",
+		},
+		{
+			name:             "Empty token defaults to EU endpoint",
+			token:            "",
+			expectedEndpoint: "https://guard.aikido.dev/",
+		},
 	}
 
-	aikidoConfig := &aikido_types.AikidoConfigData{
-		LogLevel:         "INFO",
-		Token:            "test-token",
-		CollectAPISchema: true,
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			environmentConfig := &aikido_types.EnvironmentConfigData{
+				PlatformName:    "test-platform",
+				PlatformVersion: "1.0.0",
+				Library:         "test-lib",
+				Endpoint:        "", // Empty endpoint
+				ConfigEndpoint:  "", // Empty config endpoint
+				Version:         "1.0.0",
+			}
 
-	Init(environmentConfig, aikidoConfig)
+			aikidoConfig := &aikido_types.AikidoConfigData{
+				LogLevel:         "INFO",
+				Token:            tt.token,
+				CollectAPISchema: true,
+			}
 
-	// Verify defaults were applied
-	if globals.EnvironmentConfig.Endpoint != "https://guard.aikido.dev/" {
-		t.Errorf("Expected Endpoint to be https://guard.aikido.dev/, but got %q", globals.EnvironmentConfig.Endpoint)
-	}
+			Init(environmentConfig, aikidoConfig)
 
-	if globals.EnvironmentConfig.ConfigEndpoint != "https://runtime.aikido.dev/" {
-		t.Errorf("Expected ConfigEndpoint to be https://runtime.aikido.dev/, but got %q", globals.EnvironmentConfig.ConfigEndpoint)
+			// Verify correct endpoint was applied based on token region
+			if globals.EnvironmentConfig.Endpoint != tt.expectedEndpoint {
+				t.Errorf("Expected Endpoint to be %q, but got %q", tt.expectedEndpoint, globals.EnvironmentConfig.Endpoint)
+			}
+
+			// ConfigEndpoint should always be the default
+			if globals.EnvironmentConfig.ConfigEndpoint != "https://runtime.aikido.dev/" {
+				t.Errorf("Expected ConfigEndpoint to be https://runtime.aikido.dev/, but got %q", globals.EnvironmentConfig.ConfigEndpoint)
+			}
+		})
 	}
 }
 
 // TestInitWithProvidedEndpoints tests that Init preserves provided endpoint values.
+// Explicitly provided endpoints should override region-based endpoint selection.
 func TestInitWithProvidedEndpoints(t *testing.T) {
 	customEndpoint := "https://custom.example.com/"
 	customConfigEndpoint := "https://custom-config.example.com/"
@@ -50,15 +211,16 @@ func TestInitWithProvidedEndpoints(t *testing.T) {
 		Version:         "1.0.0",
 	}
 
+	// Use a US token, but the custom endpoint should still be used
 	aikidoConfig := &aikido_types.AikidoConfigData{
 		LogLevel:         "INFO",
-		Token:            "test-token",
+		Token:            "AIK_RUNTIME_123_456_US_789",
 		CollectAPISchema: true,
 	}
 
 	Init(environmentConfig, aikidoConfig)
 
-	// Verify custom values were preserved
+	// Verify custom values were preserved (not the US endpoint)
 	if globals.EnvironmentConfig.Endpoint != customEndpoint {
 		t.Errorf("Expected Endpoint to be %q, but got %q", customEndpoint, globals.EnvironmentConfig.Endpoint)
 	}

--- a/zen/main.go
+++ b/zen/main.go
@@ -24,8 +24,10 @@ func Init() error {
 
 	// Agent Config :
 	token := os.Getenv("AIKIDO_TOKEN")
+	endpoint := os.Getenv("AIKIDO_ENDPOINT")
+	configEndpoint := os.Getenv("AIKIDO_REALTIME_ENDPOINT")
 
-	err := initAgent(config.CollectAPISchema, logLevel, token)
+	err := initAgent(config.CollectAPISchema, logLevel, token, endpoint, configEndpoint)
 	if err != nil {
 		return err
 	}
@@ -35,13 +37,13 @@ func Init() error {
 	return nil
 }
 
-func initAgent(collectAPISchema bool, logLevel string, token string) error {
+func initAgent(collectAPISchema bool, logLevel string, token string, endpoint string, configEndpoint string) error {
 	environmentConfig := &aikido_types.EnvironmentConfigData{
 		PlatformName:    "golang",
 		PlatformVersion: runtime.Version(),
 		Library:         "firewall-go",
-		Endpoint:        "https://guard.aikido.dev/",
-		ConfigEndpoint:  "https://runtime.aikido.dev/",
+		Endpoint:        endpoint,
+		ConfigEndpoint:  configEndpoint,
 		Version:         config.Version, // firewall-go version
 	}
 	aikidoConfig := &aikido_types.AikidoConfigData{


### PR DESCRIPTION
Add configurable endpoint and config endpoints trhough envvars.

Copied multi-region endpoints from token from:
- https://github.com/AikidoSec/firewall-node/pull/765