### PR TITLE
Move log package to use slog

### DIFF
--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,64 @@
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetLogLevelMapping(t *testing.T) {
+	prev := levelVar.Level()
+	t.Cleanup(func() { levelVar.Set(prev) })
+
+	require.NoError(t, SetLogLevel("debug"))
+	assert.Equal(t, slog.LevelDebug, levelVar.Level())
+
+	require.NoError(t, SetLogLevel("INFO"))
+	assert.Equal(t, slog.LevelInfo, levelVar.Level())
+
+	require.NoError(t, SetLogLevel("warn"))
+	assert.Equal(t, slog.LevelWarn, levelVar.Level())
+
+	require.NoError(t, SetLogLevel("ERR"))
+	assert.Equal(t, slog.LevelError, levelVar.Level())
+
+	err := SetLogLevel("nope")
+	require.Error(t, err)
+}
+
+func TestSetLoggerAddsLibAttribute(t *testing.T) {
+	original := logger
+	t.Cleanup(func() { logger = original })
+
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	SetLogger(slog.New(h))
+
+	Info("hello")
+
+	out := buf.String()
+	require.NotEmpty(t, out)
+	assert.Contains(t, out, "lib=aikido")
+	assert.Contains(t, out, "hello")
+}
+
+func TestLevelFilteringWithSlog(t *testing.T) {
+	original := logger
+	t.Cleanup(func() { logger = original })
+
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	SetLogger(slog.New(h))
+
+	// Below threshold
+	Debug("nope")
+	assert.Equal(t, "", buf.String())
+
+	// Meets threshold
+	Info("yes")
+	out := buf.String()
+	assert.Contains(t, out, "yes")
+}


### PR DESCRIPTION
Currently doesn't support fields as part of logging, but will add that next. First step was using slog and allowing a logger to be set.

Example of this running with the current set of logs:
<img width="753" height="100" alt="image" src="https://github.com/user-attachments/assets/93cbe086-0673-4bc1-9b9c-6832d9379fd2" />
