### PR TITLE
feat: add ability to set logger through config

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -89,6 +89,12 @@ func SetLogger(l *slog.Logger) {
 	logger = l.With(slog.String("lib", "aikido"))
 }
 
+// Logger returns the currently in-use instance of *slog.Logger
+// This can be used in tests to get the default loggers to later restore on cleanup.
+func Logger() *slog.Logger {
+	return logger
+}
+
 func SetFormat(format string) error {
 	f := strings.ToLower(strings.TrimSpace(format))
 	switch f {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -29,22 +29,6 @@ func TestSetLogLevelMapping(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSetLoggerAddsLibAttribute(t *testing.T) {
-	original := logger
-	t.Cleanup(func() { logger = original })
-
-	var buf bytes.Buffer
-	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
-	SetLogger(slog.New(h))
-
-	Info("hello")
-
-	out := buf.String()
-	require.NotEmpty(t, out)
-	assert.Contains(t, out, "lib=aikido")
-	assert.Contains(t, out, "hello")
-}
-
 func TestLevelFilteringWithSlog(t *testing.T) {
 	original := logger
 	t.Cleanup(func() { logger = original })
@@ -61,4 +45,31 @@ func TestLevelFilteringWithSlog(t *testing.T) {
 	Info("yes")
 	out := buf.String()
 	assert.Contains(t, out, "yes")
+}
+
+func TestSetLogger(t *testing.T) {
+	original := Logger()
+	defer SetLogger(original)
+
+	t.Run("adds lib attribute", func(t *testing.T) {
+		original := logger
+		t.Cleanup(func() { logger = original })
+
+		var buf bytes.Buffer
+		h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+		SetLogger(slog.New(h))
+
+		Info("hello")
+
+		out := buf.String()
+		require.NotEmpty(t, out)
+		assert.Contains(t, out, "lib=aikido")
+		assert.Contains(t, out, "hello")
+	})
+
+	t.Run("ignores nil logger", func(t *testing.T) {
+		before := Logger()
+		SetLogger(nil)
+		require.Equal(t, before, Logger(), "logger should not change when SetLogger receives nil")
+	})
 }

--- a/zen/main.go
+++ b/zen/main.go
@@ -3,6 +3,7 @@
 package zen
 
 import (
+	"log/slog"
 	"os"
 	"runtime"
 	"sync"
@@ -25,6 +26,8 @@ type Config struct {
 	LogLevel string
 	// LogFormat sets the logging format (text, json)
 	LogFormat string
+	// Logger provides a custom slog instance that overrrides LogLevel and LogFormat
+	Logger *slog.Logger
 	// Debug enables debug logging (overrides LogLevel)
 	Debug bool
 	// Token is the Aikido API token
@@ -81,6 +84,10 @@ func doProtect(cfg *Config) {
 			protectErr = err
 			return
 		}
+	}
+
+	if mergedCfg.Logger != nil {
+		log.SetLogger(mergedCfg.Logger)
 	}
 
 	config.CollectAPISchema = true


### PR DESCRIPTION
- Set logger through config if consumer wants to provide their own logger
- Add `Logger()` to be used in tests to be able to restore original loggers. It's in an internal package, so isn't accessible to consumers of the pkg.