### PR TITLE
Add test for os sink to ensure os.OpenFile instrumentation

### DIFF
--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package os_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
+	"github.com/AikidoSec/firewall-go/zen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenFileIsAutomaticallyInstrumented(t *testing.T) {
+	zen.Protect()
+
+	// Enable blocking so that Zen should cause os.OpenFile to return an error
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, "/route?path=../test.txt", "test", &ip, nil)
+
+	request.WrapWithGLS(ctx, func() {
+		_, err := os.OpenFile("/tmp/"+"../test.txt", os.O_RDONLY, 0o600)
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+	})
+
+	config.SetBlocking(original)
+}

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -95,3 +95,10 @@ func IsBlockingEnabled() bool {
 
 	return serviceConfig.Block
 }
+
+func SetBlocking(blocking bool) {
+	serviceConfigMutex.Lock()
+	defer serviceConfigMutex.Unlock()
+
+	serviceConfig.Block = blocking
+}

--- a/internal/transits/main.go
+++ b/internal/transits/main.go
@@ -1,6 +1,8 @@
 package transits
 
-import "sync"
+import (
+	"sync"
+)
 
 // OSSinkFunction is a global variable that will hold the function to
 // test for path traversal. We cannot directly call it because then the compiler crashes.

--- a/internal/vulnerabilities/attack.go
+++ b/internal/vulnerabilities/attack.go
@@ -92,12 +92,28 @@ func getAttackDetected(ctx context.Context, res InterceptorResult) *aikido_types
 	}
 }
 
+type AttackDetectedError struct {
+	Kind          AttackKind
+	Operation     string
+	Source        string
+	PathToPayload string
+}
+
+func (e *AttackDetectedError) Error() string {
+	return fmt.Sprintf("aikido firewall has blocked %s: %s(...) originating from %s%s",
+		getDisplayNameForAttackKind(e.Kind),
+		e.Operation,
+		e.Source,
+		html.EscapeString(e.PathToPayload))
+}
+
 func buildAttackDetectedError(result InterceptorResult) error {
-	return fmt.Errorf("aikido firewall has blocked %s: %s(...) originating from %s%s",
-		getDisplayNameForAttackKind(result.Kind),
-		result.Operation,
-		result.Source,
-		html.EscapeString(result.PathToPayload))
+	return &AttackDetectedError{
+		Kind:          result.Kind,
+		Operation:     result.Operation,
+		Source:        result.Source,
+		PathToPayload: result.PathToPayload,
+	}
 }
 
 // onInterceptorResult sends the detected attack to the cloud


### PR DESCRIPTION
- Add func to SetBlocking to force errors in tests
- Add AttackDetectedError type to be able to assert on the type of error returned
- Add test to ensure instrumentation works with `os.OpenFile`