### PR TITLE
chore: update zen-internals v0.1.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint-fix:
 	@echo "✅ Linting and fixing completed successfully"
 
 
-BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.37
+BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.51
 FILES = \
     libzen_internals_aarch64-apple-darwin.dylib \
     libzen_internals_aarch64-apple-darwin.dylib.sha256sum \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint-fix:
 	@echo "✅ Linting and fixing completed successfully"
 
 
-BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.51
+BASE_URL = https://github.com/AikidoSec/zen-internals/releases/download/v0.1.52
 FILES = \
     libzen_internals_aarch64-apple-darwin.dylib \
     libzen_internals_aarch64-apple-darwin.dylib.sha256sum \

--- a/internal/vulnerabilities/zeninternals/zen_internals.go
+++ b/internal/vulnerabilities/zeninternals/zen_internals.go
@@ -4,10 +4,10 @@ package zeninternals
 // #include <dlfcn.h>
 // #include <stdlib.h>
 //
-// typedef int (*detect_sql_injection_func)(const char*, const char*, int);
+// typedef int (*detect_sql_injection_func)(const char*, size_t, const char*, size_t, int);
 //
-// int call_detect_sql_injection(detect_sql_injection_func func, const char* query, const char* input, int sql_dialect) {
-//     return func(query, input, sql_dialect);
+// int call_detect_sql_injection(detect_sql_injection_func func, const char* query, size_t query_len, const char* input, size_t input_len, int sql_dialect) {
+//     return func(query, query_len, input, input_len, sql_dialect);
 // }
 import "C"
 
@@ -69,11 +69,15 @@ func DetectSQLInjection(query string, userInput string, dialect int) int {
 	// Convert strings to C strings
 	cQuery := C.CString(query)
 	cUserInput := C.CString(userInput)
+
 	defer C.free(unsafe.Pointer(cQuery))
 	defer C.free(unsafe.Pointer(cUserInput))
 
+	queryLen := C.size_t(len(query))
+	userInputLen := C.size_t(len(userInput))
+
 	// Call the detect_sql_injection function
-	result := int(C.call_detect_sql_injection(detectSQLInjection, cQuery, cUserInput, C.int(dialect)))
+	result := int(C.call_detect_sql_injection(detectSQLInjection, cQuery, queryLen, cUserInput, userInputLen, C.int(dialect)))
 	log.Debugf("DetectSqlInjection(%s, %s, %d) -> %d", query, userInput, dialect, result)
 	return result
 }

--- a/sample-apps/echo-postgres/Makefile
+++ b/sample-apps/echo-postgres/Makefile
@@ -1,7 +1,5 @@
 .PHONY: run
 run:
-	go clean -a
-	go clean -cache
 	go run -toolexec="orchestrion toolexec" -v echo-postgres
 
 build:

--- a/sample-apps/gin-postgres/Makefile
+++ b/sample-apps/gin-postgres/Makefile
@@ -1,7 +1,5 @@
 .PHONY: run
 run:
-	go clean -a
-	go clean -cache
 	go run -toolexec="orchestrion toolexec" -v gin-postgres
 
 build:


### PR DESCRIPTION
- Updated zen internals to v0.1.52, which required updating function signature
- Removed cleaning cache on sample apps, it's not necessary here