### PR TITLE
feat: add shell injection vuln function

### DIFF
--- a/internal/vulnerabilities/shellinjection/vulnerability.go
+++ b/internal/vulnerabilities/shellinjection/vulnerability.go
@@ -4,6 +4,12 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 )
 
+var ShellInjectionVulnerability = vulnerabilities.Vulnerability{
+	ScanFunction: scanFunction,
+	Kind:         vulnerabilities.KindShellInjection,
+	Error:        "A shell injection has been detected.",
+}
+
 func scanFunction(userInput string, args []string) *vulnerabilities.ScanResult {
 	if len(args) != 1 {
 		return nil


### PR DESCRIPTION
Add missing vulnerability definition for shell injection to ensure linter is happy. It was failing on the unused scan function.