### PR TITLE
chore: remove use of ioutil

### DIFF
--- a/sample-apps/echo-postgres/api.go
+++ b/sample-apps/echo-postgres/api.go
@@ -66,7 +66,7 @@ func defineAPIRoutes(e *echo.Echo, db *DatabaseHelper) {
 		if err := c.Bind(req); err != nil {
 			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 		}
-		response, err := makeHttpRequest(req.URL)
+		response, err := makeHTTPRequest(req.URL)
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}

--- a/sample-apps/echo-postgres/helpers.go
+++ b/sample-apps/echo-postgres/helpers.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"os/exec"
 )
 
@@ -20,15 +21,15 @@ func executeShellCommand(command string) (string, error) {
 	return output.String(), nil
 }
 
-// makeHttpRequest makes a simple HTTP GET request and returns the response.
-func makeHttpRequest(url string) (string, error) {
+// makeHTTPRequest makes a simple HTTP GET request and returns the response.
+func makeHTTPRequest(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -37,9 +38,8 @@ func makeHttpRequest(url string) (string, error) {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	content, err := ioutil.ReadFile("content/blogs/" + filePath)
+	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
-
 		return "", err
 	}
 	return string(content), nil

--- a/sample-apps/gin-postgres/api.go
+++ b/sample-apps/gin-postgres/api.go
@@ -62,7 +62,7 @@ func defineAPIRoutes(r *gin.Engine, db *DatabaseHelper) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		response := makeHttpRequest(req.URL)
+		response := makeHTTPRequest(req.URL)
 		c.String(http.StatusOK, response)
 	})
 

--- a/sample-apps/gin-postgres/helpers.go
+++ b/sample-apps/gin-postgres/helpers.go
@@ -22,8 +22,8 @@ func executeShellCommand(command string) string {
 	return output.String()
 }
 
-// makeHttpRequest makes a simple HTTP GET request and returns the response.
-func makeHttpRequest(url string) string {
+// makeHTTPRequest makes a simple HTTP GET request and returns the response.
+func makeHTTPRequest(url string) string {
 	resp, err := http.Get(url)
 	if err != nil {
 		return fmt.Sprintf("Error: %s", err.Error())


### PR DESCRIPTION
`io/ioutil` is [deprecated](https://pkg.go.dev/io/ioutil#pkg-overview), swapped out for `io`/`os` methods.