### PR TITLE
feat: use atomic.Bool for log token error

### DIFF
--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -13,6 +13,8 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
+var loggedTokenError atomic.Bool
+
 func getAgentInfo() aikido_types.AgentInfo {
 	return aikido_types.AgentInfo{
 		DryMode:   !config.IsBlockingEnabled(),
@@ -108,11 +110,9 @@ func (c *Client) storeCloudConfig(configReponse []byte) bool {
 
 func logCloudRequestError(text string, err error) {
 	if err.Error() == "no token set" {
-		if atomic.LoadUint32(&globals.LoggedTokenError) != 0 {
-			// Only report the "no token set" once, so we don't pollute the logs
+		if !loggedTokenError.CompareAndSwap(false, true) {
 			return
 		}
-		atomic.StoreUint32(&globals.LoggedTokenError, 1)
 	}
 	log.Warn(text, slog.Any("error", err))
 }

--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"sync/atomic"
 	"time"
@@ -109,7 +110,7 @@ func (c *Client) storeCloudConfig(configReponse []byte) bool {
 }
 
 func logCloudRequestError(text string, err error) {
-	if err.Error() == "no token set" {
+	if errors.Is(err, ErrNoTokenSet) {
 		if !loggedTokenError.CompareAndSwap(false, true) {
 			return
 		}

--- a/internal/agent/cloud/common_test.go
+++ b/internal/agent/cloud/common_test.go
@@ -1,0 +1,83 @@
+package cloud
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogCloudRequestError(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		err          error
+		callCount    int
+		expectedLogs int
+	}{
+		{
+			name:         "ErrNoTokenSet logs only once",
+			text:         "token error",
+			err:          ErrNoTokenSet,
+			callCount:    5,
+			expectedLogs: 1, // Should only log the first time
+		},
+		{
+			name:         "other errors log every time",
+			text:         "network error",
+			err:          errors.New("connection failed"),
+			callCount:    3,
+			expectedLogs: 3, // Should log all 3 times
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset the atomic boolean before each test
+			loggedTokenError.Store(false)
+
+			original := log.Logger()
+
+			// Use a custom handler to count log calls
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, nil)
+			log.SetLogger(slog.New(handler))
+
+			// Call the function multiple times
+			for i := 0; i < tt.callCount; i++ {
+				logCloudRequestError(tt.text, tt.err)
+			}
+
+			// Count the number of log entries
+			logCount := strings.Count(buf.String(), "level=WARN")
+
+			require.Equal(t, tt.expectedLogs, logCount)
+
+			// Restore original logger
+			log.SetLogger(original)
+		})
+	}
+
+	t.Run("different errors after ErrNoTokenSet still log", func(t *testing.T) {
+		loggedTokenError.Store(false)
+		original := log.Logger()
+
+		var buf bytes.Buffer
+		handler := slog.NewTextHandler(&buf, nil)
+		log.SetLogger(slog.New(handler))
+
+		logCloudRequestError("token error", ErrNoTokenSet)
+		logCloudRequestError("token error again", ErrNoTokenSet) // should be suppressed
+		logCloudRequestError("network error", errors.New("connection failed"))
+		logCloudRequestError("timeout error", errors.New("timeout"))
+
+		logCount := strings.Count(buf.String(), "level=WARN")
+		require.Equal(t, 3, logCount) // token (1) + network (1) + timeout (1)
+
+		log.SetLogger(original)
+	})
+}

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -14,10 +14,12 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
+var ErrNoTokenSet = errors.New("no token set")
+
 func (c *Client) sendCloudRequest(endpoint string, route string, method string, payload any) ([]byte, error) {
 	token := config.GetToken()
 	if token == "" {
-		return nil, errors.New("no token set")
+		return nil, ErrNoTokenSet
 	}
 
 	apiEndpoint, err := url.JoinPath(endpoint, route)

--- a/internal/agent/globals/globals.go
+++ b/internal/agent/globals/globals.go
@@ -39,6 +39,3 @@ var UsersMutex sync.Mutex
 
 // MiddlewareInstalled boolean value to be reported on heartbeat events
 var MiddlewareInstalled uint32
-
-// Did we log a token error?
-var LoggedTokenError uint32


### PR DESCRIPTION
- Removed the global for checking if we've logged token error before
- Switched to `atomic.Bool` instead of using an `uint32`
- Using `CompareAndSwap` to reduce operations and remove chance of race condition, although extremely unlikely.