### PR TITLE
feat: move machine global

### DIFF
--- a/internal/agent/aikido_types/init_data.go
+++ b/internal/agent/aikido_types/init_data.go
@@ -2,14 +2,6 @@ package aikido_types
 
 import "sync"
 
-type MachineData struct {
-	HostName   string `json:"hostname"`
-	DomainName string `json:"domainname"`
-	OS         string `json:"os"`
-	OSVersion  string `json:"os_version"`
-	IPAddress  string `json:"ip_address"`
-}
-
 type EnvironmentConfigData struct {
 	PlatformName    string `json:"platform_name"`             // Platform name (fpm-fcgi, cli-server, ...)
 	PlatformVersion string `json:"platform_version"`          // Language version

--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
+	"github.com/AikidoSec/firewall-go/internal/agent/machine"
 	"github.com/AikidoSec/firewall-go/internal/agent/ratelimiting"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
@@ -19,12 +20,12 @@ var loggedTokenError atomic.Bool
 func getAgentInfo() aikido_types.AgentInfo {
 	return aikido_types.AgentInfo{
 		DryMode:   !config.IsBlockingEnabled(),
-		Hostname:  globals.Machine.HostName,
+		Hostname:  machine.Machine.HostName,
 		Version:   globals.EnvironmentConfig.Version,
-		IPAddress: globals.Machine.IPAddress,
+		IPAddress: machine.Machine.IPAddress,
 		OS: aikido_types.OsInfo{
-			Name:    globals.Machine.OS,
-			Version: globals.Machine.OSVersion,
+			Name:    machine.Machine.OS,
+			Version: machine.Machine.OSVersion,
 		},
 		Platform: aikido_types.PlatformInfo{
 			Name:    globals.EnvironmentConfig.PlatformName,

--- a/internal/agent/globals/globals.go
+++ b/internal/agent/globals/globals.go
@@ -12,9 +12,6 @@ var EnvironmentConfig *aikido_types.EnvironmentConfigData
 // Aikido config that contains info about endpoint, log_level, token, ...
 var AikidoConfig *aikido_types.AikidoConfigData
 
-// Data about the current machine, computed at init
-var Machine aikido_types.MachineData
-
 // List of outgoing hostnames, their ports and number of hits, collected from the requests
 var Hostnames = make(map[string]map[uint32]uint64)
 

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -9,12 +9,19 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
+type MachineData struct {
+	HostName   string
+	DomainName string
+	OS         string
+	OSVersion  string
+	IPAddress  string
+}
+
 // Machine holds data about the current machine, computed at init
-var Machine aikido_types.MachineData
+var Machine MachineData
 var initOnce sync.Once
 
 func getHostName() string {
@@ -68,8 +75,8 @@ func getIPAddress() string {
 	return ""
 }
 
-func getMachineData() aikido_types.MachineData {
-	return aikido_types.MachineData{
+func getMachineData() MachineData {
+	return MachineData{
 		HostName:   getHostName(),
 		DomainName: getDomainName(),
 		OS:         runtime.GOOS,

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -47,6 +47,8 @@ func getDomainName(ctx context.Context) string {
 	fqdn := strings.TrimSpace(string(output))
 
 	// Extract domain by removing the first part (hostname)
+	// Example: if fqdn is "web01.prod.example.com", we split into ["web01", "prod.example.com"]
+	// and return parts[1] which is "prod.example.com"
 	parts := strings.SplitN(fqdn, ".", 2)
 	if len(parts) == 2 {
 		return parts[1]

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -24,15 +24,21 @@ func getHostName() string {
 }
 
 func getDomainName() string {
-	var domainName string
-
-	cmd := exec.Command("hostname", "--domain")
+	cmd := exec.Command("hostname", "-f")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
-	domainName = strings.TrimSpace(string(output))
-	return domainName
+
+	fqdn := strings.TrimSpace(string(output))
+
+	// Extract domain by removing the first part (hostname)
+	parts := strings.SplitN(fqdn, ".", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+
+	return ""
 }
 
 func getOSVersion() string {
@@ -60,14 +66,18 @@ func getIPAddress() string {
 	return ""
 }
 
-func Init() {
-	Machine = aikido_types.MachineData{
+func getMachineData() aikido_types.MachineData {
+	return aikido_types.MachineData{
 		HostName:   getHostName(),
 		DomainName: getDomainName(),
 		OS:         runtime.GOOS,
 		OSVersion:  getOSVersion(),
 		IPAddress:  getIPAddress(),
 	}
+}
+
+func Init() {
+	Machine = getMachineData()
 
 	log.Info("Machine info", slog.Any("machine", Machine))
 }

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -15,11 +15,10 @@ import (
 )
 
 type MachineData struct {
-	HostName   string
-	DomainName string
-	OS         string
-	OSVersion  string
-	IPAddress  string
+	HostName  string
+	OS        string
+	OSVersion string
+	IPAddress string
 }
 
 // Machine caches immutable system information to avoid expensive repeated system calls.
@@ -36,28 +35,10 @@ func getHostName() string {
 	return hostname
 }
 
-func getDomainName(ctx context.Context) string {
-	// We're using `hostname -f` instead of `hostname --domain` for darwin support
-	cmd := exec.CommandContext(ctx, "hostname", "-f")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
+func getOSVersion() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
-	fqdn := strings.TrimSpace(string(output))
-
-	// Extract domain by removing the first part (hostname)
-	// Example: if fqdn is "web01.prod.example.com", we split into ["web01", "prod.example.com"]
-	// and return parts[1] which is "prod.example.com"
-	parts := strings.SplitN(fqdn, ".", 2)
-	if len(parts) == 2 {
-		return parts[1]
-	}
-
-	return ""
-}
-
-func getOSVersion(ctx context.Context) string {
 	cmd := exec.CommandContext(ctx, "uname", "-r")
 	output, err := cmd.Output()
 	if err != nil {
@@ -82,22 +63,18 @@ func getIPAddress() string {
 	return ""
 }
 
-func getMachineData(ctx context.Context) MachineData {
+func getMachineData() MachineData {
 	return MachineData{
-		HostName:   getHostName(),
-		DomainName: getDomainName(ctx),
-		OS:         runtime.GOOS,
-		OSVersion:  getOSVersion(ctx),
-		IPAddress:  getIPAddress(),
+		HostName:  getHostName(),
+		OS:        runtime.GOOS,
+		OSVersion: getOSVersion(),
+		IPAddress: getIPAddress(),
 	}
 }
 
 func Init() {
 	initOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-
-		Machine = getMachineData(ctx)
+		Machine = getMachineData()
 		log.Debug("Machine data", slog.Any("machine", Machine))
 	})
 }

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/log"
@@ -14,6 +15,7 @@ import (
 
 // Machine holds data about the current machine, computed at init
 var Machine aikido_types.MachineData
+var initOnce sync.Once
 
 func getHostName() string {
 	hostname, err := os.Hostname()
@@ -77,7 +79,8 @@ func getMachineData() aikido_types.MachineData {
 }
 
 func Init() {
-	Machine = getMachineData()
-
-	log.Info("Machine info", slog.Any("machine", Machine))
+	initOnce.Do(func() {
+		Machine = getMachineData()
+		log.Debug("Machine data", slog.Any("machine", Machine))
+	})
 }

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -21,8 +21,10 @@ type MachineData struct {
 }
 
 // Machine holds data about the current machine, computed at init
-var Machine MachineData
-var initOnce sync.Once
+var (
+	Machine  MachineData
+	initOnce sync.Once
+)
 
 func getHostName() string {
 	hostname, err := os.Hostname()
@@ -33,6 +35,7 @@ func getHostName() string {
 }
 
 func getDomainName() string {
+	// We're using `hostname -f` instead of `hostname --domain` for darwin support
 	cmd := exec.Command("hostname", "-f")
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
-	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
+
+// Machine holds data about the current machine, computed at init
+var Machine aikido_types.MachineData
 
 func getHostName() string {
 	hostname, err := os.Hostname()
@@ -59,7 +61,7 @@ func getIPAddress() string {
 }
 
 func Init() {
-	globals.Machine = aikido_types.MachineData{
+	Machine = aikido_types.MachineData{
 		HostName:   getHostName(),
 		DomainName: getDomainName(),
 		OS:         runtime.GOOS,
@@ -67,5 +69,5 @@ func Init() {
 		IPAddress:  getIPAddress(),
 	}
 
-	log.Info("Machine info", slog.Any("machine", globals.Machine))
+	log.Info("Machine info", slog.Any("machine", Machine))
 }

--- a/internal/agent/machine/machine.go
+++ b/internal/agent/machine/machine.go
@@ -20,7 +20,7 @@ type MachineData struct {
 	IPAddress  string
 }
 
-// Machine holds data about the current machine, computed at init
+// Machine caches immutable system information to avoid expensive repeated system calls.
 var (
 	Machine  MachineData
 	initOnce sync.Once

--- a/internal/agent/machine/machine_test.go
+++ b/internal/agent/machine/machine_test.go
@@ -1,7 +1,6 @@
 package machine
 
 import (
-	"context"
 	"net"
 	"runtime"
 	"testing"
@@ -10,12 +9,11 @@ import (
 )
 
 func TestGetMachineData(t *testing.T) {
-	machineData := getMachineData(context.TODO())
+	machineData := getMachineData()
 
 	assert.Equal(t, runtime.GOOS, machineData.OS, "OS should match runtime.GOOS")
 	assert.NotEmpty(t, machineData.OSVersion, "OSVersion should be set")
 	assert.NotEmpty(t, machineData.HostName, "HostName should be set")
-	assert.NotEmpty(t, machineData.DomainName, "DomainName should be set")
 	assert.NotEmpty(t, machineData.OSVersion, "OSVersion should be set")
 	assert.NotEmpty(t, machineData.IPAddress, "IPAddress should be set")
 

--- a/internal/agent/machine/machine_test.go
+++ b/internal/agent/machine/machine_test.go
@@ -1,0 +1,24 @@
+package machine
+
+import (
+	"net"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMachineData(t *testing.T) {
+	machineData := getMachineData()
+
+	assert.Equal(t, runtime.GOOS, machineData.OS, "OS should match runtime.GOOS")
+	assert.NotEmpty(t, machineData.OSVersion, "OSVersion should be set")
+	assert.NotEmpty(t, machineData.HostName, "HostName should be set")
+	assert.NotEmpty(t, machineData.DomainName, "DomainName should be set")
+	assert.NotEmpty(t, machineData.OSVersion, "OSVersion should be set")
+	assert.NotEmpty(t, machineData.IPAddress, "IPAddress should be set")
+
+	parsedIP := net.ParseIP(machineData.IPAddress)
+	assert.NotNil(t, parsedIP, "IPAddress should be a valid IP address")
+	assert.False(t, parsedIP.IsLoopback(), "IPAddress should not be loopback")
+}

--- a/internal/agent/machine/machine_test.go
+++ b/internal/agent/machine/machine_test.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"context"
 	"net"
 	"runtime"
 	"testing"
@@ -9,7 +10,7 @@ import (
 )
 
 func TestGetMachineData(t *testing.T) {
-	machineData := getMachineData()
+	machineData := getMachineData(context.TODO())
 
 	assert.Equal(t, runtime.GOOS, machineData.OS, "OS should match runtime.GOOS")
 	assert.NotEmpty(t, machineData.OSVersion, "OSVersion should be set")


### PR DESCRIPTION
- Move machine data type to `machine` package
- Move machine global to `machine` package
- Removed `getDomain` as the information isn't used.
- Add overall 2 second timeout to protect against and potential indefinite hangs