### PR TITLE
refactor: modernize slices.Contains, strings.SplitSeq

### DIFF
--- a/internal/http/should_discover_route.go
+++ b/internal/http/should_discover_route.go
@@ -2,16 +2,19 @@ package http
 
 import (
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
-var excludedMethods = []string{"OPTIONS", "HEAD"}
-var ignoreExtensions = []string{"properties", "asp", "aspx", "jsp", "config"}
-var allowExtensions = []string{"html", "php"}
-var ignoreStrings = []string{"cgi-bin"}
+var (
+	excludedMethods  = []string{"OPTIONS", "HEAD"}
+	ignoreExtensions = []string{"properties", "asp", "aspx", "jsp", "config"}
+	allowExtensions  = []string{"html", "php"}
+	ignoreStrings    = []string{"cgi-bin"}
+)
 
 func shouldDiscoverRoute(statusCode int, route, method string) bool {
-	if containsStr(excludedMethods, method) {
+	if slices.Contains(excludedMethods, method) {
 		return false
 	}
 
@@ -19,10 +22,10 @@ func shouldDiscoverRoute(statusCode int, route, method string) bool {
 		return false
 	}
 
-	segments := strings.Split(route, "/")
+	segments := strings.SplitSeq(route, "/")
 
 	// e.g. /path/to/.file or /.directory/file
-	for _, segment := range segments {
+	for segment := range segments {
 		if isDotFile(segment) {
 			return false
 		}
@@ -45,7 +48,7 @@ func isAllowedExtension(segment string) bool {
 	if extension != "" && strings.HasPrefix(extension, ".") {
 		extension = extension[1:]
 
-		if containsStr(allowExtensions, extension) {
+		if slices.Contains(allowExtensions, extension) {
 			return true
 		}
 
@@ -53,7 +56,7 @@ func isAllowedExtension(segment string) bool {
 			return false
 		}
 
-		if containsStr(ignoreExtensions, extension) {
+		if slices.Contains(ignoreExtensions, extension) {
 			return false
 		}
 	}
@@ -72,15 +75,6 @@ func isDotFile(segment string) bool {
 func containsIgnoredString(segment string) bool {
 	for _, str := range ignoreStrings {
 		if strings.Contains(segment, str) {
-			return true
-		}
-	}
-	return false
-}
-
-func containsStr(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
 			return true
 		}
 	}

--- a/internal/vulnerabilities/shellinjection/is_safely_encapsulated.go
+++ b/internal/vulnerabilities/shellinjection/is_safely_encapsulated.go
@@ -1,6 +1,7 @@
 package shellinjection
 
 import (
+	"slices"
 	"strings"
 )
 
@@ -28,13 +29,7 @@ func isSafelyEncapsulated(command, userInput string) bool {
 		}
 
 		// Check if the character before the user input is an escape character
-		isEscapeChar := false
-		for _, char := range escapeChars {
-			if char == charBeforeUserInput {
-				isEscapeChar = true
-				break
-			}
-		}
+		isEscapeChar := slices.Contains(escapeChars, charBeforeUserInput)
 
 		if !isEscapeChar {
 			return false


### PR DESCRIPTION
- Replaced `containsStr` with `slices.Contains`
- Replaced `strings.Split` range with slightly more efficient `strings.SplitSeq`