### PR TITLE
Use large runner for Mac Intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             name: ubuntu-x86_64
           - runner: macos-14
             name: macos-arm64
-          - runner: macos-15-intel
+          - runner: macos-15-large
             name: macos-x86_64
       fail-fast: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             name: ubuntu-x86_64
           - runner: macos-14
             name: macos-arm64
-          - runner: macos-15-large
+          - runner: macos-14-large
             name: macos-x86_64
       fail-fast: false
 


### PR DESCRIPTION
Mac Intel tests are taking about double the amount of time compared to other platforms.