### PR TITLE
Add support for context propagation across same goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0
+	github.com/jtolds/gls v4.20.0+incompatible
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/seancfoley/ipaddress-go v1.7.0
 	github.com/stretchr/testify v1.11.1
@@ -27,6 +28,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,12 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=

--- a/instrumentation/sources/gingonic/middleware.go
+++ b/instrumentation/sources/gingonic/middleware.go
@@ -27,7 +27,9 @@ func GetMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		c.Next() // serve the request to the next middleware
+		request.WrapWithGLS(reqCtx, func() {
+			c.Next() // serve the request to the next middleware
+		})
 
 		statusCode := c.Writer.Status()
 		http.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)

--- a/instrumentation/sources/gingonic/middleware.go
+++ b/instrumentation/sources/gingonic/middleware.go
@@ -28,7 +28,7 @@ func GetMiddleware() gin.HandlerFunc {
 		}
 
 		request.WrapWithGLS(reqCtx, func() {
-			c.Next() // serve the request to the next middleware
+			c.Next()
 		})
 
 		statusCode := c.Writer.Status()

--- a/instrumentation/sources/labstackecho/middleware.go
+++ b/instrumentation/sources/labstackecho/middleware.go
@@ -30,7 +30,7 @@ func GetMiddleware() echo.MiddlewareFunc {
 
 			var err error
 			request.WrapWithGLS(reqCtx, func() {
-				err = next(c) // serve the request to the next middleware
+				err = next(c)
 			})
 
 			// Report after call with status code :

--- a/instrumentation/sources/labstackecho/middleware.go
+++ b/instrumentation/sources/labstackecho/middleware.go
@@ -28,7 +28,10 @@ func GetMiddleware() echo.MiddlewareFunc {
 				return c.String(res.StatusCode, res.Message)
 			}
 
-			err := next(c) // serve the request to the next middleware
+			var err error
+			request.WrapWithGLS(reqCtx, func() {
+				err = next(c) // serve the request to the next middleware
+			})
 
 			// Report after call with status code :
 			status := c.Response().Status

--- a/instrumentation/sources/labstackecho/middleware_test.go
+++ b/instrumentation/sources/labstackecho/middleware_test.go
@@ -1,6 +1,7 @@
 package labstackecho
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -27,6 +28,26 @@ func TestMiddlewareAddsContext(t *testing.T) {
 	})
 
 	r := httptest.NewRequest("GET", "/route?query=value", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
+func TestMiddlewareGLSFallback(t *testing.T) {
+	router := echo.New()
+	router.Use(GetMiddleware())
+
+	router.GET("/route", func(e echo.Context) error {
+		// Test that we can get context using context.Background() (should fallback to GLS)
+		ctx := request.GetContext(context.Background())
+		require.NotNil(t, ctx, "request context should be set via GLS fallback")
+
+		assert.Equal(t, "echo", ctx.Source)
+		assert.Equal(t, "/route", ctx.Route)
+		return nil
+	})
+
+	r := httptest.NewRequest("GET", "/route", nil)
 	w := httptest.NewRecorder()
 
 	router.ServeHTTP(w, r)

--- a/internal/define_transits.go
+++ b/internal/define_transits.go
@@ -20,8 +20,7 @@ func DefineTransits() {
 func OSExamine(path string) error {
 	operation := "os.OpenFile"
 
-	// @todo doesn't have access to the request context
-	return vulnerabilities.Scan(context.TODO(), operation, pathtraversal.PathTraversalVulnerability, []string{
+	return vulnerabilities.Scan(context.Background(), operation, pathtraversal.PathTraversalVulnerability, []string{
 		path /* checkPathStart */, "1",
 	})
 }

--- a/internal/request/gls.go
+++ b/internal/request/gls.go
@@ -1,0 +1,37 @@
+package request
+
+import (
+	"context"
+
+	"github.com/jtolds/gls"
+)
+
+var (
+	glsManager *gls.ContextManager
+	glsCtxKey  = "ctx"
+)
+
+func init() {
+	glsManager = gls.NewContextManager()
+}
+
+func getLocalContext() *Context {
+	if ctx, ok := glsManager.GetValue(glsCtxKey); ok && ctx != nil {
+		return ctx.(*Context)
+	}
+
+	return nil
+}
+
+// WrapWithGLS keeps the context alive in the GLS until the given function has finished executing.
+func WrapWithGLS(ctx context.Context, fn func()) {
+	reqCtx := GetContext(ctx)
+	if reqCtx != nil {
+		glsManager.SetValues(gls.Values{
+			glsCtxKey: reqCtx,
+		}, fn)
+		return
+	}
+
+	fn()
+}

--- a/internal/request/gls.go
+++ b/internal/request/gls.go
@@ -15,6 +15,8 @@ func init() {
 	glsManager = gls.NewContextManager()
 }
 
+// getLocalContext attempts to retrieve the request context for the current goroutine
+// This should return the context if it is called within the same callstack as WrapWithGLS
 func getLocalContext() *Context {
 	if ctx, ok := glsManager.GetValue(glsCtxKey); ok && ctx != nil {
 		return ctx.(*Context)

--- a/internal/request/gls_test.go
+++ b/internal/request/gls_test.go
@@ -1,0 +1,129 @@
+package request
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapWithGLS(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupCtx func() context.Context
+		wantNil  bool
+	}{
+		{
+			name: "context with request context",
+			setupCtx: func() context.Context {
+				req, _ := http.NewRequest("GET", "https://example.com/test", nil)
+				req.Header.Set("User-Agent", "test-agent")
+				req.RemoteAddr = "192.168.1.1:8080"
+
+				ctx := context.Background()
+				return SetContext(ctx, req, "/test", "test-source", &req.RemoteAddr, nil)
+			},
+			wantNil: false,
+		},
+		{
+			name: "context without request context",
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			wantNil: true,
+		},
+		{
+			name: "nil context",
+			setupCtx: func() context.Context {
+				return nil
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupCtx()
+
+			var capturedCtx *Context
+
+			// Wrap the function with GLS
+			WrapWithGLS(ctx, func() {
+				// Inside the wrapped function, get the local context
+				capturedCtx = getLocalContext()
+			})
+
+			if tt.wantNil {
+				assert.Nil(t, capturedCtx, "WrapWithGLS() should capture nil context")
+			} else {
+				require.NotNil(t, capturedCtx, "WrapWithGLS() should capture non-nil context")
+
+				// Verify the context was properly propagated
+				originalCtx := GetContext(ctx)
+				require.NotNil(t, originalCtx, "GetContext() should return non-nil")
+
+				// Compare key fields to ensure they match
+				assert.Equal(t, originalCtx.URL, capturedCtx.URL, "URL should match")
+				assert.Equal(t, originalCtx.Source, capturedCtx.Source, "Source should match")
+				assert.Equal(t, originalCtx.Route, capturedCtx.Route, "Route should match")
+				assert.Equal(t, originalCtx.GetMethod(), capturedCtx.GetMethod(), "Method should match")
+			}
+		})
+	}
+}
+
+func TestGetLocalContext_WithoutWrap(t *testing.T) {
+	// Test that getLocalContext returns nil when not wrapped
+	ctx := getLocalContext()
+	assert.Nil(t, ctx, "getLocalContext() should return nil when not wrapped")
+}
+
+func TestWrapWithGLS_ConcurrentAccess(t *testing.T) {
+	// Test that GLS works correctly with concurrent goroutines
+	const numGoroutines = 5
+	blockers := make([]chan struct{}, numGoroutines)
+	results := make(chan *Context, numGoroutines)
+
+	// Create different contexts for each goroutine
+	for i := 0; i < numGoroutines; i++ {
+		blockers[i] = make(chan struct{})
+
+		go func(id int) {
+			req, _ := http.NewRequest("GET", fmt.Sprintf("https://example.com/req%d", id), nil)
+			req.RemoteAddr = fmt.Sprintf("192.168.1.%d:8080", id)
+			ctx := SetContext(context.Background(), req, fmt.Sprintf("/req%d", id), fmt.Sprintf("source%d", id), &req.RemoteAddr, nil)
+
+			WrapWithGLS(ctx, func() {
+				// Block here until we're told to proceed
+				<-blockers[id]
+
+				// Now get the local context
+				captured := getLocalContext()
+				results <- captured
+			})
+		}(i)
+	}
+
+	// Unblock one by one and verify each gets the correct context
+	for i := 0; i < numGoroutines; i++ {
+		// Unblock this goroutine
+		close(blockers[i])
+
+		// Get its result
+		ctx := <-results
+		require.NotNil(t, ctx, "Expected context to be non-nil")
+
+		// Verify it has the correct data for this goroutine
+		expectedURL := fmt.Sprintf("http://example.com/req%d", i)
+		expectedSource := fmt.Sprintf("source%d", i)
+		expectedRoute := fmt.Sprintf("/req%d", i)
+
+		assert.Equal(t, expectedURL, ctx.URL, "URL should match for goroutine %d", i)
+		assert.Equal(t, expectedSource, ctx.Source, "Source should match for goroutine %d", i)
+		assert.Equal(t, expectedRoute, ctx.Route, "Route should match for goroutine %d", i)
+		assert.Equal(t, "GET", ctx.GetMethod(), "Method should be GET")
+	}
+}

--- a/internal/request/gls_test.go
+++ b/internal/request/gls_test.go
@@ -29,11 +29,9 @@ func TestWrapWithGLS(t *testing.T) {
 			wantNil: false,
 		},
 		{
-			name: "context without request context",
-			setupCtx: func() context.Context {
-				return context.Background()
-			},
-			wantNil: true,
+			name:     "context without request context",
+			setupCtx: context.Background,
+			wantNil:  true,
 		},
 		{
 			name: "nil context",
@@ -69,7 +67,7 @@ func TestWrapWithGLS(t *testing.T) {
 				assert.Equal(t, originalCtx.URL, capturedCtx.URL, "URL should match")
 				assert.Equal(t, originalCtx.Source, capturedCtx.Source, "Source should match")
 				assert.Equal(t, originalCtx.Route, capturedCtx.Route, "Route should match")
-				assert.Equal(t, originalCtx.GetMethod(), capturedCtx.GetMethod(), "Method should match")
+				assert.Equal(t, originalCtx.Method, capturedCtx.Method, "Method should match")
 			}
 		})
 	}
@@ -124,6 +122,6 @@ func TestWrapWithGLS_ConcurrentAccess(t *testing.T) {
 		assert.Equal(t, expectedURL, ctx.URL, "URL should match for goroutine %d", i)
 		assert.Equal(t, expectedSource, ctx.Source, "Source should match for goroutine %d", i)
 		assert.Equal(t, expectedRoute, ctx.Route, "Route should match for goroutine %d", i)
-		assert.Equal(t, "GET", ctx.GetMethod(), "Method should be GET")
+		assert.Equal(t, "GET", ctx.Method, "Method should be GET")
 	}
 }

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -33,7 +33,6 @@ func SetContext(ctx context.Context, r *http.Request, route string, source strin
 }
 
 func GetContext(ctx context.Context) *Context {
-	// First, try to get context from the provided context
 	if ctx != nil {
 		if c := ctx.Value(reqCtxKey); c != nil {
 			return c.(*Context)

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -40,6 +40,8 @@ func GetContext(ctx context.Context) *Context {
 	}
 
 	// Fallback to GLS if not found in context
+	// This is used when we are protecting a method that doesn't take a context
+	// such as `os.OpenFile`.
 	return getLocalContext()
 }
 

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -33,12 +33,15 @@ func SetContext(ctx context.Context, r *http.Request, route string, source strin
 }
 
 func GetContext(ctx context.Context) *Context {
-	c := ctx.Value(reqCtxKey)
-	if c == nil {
-		return nil
+	// First, try to get context from the provided context
+	if ctx != nil {
+		if c := ctx.Value(reqCtxKey); c != nil {
+			return c.(*Context)
+		}
 	}
 
-	return c.(*Context)
+	// Fallback to GLS if not found in context
+	return getLocalContext()
 }
 
 func headersToMap(headers http.Header) map[string][]string {

--- a/sample-apps/echo-postgres/go.mod
+++ b/sample-apps/echo-postgres/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-tpm v0.9.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect
@@ -75,6 +76,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect

--- a/sample-apps/echo-postgres/go.sum
+++ b/sample-apps/echo-postgres/go.sum
@@ -154,6 +154,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -205,6 +207,8 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/sample-apps/gin-postgres/go.mod
+++ b/sample-apps/gin-postgres/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-tpm v0.9.6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect
@@ -74,6 +75,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/labstack/echo/v4 v4.13.4 // indirect

--- a/sample-apps/gin-postgres/go.sum
+++ b/sample-apps/gin-postgres/go.sum
@@ -154,6 +154,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
+github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
@@ -205,6 +207,8 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
Add first version of support for context propagation across same goroutine, this is using https://github.com/jtolio/gls.

For us to propagation _across_ goroutines, then we will have to start messing around with the Go runtime. This PR is a good first step and allows us to protect `os.OpenFile` in cases where it's on the same goroutine as the main request without having to do anything with the runtime.