### PR TITLE
Adjust context types, remove unused fields

### DIFF
--- a/internal/http/on_init_request.go
+++ b/internal/http/on_init_request.go
@@ -37,7 +37,7 @@ func OnInitRequest(ctx context.Context) *Response {
 	}
 
 	matches := MatchEndpoints(
-		RouteMetadata{URL: reqCtx.URL, Method: reqCtx.GetMethod(), Route: reqCtx.Route},
+		RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
 		config.GetEndpoints(),
 	)
 	// IP Allowlists per route

--- a/internal/http/on_post_request.go
+++ b/internal/http/on_post_request.go
@@ -35,6 +35,6 @@ func OnPostRequest(ctx context.Context, statusCode int) {
 	apiSpec := apidiscovery.GetAPIInfo(reqCtx)
 
 	go OnRequestShutdownReporting(
-		reqCtx.GetMethod(), reqCtx.Route, statusCode, reqCtx.GetUserID(), reqCtx.GetIP(), apiSpec,
+		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUserID(), reqCtx.GetIP(), apiSpec,
 	)
 }

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -14,10 +14,8 @@ type Context struct {
 	RemoteAddress      *string
 	Body               any
 	Cookies            map[string]string
-	AttackDetected     *bool
 	Source             string
 	Route              string
-	Subdomains         []string
 	executedMiddleware bool
 	user               *User
 

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -7,7 +7,7 @@ import (
 
 type Context struct {
 	URL                string
-	Method             *string
+	Method             string
 	Query              map[string][]string
 	Headers            map[string][]string
 	RouteParams        map[string]string
@@ -75,13 +75,6 @@ func (ctx *Context) HasMiddlewareExecuted() bool {
 	defer ctx.mu.RUnlock()
 
 	return ctx.executedMiddleware
-}
-
-func (ctx *Context) GetMethod() string {
-	if ctx.Method != nil {
-		return *ctx.Method
-	}
-	return "*"
 }
 
 func (ctx *Context) GetIP() string {

--- a/internal/request/context_test.go
+++ b/internal/request/context_test.go
@@ -140,27 +140,22 @@ func TestContext_HasMiddlewareExecuted(t *testing.T) {
 func TestContext_GetMethod(t *testing.T) {
 	tests := []struct {
 		name     string
-		method   *string
+		method   string
 		expected string
 	}{
 		{
-			name:     "nil method",
-			method:   nil,
-			expected: "*",
-		},
-		{
 			name:     "GET method",
-			method:   stringPtr("GET"),
+			method:   "GET",
 			expected: "GET",
 		},
 		{
 			name:     "POST method",
-			method:   stringPtr("POST"),
+			method:   "POST",
 			expected: "POST",
 		},
 		{
 			name:     "empty method",
-			method:   stringPtr(""),
+			method:   "",
 			expected: "",
 		},
 	}
@@ -168,7 +163,7 @@ func TestContext_GetMethod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &Context{Method: tt.method}
-			result := ctx.GetMethod()
+			result := ctx.Method
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -18,7 +18,7 @@ func SetContext(ctx context.Context, r *http.Request, route string, source strin
 
 	c := &Context{
 		URL:                fullURL(r),
-		Method:             &r.Method,
+		Method:             r.Method,
 		Query:              r.URL.Query(),
 		Headers:            headersToMap(r.Header),
 		RouteParams:        nil,

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -25,10 +25,8 @@ func SetContext(ctx context.Context, r *http.Request, route string, source strin
 		RemoteAddress:      remoteAddress,
 		Body:               body,
 		Cookies:            cookiesToMap(r.Cookies()),
-		AttackDetected:     nil,
 		Source:             source,
 		Route:              route,
-		Subdomains:         []string{},
 		executedMiddleware: false, // We start with no middleware executed.
 	}
 	return context.WithValue(ctx, reqCtxKey, c)

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -78,7 +78,7 @@ func TestSetContext(t *testing.T) {
 			// Verify basic request data is captured
 			assert.NotEmpty(t, reqCtx.URL, "URL should not be empty")
 			assert.NotNil(t, reqCtx.Method, "Method should not be nil")
-			assert.Equal(t, "POST", *reqCtx.Method, "Method should be POST")
+			assert.Equal(t, "POST", reqCtx.Method, "Method should be POST")
 			// Note: Body comparison removed as it can contain uncomparable types like maps
 			assert.Equal(t, tt.remoteAddress, reqCtx.RemoteAddress)
 		})

--- a/internal/vulnerabilities/attack.go
+++ b/internal/vulnerabilities/attack.go
@@ -67,7 +67,7 @@ func GetAttackDetected(ctx context.Context, res InterceptorResult) *aikido_types
 
 	return &aikido_types.DetectedAttack{
 		Request: aikido_types.RequestInfo{
-			Method:    *reqCtx.Method,
+			Method:    reqCtx.Method,
 			IPAddress: *reqCtx.RemoteAddress,
 			UserAgent: reqCtx.GetUserAgent(),
 			URL:       reqCtx.URL,

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -26,7 +26,7 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 	}
 	// rate-limiting :
 	matches := http.MatchEndpoints(
-		http.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.GetMethod(), Route: reqCtx.Route},
+		http.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
 		config.GetEndpoints(),
 	)
 


### PR DESCRIPTION
Method is always set, so changed it to a string.
Removed fields that aren't used here or in other languages.
Kept `RouteParams` as this isn't used but it is used in other languages.