### PR TITLE
chore: rename zen.Init to zen.Protect

### DIFF
--- a/instrumentation/sources/gingonic/integration_test.go
+++ b/instrumentation/sources/gingonic/integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGinIsAutomaticallyInstrumented(t *testing.T) {
-	zen.Init()
+	zen.Protect()
 
 	router := gin.New()
 	router.ContextWithFallback = true

--- a/instrumentation/sources/labstackecho/integration_test.go
+++ b/instrumentation/sources/labstackecho/integration_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestEchoIsAutomaticallyInstrumented(t *testing.T) {
-	zen.Init()
+	zen.Protect()
 
 	router := echo.New()
 

--- a/sample-apps/echo-postgres/main.go
+++ b/sample-apps/echo-postgres/main.go
@@ -11,7 +11,7 @@ import (
 var db *DatabaseHelper
 
 func main() {
-	zen.Init()
+	zen.Protect()
 	db = NewDatabaseHelper()
 	// Set up Echo router
 	e := echo.New()

--- a/sample-apps/gin-postgres/main.go
+++ b/sample-apps/gin-postgres/main.go
@@ -10,7 +10,7 @@ import (
 var db *DatabaseHelper
 
 func main() {
-	zen.Init()
+	zen.Protect()
 	db = NewDatabaseHelper()
 	// Set up Gin router
 	r := gin.Default()

--- a/zen/main.go
+++ b/zen/main.go
@@ -1,6 +1,6 @@
+// Package zen provides the main API for firewall-go, including user management,
+// request blocking, and middleware integration for Go applications.
 package zen
-
-// This is the main module users will interact with : SetUser, ShouldBlockRequest, middleware, ...
 
 import (
 	"os"
@@ -13,9 +13,10 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
-// Init needs to be called in the user's app to start the background process
-func Init() error {
-	// Logger :
+// Protect initializes and starts the firewall background process.
+// This function must be called early in the application lifecycle to enable
+// request monitoring and protection features.
+func Protect() error {
 	logLevel := "DEBUG"
 	if err := log.SetLogLevel(logLevel); err != nil {
 		return err
@@ -23,7 +24,6 @@ func Init() error {
 
 	config.CollectAPISchema = true
 
-	// Agent Config :
 	token := os.Getenv("AIKIDO_TOKEN")
 	endpoint := os.Getenv("AIKIDO_ENDPOINT")
 	configEndpoint := os.Getenv("AIKIDO_REALTIME_ENDPOINT")


### PR DESCRIPTION
Renamed `zen.Init()` to `zen.Protect()` to help describe what it's actually doing.
This matches the naming in [`firewall-python`.](https://github.com/AikidoSec/firewall-python/blob/7f46a07a7b936d433c9087c574af0f3111c2afb1/sample-apps/quart-postgres-uvicorn/app.py#L2)