### PR TITLE
Remove panic from config, and remove unnecessary goroutines

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,14 +14,16 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
-var ErrCloudConfigNotUpdated = errors.New("cloud config was not updated")
+var (
+	ErrCloudConfigNotUpdated = errors.New("cloud config was not updated")
+	cloudClient              *cloud.Client
+)
 
-var cloudClient *cloud.Client
-
-func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
+func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) error {
 	machine.Init()
-	if !config.Init(environmentConfig, aikidoConfig) {
-		return false
+
+	if err := config.Init(environmentConfig, aikidoConfig); err != nil {
+		return err
 	}
 
 	cloudClient = cloud.NewClient(&cloud.ClientConfig{})
@@ -32,7 +34,7 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 	ratelimiting.Init()
 
 	log.Info("Aikido Agent loaded!", slog.String("version", globals.EnvironmentConfig.Version))
-	return true
+	return nil
 }
 
 func AgentUninit() error {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,14 +18,7 @@ var ErrCloudConfigNotUpdated = errors.New("cloud config was not updated")
 
 var cloudClient *cloud.Client
 
-func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) (initOk bool) {
-	defer func() {
-		if r := recover(); r != nil {
-			log.Warn("Recovered from panic", slog.Any("error", r))
-			initOk = false
-		}
-	}()
-
+func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
 	machine.Init()
 	if !config.Init(environmentConfig, aikidoConfig) {
 		return false

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -51,13 +51,13 @@ func getEndpointURL(token string) string {
 	}
 }
 
-func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) bool {
+func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) error {
 	globals.EnvironmentConfig = environmentConfig
 	globals.AikidoConfig = aikidoConfig
 
 	if globals.AikidoConfig.LogLevel != "" {
 		if err := log.SetLogLevel(globals.AikidoConfig.LogLevel); err != nil {
-			panic(fmt.Sprintf("Error setting log level: %s", err))
+			return fmt.Errorf("error setting log level: %w", err)
 		}
 	}
 
@@ -75,7 +75,7 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 		log.Info("No token set!")
 	}
 
-	return true
+	return nil
 }
 
 func Uninit() {}

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -51,6 +51,8 @@ func getEndpointURL(token string) string {
 	}
 }
 
+// Init initializes the configuration system, extracting region from token to determine default endpoint URL if not set.
+// Returns an error if setting the log level fails.
 func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *aikido_types.AikidoConfigData) error {
 	globals.EnvironmentConfig = environmentConfig
 	globals.AikidoConfig = aikidoConfig

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
+	"github.com/stretchr/testify/require"
 )
 
 // TestExtractRegionFromToken tests the extractRegionFromToken function.
@@ -181,7 +182,8 @@ func TestInitWithEmptyEndpoints(t *testing.T) {
 				CollectAPISchema: true,
 			}
 
-			Init(environmentConfig, aikidoConfig)
+			err := Init(environmentConfig, aikidoConfig)
+			require.NoError(t, err)
 
 			// Verify correct endpoint was applied based on token region
 			if globals.EnvironmentConfig.Endpoint != tt.expectedEndpoint {
@@ -218,7 +220,8 @@ func TestInitWithProvidedEndpoints(t *testing.T) {
 		CollectAPISchema: true,
 	}
 
-	Init(environmentConfig, aikidoConfig)
+	err := Init(environmentConfig, aikidoConfig)
+	require.NoError(t, err)
 
 	// Verify custom values were preserved (not the US endpoint)
 	if globals.EnvironmentConfig.Endpoint != customEndpoint {
@@ -228,4 +231,12 @@ func TestInitWithProvidedEndpoints(t *testing.T) {
 	if globals.EnvironmentConfig.ConfigEndpoint != customConfigEndpoint {
 		t.Errorf("Expected ConfigEndpoint to be %q, but got %q", customConfigEndpoint, globals.EnvironmentConfig.ConfigEndpoint)
 	}
+}
+
+func TestInitReturnsErrorForInvalidConfig(t *testing.T) {
+	err := Init(nil, &aikido_types.AikidoConfigData{
+		LogLevel: "INVALID",
+	})
+
+	require.Error(t, err)
 }

--- a/internal/http/on_init_request.go
+++ b/internal/http/on_init_request.go
@@ -19,7 +19,7 @@ func OnInitRequest(ctx context.Context) *Response {
 	}
 
 	if config.IsIPBypassed(reqCtx.GetIP()) {
-		return nil // Return early, not setting a context object.
+		return nil
 	}
 
 	// Blocked IP lists (e.g. known threat actors, geo blocking, ...)

--- a/zen/main.go
+++ b/zen/main.go
@@ -120,7 +120,8 @@ func initAgent(collectAPISchema bool, logLevel string, token string, endpoint st
 		CollectAPISchema: collectAPISchema,
 	}
 
-	go agent.Init(environmentConfig, aikidoConfig)
+	agent.Init(environmentConfig, aikidoConfig)
+
 	return nil
 }
 

--- a/zen/main.go
+++ b/zen/main.go
@@ -120,9 +120,7 @@ func initAgent(collectAPISchema bool, logLevel string, token string, endpoint st
 		CollectAPISchema: collectAPISchema,
 	}
 
-	agent.Init(environmentConfig, aikidoConfig)
-
-	return nil
+	return agent.Init(environmentConfig, aikidoConfig)
 }
 
 // populateConfigFromEnv fills zero-value config fields from environment variables.

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -17,7 +17,7 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 		return nil // Do not run middleware twice.
 	}
 
-	go agent.OnMiddlewareInstalled() // Report middleware as installed, handy for dashboard.
+	agent.OnMiddlewareInstalled() // Report middleware as installed, handy for dashboard.
 
 	// user-blocking :
 	userID := reqCtx.GetUserID()


### PR DESCRIPTION
- Removed panic from config, and returned error instead
- Removed goroutine from `agent.Init`
  - Function is fast enough to not need it, will reduce concurrency issues
  - Added goroutine for sending start event to prevent that request from blocking startup
- Removed goroutine for`agent.OnMiddlewareInstalled`
  - It's using an atomic value, it won't block, so it's not needed.
