### PR TITLE
Add envvars and config struct for setting up logs

### DIFF
--- a/zen/main.go
+++ b/zen/main.go
@@ -32,10 +32,20 @@ func Protect() error {
 // the agent. This is separated from Protect to maintain thread-safety
 // with sync.Once while preserving readability.
 func doProtect() {
-	logLevel := "DEBUG"
+	logLevel := os.Getenv("AIKIDO_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = "INFO" // fallback to existing default
+	}
 	if err := log.SetLogLevel(logLevel); err != nil {
 		protectErr = err
 		return
+	}
+
+	logFormat := os.Getenv("AIKIDO_LOG_FORMAT")
+	if logFormat != "" {
+		if err := log.SetFormat(logFormat); err != nil {
+			return err
+		}
 	}
 
 	config.CollectAPISchema = true

--- a/zen/main.go
+++ b/zen/main.go
@@ -113,7 +113,6 @@ func initAgent(collectAPISchema bool, logLevel string, token string, endpoint st
 	return nil
 }
 
-// populateConfigFromEnv fills empty config fields with environment variable values
 func populateConfigFromEnv(cfg *Config) *Config {
 	// Start with empty config if nil, otherwise copy the input
 	result := Config{}

--- a/zen/main.go
+++ b/zen/main.go
@@ -36,6 +36,12 @@ func doProtect() {
 	if logLevel == "" {
 		logLevel = "INFO" // fallback to existing default
 	}
+
+	// AIKIDO_DEBUG takes precedence over AIKIDO_LOG_LEVEL
+	if os.Getenv("AIKIDO_DEBUG") == "true" {
+		logLevel = "DEBUG"
+	}
+
 	if err := log.SetLogLevel(logLevel); err != nil {
 		protectErr = err
 		return

--- a/zen/main.go
+++ b/zen/main.go
@@ -113,6 +113,8 @@ func initAgent(collectAPISchema bool, logLevel string, token string, endpoint st
 	return nil
 }
 
+// populateConfigFromEnv fills zero-value config fields from environment variables.
+// Config values take precedence over env vars. Returns a new Config without modifying the input.
 func populateConfigFromEnv(cfg *Config) *Config {
 	// Start with empty config if nil, otherwise copy the input
 	result := Config{}

--- a/zen/main.go
+++ b/zen/main.go
@@ -19,11 +19,36 @@ var (
 	protectErr  error
 )
 
+// Config holds configuration options for the Zen firewall
+type Config struct {
+	// LogLevel sets the logging level (DEBUG, INFO, WARN, ERROR)
+	LogLevel string
+	// LogFormat sets the logging format (text, json)
+	LogFormat string
+	// Debug enables debug logging (overrides LogLevel)
+	Debug bool
+	// Token is the Aikido API token
+	Token string
+	// Endpoint is the Aikido API endpoint
+	Endpoint string
+	// ConfigEndpoint is the Aikido real-time config endpoint
+	ConfigEndpoint string
+}
+
 // Protect initializes and starts the firewall background process.
 // This function must be called early in the application lifecycle to enable
 // request monitoring and protection features.
 func Protect() error {
-	protectOnce.Do(doProtect)
+	return ProtectWithConfig(nil)
+}
+
+// ProtectWithConfig initializes the Aikido firewall with explicit configuration.
+// Empty config fields fall back to environment variables.
+func ProtectWithConfig(cfg *Config) error {
+	protectOnce.Do(func() {
+		doProtect(cfg)
+	})
+
 	return protectErr
 }
 
@@ -31,14 +56,18 @@ func Protect() error {
 // It configures logging, loads environment variables, and initializes
 // the agent. This is separated from Protect to maintain thread-safety
 // with sync.Once while preserving readability.
-func doProtect() {
-	logLevel := os.Getenv("AIKIDO_LOG_LEVEL")
+func doProtect(cfg *Config) {
+	// Fallback to environment variables for empty config fields
+	cfg = populateConfigFromEnv(cfg)
+
+	// Logger configuration
+	logLevel := cfg.LogLevel
 	if logLevel == "" {
-		logLevel = "INFO" // fallback to existing default
+		logLevel = "INFO" // fallback to default
 	}
 
-	// AIKIDO_DEBUG takes precedence over AIKIDO_LOG_LEVEL
-	if os.Getenv("AIKIDO_DEBUG") == "true" {
+	// Debug takes precedence over LogLevel
+	if cfg.Debug {
 		logLevel = "DEBUG"
 	}
 
@@ -47,20 +76,16 @@ func doProtect() {
 		return
 	}
 
-	logFormat := os.Getenv("AIKIDO_LOG_FORMAT")
-	if logFormat != "" {
-		if err := log.SetFormat(logFormat); err != nil {
-			return err
+	if cfg.LogFormat != "" {
+		if err := log.SetFormat(cfg.LogFormat); err != nil {
+			protectErr = err
+			return
 		}
 	}
 
 	config.CollectAPISchema = true
 
-	token := os.Getenv("AIKIDO_TOKEN")
-	endpoint := os.Getenv("AIKIDO_ENDPOINT")
-	configEndpoint := os.Getenv("AIKIDO_REALTIME_ENDPOINT")
-
-	err := initAgent(config.CollectAPISchema, logLevel, token, endpoint, configEndpoint)
+	err := initAgent(config.CollectAPISchema, logLevel, cfg.Token, cfg.Endpoint, cfg.ConfigEndpoint)
 	if err != nil {
 		protectErr = err
 		return
@@ -86,4 +111,35 @@ func initAgent(collectAPISchema bool, logLevel string, token string, endpoint st
 
 	go agent.Init(environmentConfig, aikidoConfig)
 	return nil
+}
+
+// populateConfigFromEnv fills empty config fields with environment variable values
+func populateConfigFromEnv(cfg *Config) *Config {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	// Create a copy to avoid modifying the original
+	result := *cfg
+
+	if result.LogLevel == "" {
+		result.LogLevel = os.Getenv("AIKIDO_LOG_LEVEL")
+	}
+	if result.LogFormat == "" {
+		result.LogFormat = os.Getenv("AIKIDO_LOG_FORMAT")
+	}
+	if !result.Debug {
+		result.Debug = os.Getenv("AIKIDO_DEBUG") == "true"
+	}
+	if result.Token == "" {
+		result.Token = os.Getenv("AIKIDO_TOKEN")
+	}
+	if result.Endpoint == "" {
+		result.Endpoint = os.Getenv("AIKIDO_ENDPOINT")
+	}
+	if result.ConfigEndpoint == "" {
+		result.ConfigEndpoint = os.Getenv("AIKIDO_REALTIME_ENDPOINT")
+	}
+
+	return &result
 }

--- a/zen/main_test.go
+++ b/zen/main_test.go
@@ -1,0 +1,75 @@
+package zen
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPopulateConfigFromEnv(t *testing.T) {
+	// Set up test environment
+	os.Setenv("AIKIDO_LOG_LEVEL", "DEBUG")
+	os.Setenv("AIKIDO_LOG_FORMAT", "json")
+	os.Setenv("AIKIDO_DEBUG", "true")
+	os.Setenv("AIKIDO_TOKEN", "test-token")
+	os.Setenv("AIKIDO_ENDPOINT", "https://test.example.com")
+	os.Setenv("AIKIDO_REALTIME_ENDPOINT", "https://runtime.test.example.com")
+	defer func() {
+		os.Unsetenv("AIKIDO_LOG_LEVEL")
+		os.Unsetenv("AIKIDO_LOG_FORMAT")
+		os.Unsetenv("AIKIDO_DEBUG")
+		os.Unsetenv("AIKIDO_TOKEN")
+		os.Unsetenv("AIKIDO_ENDPOINT")
+		os.Unsetenv("AIKIDO_REALTIME_ENDPOINT")
+	}()
+
+	t.Run("nil config", func(t *testing.T) {
+		result := populateConfigFromEnv(nil)
+		require.NotNil(t, result)
+		require.Equal(t, "DEBUG", result.LogLevel)
+		require.Equal(t, "json", result.LogFormat)
+		require.True(t, result.Debug)
+		require.Equal(t, "test-token", result.Token)
+		require.Equal(t, "https://test.example.com", result.Endpoint)
+		require.Equal(t, "https://runtime.test.example.com", result.ConfigEndpoint)
+	})
+
+	t.Run("partial config with env fallback", func(t *testing.T) {
+		original := &Config{
+			LogLevel: "ERROR",          // explicit value should not be overridden
+			Token:    "explicit-token", // explicit value should not be overridden
+			// other fields should fall back to env vars
+		}
+
+		result := populateConfigFromEnv(original)
+
+		// Original should not be modified
+		require.Equal(t, "ERROR", original.LogLevel)
+		require.Equal(t, "explicit-token", original.Token)
+
+		// Result should have explicit values where provided, env vars elsewhere
+		require.Equal(t, "ERROR", result.LogLevel)                                  // explicit value preserved
+		require.Equal(t, "json", result.LogFormat)                                  // from env
+		require.True(t, result.Debug)                                               // from env
+		require.Equal(t, "explicit-token", result.Token)                            // explicit value preserved
+		require.Equal(t, "https://test.example.com", result.Endpoint)               // from env
+		require.Equal(t, "https://runtime.test.example.com", result.ConfigEndpoint) // from env
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		original := &Config{}
+		result := populateConfigFromEnv(original)
+
+		// Original should not be modified
+		require.Equal(t, "", original.LogLevel)
+
+		// Result should have env var values
+		require.Equal(t, "DEBUG", result.LogLevel)
+		require.Equal(t, "json", result.LogFormat)
+		require.True(t, result.Debug)
+		require.Equal(t, "test-token", result.Token)
+		require.Equal(t, "https://test.example.com", result.Endpoint)
+		require.Equal(t, "https://runtime.test.example.com", result.ConfigEndpoint)
+	})
+}


### PR DESCRIPTION
Based on other versions of Zen, I've added:
- `AIKIDO_LOG_LEVEL` to configure log levels in default `slog`
- `AIKIDO_DEBUG` to enable debug logs, takes precedence over the above. 
- `AIKIDO_LOG_FORMAT` to configure either text or JSON output.

I've added an option to initialise Zen with a config struct, this is typical in a lot of Go libraries.