### PR TITLE
Use generics for vulnerabilities scan arguments

### DIFF
--- a/instrumentation/sinks/database/sql/main.go
+++ b/instrumentation/sinks/database/sql/main.go
@@ -17,7 +17,8 @@ func Examine(query string, op string) error {
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.
 func ExamineContext(ctx context.Context, query string, op string) error {
-	return vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, []string{
-		query /* dialect */, "default",
+	return vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
+		Statement: query,
+		Dialect:   "default",
 	})
 }

--- a/internal/define_transits.go
+++ b/internal/define_transits.go
@@ -20,7 +20,8 @@ func DefineTransits() {
 func OSExamine(path string) error {
 	operation := "os.OpenFile"
 
-	return vulnerabilities.Scan(context.Background(), operation, pathtraversal.PathTraversalVulnerability, []string{
-		path /* checkPathStart */, "1",
+	return vulnerabilities.Scan(context.Background(), operation, pathtraversal.PathTraversalVulnerability, &pathtraversal.ScanArgs{
+		FilePath:       path,
+		CheckPathStart: true,
 	})
 }

--- a/internal/vulnerabilities/pathtraversal/vulnerability.go
+++ b/internal/vulnerabilities/pathtraversal/vulnerability.go
@@ -6,20 +6,24 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 )
 
-var PathTraversalVulnerability = vulnerabilities.Vulnerability{
+var PathTraversalVulnerability = vulnerabilities.Vulnerability[*ScanArgs]{
 	ScanFunction: scanFunction,
 	Kind:         vulnerabilities.KindPathTraversal,
 	Error:        "A path traversal attack has been detected.",
 }
 
-func scanFunction(userInput string, args []string) (*vulnerabilities.ScanResult, error) {
-	// Validate arguments :
-	if len(args) != 2 {
-		return nil, errors.New("expected 2 arguments")
+type ScanArgs struct {
+	FilePath       string
+	CheckPathStart bool
+}
+
+func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult, error) {
+	if args == nil {
+		return nil, errors.New("args cannot be nil")
 	}
 
-	filePath := args[0]
-	checkPathStart := args[1] == "1"
+	filePath := args.FilePath
+	checkPathStart := args.CheckPathStart
 
 	if detectPathTraversal(filePath, userInput, checkPathStart) {
 		return &vulnerabilities.ScanResult{

--- a/internal/vulnerabilities/scan.go
+++ b/internal/vulnerabilities/scan.go
@@ -13,8 +13,8 @@ type ScanResult struct {
 	Metadata       map[string]string
 }
 
-type Vulnerability struct {
-	ScanFunction func(string, []string) (*ScanResult, error)
+type Vulnerability[T any] struct {
+	ScanFunction func(string, T) (*ScanResult, error)
 	Kind         AttackKind
 	Error        string
 }
@@ -23,7 +23,7 @@ type Attack struct {
 	Kind string
 }
 
-func Scan(ctx context.Context, operation string, vulnerability Vulnerability, args []string) error {
+func Scan[T any](ctx context.Context, operation string, vulnerability Vulnerability[T], args T) error {
 	reqCtx := request.GetContext(ctx)
 	if reqCtx == nil {
 		return nil
@@ -51,7 +51,7 @@ func Scan(ctx context.Context, operation string, vulnerability Vulnerability, ar
 	return nil
 }
 
-func scanSource(ctx context.Context, source string, sourceData any, operation string, vulnerability Vulnerability, args []string) error {
+func scanSource[T any](ctx context.Context, source string, sourceData any, operation string, vulnerability Vulnerability[T], args T) error {
 	userInputMap := extractStringsFromUserInput(sourceData, []pathPart{})
 
 	for userInput, path := range userInputMap {

--- a/internal/vulnerabilities/shellinjection/vulnerability.go
+++ b/internal/vulnerabilities/shellinjection/vulnerability.go
@@ -6,18 +6,22 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 )
 
-var ShellInjectionVulnerability = vulnerabilities.Vulnerability{
+var ShellInjectionVulnerability = vulnerabilities.Vulnerability[*ScanArgs]{
 	ScanFunction: scanFunction,
 	Kind:         vulnerabilities.KindShellInjection,
 	Error:        "A shell injection has been detected.",
 }
 
-func scanFunction(userInput string, args []string) (*vulnerabilities.ScanResult, error) {
-	if len(args) != 1 {
-		return nil, errors.New("expected 1 argument")
+type ScanArgs struct {
+	Command string
+}
+
+func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult, error) {
+	if args == nil {
+		return nil, errors.New("args cannot be nil")
 	}
 
-	command := args[0]
+	command := args.Command
 
 	trimmedCommand := trimInvisible(command)
 	trimmedInputString := trimInvisible(userInput)

--- a/internal/vulnerabilities/sqlinjection/vulnerability.go
+++ b/internal/vulnerabilities/sqlinjection/vulnerability.go
@@ -7,26 +7,31 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities/zeninternals"
 )
 
-var SQLInjectionVulnerability = vulnerabilities.Vulnerability{
+var SQLInjectionVulnerability = vulnerabilities.Vulnerability[*ScanArgs]{
 	ScanFunction: scanFunction,
 	Kind:         vulnerabilities.KindSQLInjection,
 	Error:        "A sql injection has been detected.",
 }
 
-func scanFunction(userInput string, args []string) (*vulnerabilities.ScanResult, error) {
-	if len(args) != 2 {
-		return nil, errors.New("expected 2 arguments")
+type ScanArgs struct {
+	Statement string
+	Dialect   string
+}
+
+func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult, error) {
+	if args == nil {
+		return nil, errors.New("args cannot be nil")
 	}
 
-	statement := args[0]
-	dialect := zeninternals.GetSQLDialectFromString(args[1])
+	statement := args.Statement
+	dialect := zeninternals.GetSQLDialectFromString(args.Dialect)
 
 	if detectSQLInjection(statement, userInput, dialect) {
 		return &vulnerabilities.ScanResult{
 			DetectedAttack: true,
 			Metadata: map[string]string{
 				"sql":     statement,
-				"dialect": args[1],
+				"dialect": args.Dialect,
 			},
 		}, nil
 	}


### PR DESCRIPTION
This allows us to have proper types for scan arguments instead of []string and having to validate the length of it.