### PR TITLE
Move agent info to cloud package

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -93,11 +93,16 @@ func OnUser(id string, username string, ip string) {
 	onUserEvent(id, username, ip)
 }
 
-func OnAttackDetected(attack *aikido_types.DetectedAttack) {
+type DetectedAttack struct {
+	Request aikido_types.RequestInfo   `json:"request"`
+	Attack  aikido_types.AttackDetails `json:"attack"`
+}
+
+func OnAttackDetected(attack *DetectedAttack) {
 	log.Debug("Reporting attack")
 
 	if cloudClient != nil {
-		cloudClient.SendAttackDetectedEvent(getAgentInfo(), attack)
+		cloudClient.SendAttackDetectedEvent(getAgentInfo(), attack.Request, attack.Attack)
 	}
 
 	storeAttackStats(attack.Attack.Blocked)

--- a/internal/agent/agent_info.go
+++ b/internal/agent/agent_info.go
@@ -1,23 +1,23 @@
 package agent
 
 import (
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 	"github.com/AikidoSec/firewall-go/internal/agent/machine"
 )
 
-func getAgentInfo() aikido_types.AgentInfo {
-	return aikido_types.AgentInfo{
+func getAgentInfo() cloud.AgentInfo {
+	return cloud.AgentInfo{
 		DryMode:   !config.IsBlockingEnabled(),
 		Hostname:  machine.Machine.HostName,
 		Version:   globals.EnvironmentConfig.Version,
 		IPAddress: machine.Machine.IPAddress,
-		OS: aikido_types.OsInfo{
+		OS: cloud.OSInfo{
 			Name:    machine.Machine.OS,
 			Version: machine.Machine.OSVersion,
 		},
-		Platform: aikido_types.PlatformInfo{
+		Platform: cloud.PlatformInfo{
 			Name:    globals.EnvironmentConfig.PlatformName,
 			Version: globals.EnvironmentConfig.PlatformVersion,
 		},

--- a/internal/agent/agent_info.go
+++ b/internal/agent/agent_info.go
@@ -1,0 +1,28 @@
+package agent
+
+import (
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/globals"
+	"github.com/AikidoSec/firewall-go/internal/agent/machine"
+)
+
+func getAgentInfo() aikido_types.AgentInfo {
+	return aikido_types.AgentInfo{
+		DryMode:   !config.IsBlockingEnabled(),
+		Hostname:  machine.Machine.HostName,
+		Version:   globals.EnvironmentConfig.Version,
+		IPAddress: machine.Machine.IPAddress,
+		OS: aikido_types.OsInfo{
+			Name:    machine.Machine.OS,
+			Version: machine.Machine.OSVersion,
+		},
+		Platform: aikido_types.PlatformInfo{
+			Name:    globals.EnvironmentConfig.PlatformName,
+			Version: globals.EnvironmentConfig.PlatformVersion,
+		},
+		Packages: make(map[string]string, 0),
+		NodeEnv:  "",
+		Library:  globals.EnvironmentConfig.Library,
+	}
+}

--- a/internal/agent/agent_info_test.go
+++ b/internal/agent/agent_info_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/globals"
+	"github.com/AikidoSec/firewall-go/internal/agent/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAgentInfo(t *testing.T) {
+	// Initialize machine data
+	machine.Init()
+
+	// Set up environment config
+	environmentConfig := &aikido_types.EnvironmentConfigData{
+		PlatformName:    "test-platform",
+		PlatformVersion: "1.2.3",
+		Library:         "test-lib",
+		Version:         "2.0.0",
+	}
+
+	aikidoConfig := &aikido_types.AikidoConfigData{
+		LogLevel: "INFO",
+		Token:    "test-token",
+	}
+
+	err := config.Init(environmentConfig, aikidoConfig)
+	require.NoError(t, err)
+
+	t.Run("DryMode reflects blocking state", func(t *testing.T) {
+		config.SetBlocking(false)
+		info := getAgentInfo()
+		assert.True(t, info.DryMode, "DryMode should be true when blocking is disabled")
+
+		config.SetBlocking(true)
+		info = getAgentInfo()
+		assert.False(t, info.DryMode, "DryMode should be false when blocking is enabled")
+	})
+
+	t.Run("all fields populated correctly", func(t *testing.T) {
+		config.SetBlocking(false)
+
+		info := getAgentInfo()
+
+		// Verify all fields are set from correct sources
+		assert.Equal(t, !config.IsBlockingEnabled(), info.DryMode)
+		assert.Equal(t, machine.Machine.HostName, info.Hostname)
+		assert.Equal(t, globals.EnvironmentConfig.Version, info.Version)
+		assert.Equal(t, machine.Machine.IPAddress, info.IPAddress)
+		assert.Equal(t, machine.Machine.OS, info.OS.Name)
+		assert.Equal(t, machine.Machine.OSVersion, info.OS.Version)
+		assert.Equal(t, globals.EnvironmentConfig.PlatformName, info.Platform.Name)
+		assert.Equal(t, globals.EnvironmentConfig.PlatformVersion, info.Platform.Version)
+		assert.Equal(t, globals.EnvironmentConfig.Library, info.Library)
+		assert.NotNil(t, info.Packages)
+		assert.Empty(t, info.Packages, "Packages should be an empty map")
+		assert.Empty(t, info.NodeEnv, "NodeEnv should be empty string")
+	})
+}

--- a/internal/agent/aikido_types/events.go
+++ b/internal/agent/aikido_types/events.go
@@ -1,15 +1,5 @@
 package aikido_types
 
-type OsInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
-type PlatformInfo struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-}
-
 type Hostname struct {
 	URL  string `json:"hostname"`
 	Port uint32 `json:"port,omitempty"`
@@ -63,36 +53,6 @@ type Stats struct {
 	Requests  Requests                      `json:"requests"`
 }
 
-type AgentInfo struct {
-	DryMode                   bool              `json:"dryMode"`
-	Hostname                  string            `json:"hostname"`
-	Version                   string            `json:"version"`
-	IPAddress                 string            `json:"ipAddress"`
-	OS                        OsInfo            `json:"os"`
-	Platform                  PlatformInfo      `json:"platform"`
-	Packages                  map[string]string `json:"packages"`
-	PreventPrototypePollution bool              `json:"preventedPrototypePollution"`
-	NodeEnv                   string            `json:"nodeEnv"`
-	Library                   string            `json:"library"`
-}
-
-type Started struct {
-	Type  string    `json:"type"`
-	Agent AgentInfo `json:"agent"`
-	Time  int64     `json:"time"`
-}
-
-type Heartbeat struct {
-	Type                string     `json:"type"`
-	Stats               Stats      `json:"stats"`
-	Hostnames           []Hostname `json:"hostnames"`
-	Routes              []Route    `json:"routes"`
-	Users               []User     `json:"users"`
-	Agent               AgentInfo  `json:"agent"`
-	Time                int64      `json:"time"`
-	MiddlewareInstalled bool       `json:"middlewareInstalled"`
-}
-
 type RequestInfo struct {
 	Method    string `json:"method"`
 	IPAddress string `json:"ipAddress"`
@@ -113,12 +73,4 @@ type AttackDetails struct {
 	Payload   string            `json:"payload"`
 	Metadata  map[string]string `json:"metadata"`
 	User      *User             `json:"user"`
-}
-
-type DetectedAttack struct {
-	Type    string        `json:"type"`
-	Request RequestInfo   `json:"request"`
-	Attack  AttackDetails `json:"attack"`
-	Agent   AgentInfo     `json:"agent"`
-	Time    int64         `json:"time"`
 }

--- a/internal/agent/cloud/common.go
+++ b/internal/agent/cloud/common.go
@@ -5,34 +5,10 @@ import (
 	"log/slog"
 	"sync/atomic"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
-	"github.com/AikidoSec/firewall-go/internal/agent/config"
-	"github.com/AikidoSec/firewall-go/internal/agent/globals"
-	"github.com/AikidoSec/firewall-go/internal/agent/machine"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
 var loggedTokenError atomic.Bool
-
-func getAgentInfo() aikido_types.AgentInfo {
-	return aikido_types.AgentInfo{
-		DryMode:   !config.IsBlockingEnabled(),
-		Hostname:  machine.Machine.HostName,
-		Version:   globals.EnvironmentConfig.Version,
-		IPAddress: machine.Machine.IPAddress,
-		OS: aikido_types.OsInfo{
-			Name:    machine.Machine.OS,
-			Version: machine.Machine.OSVersion,
-		},
-		Platform: aikido_types.PlatformInfo{
-			Name:    globals.EnvironmentConfig.PlatformName,
-			Version: globals.EnvironmentConfig.PlatformVersion,
-		},
-		Packages: make(map[string]string, 0),
-		NodeEnv:  "",
-		Library:  globals.EnvironmentConfig.Library,
-	}
-}
 
 func logCloudRequestError(text string, err error) {
 	if errors.Is(err, ErrNoTokenSet) {

--- a/internal/agent/cloud/common_test.go
+++ b/internal/agent/cloud/common_test.go
@@ -7,12 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
-	"github.com/AikidoSec/firewall-go/internal/agent/config"
-	"github.com/AikidoSec/firewall-go/internal/agent/globals"
-	"github.com/AikidoSec/firewall-go/internal/agent/machine"
 	"github.com/AikidoSec/firewall-go/internal/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,56 +79,5 @@ func TestLogCloudRequestError(t *testing.T) {
 		require.Equal(t, 3, logCount) // token (1) + network (1) + timeout (1)
 
 		log.SetLogger(original)
-	})
-}
-
-func TestGetAgentInfo(t *testing.T) {
-	// Initialize machine data
-	machine.Init()
-
-	// Set up environment config
-	environmentConfig := &aikido_types.EnvironmentConfigData{
-		PlatformName:    "test-platform",
-		PlatformVersion: "1.2.3",
-		Library:         "test-lib",
-		Version:         "2.0.0",
-	}
-
-	aikidoConfig := &aikido_types.AikidoConfigData{
-		LogLevel: "INFO",
-		Token:    "test-token",
-	}
-
-	err := config.Init(environmentConfig, aikidoConfig)
-	require.NoError(t, err)
-
-	t.Run("DryMode reflects blocking state", func(t *testing.T) {
-		config.SetBlocking(false)
-		info := getAgentInfo()
-		assert.True(t, info.DryMode, "DryMode should be true when blocking is disabled")
-
-		config.SetBlocking(true)
-		info = getAgentInfo()
-		assert.False(t, info.DryMode, "DryMode should be false when blocking is enabled")
-	})
-
-	t.Run("all fields populated correctly", func(t *testing.T) {
-		config.SetBlocking(false)
-
-		info := getAgentInfo()
-
-		// Verify all fields are set from correct sources
-		assert.Equal(t, !config.IsBlockingEnabled(), info.DryMode)
-		assert.Equal(t, machine.Machine.HostName, info.Hostname)
-		assert.Equal(t, globals.EnvironmentConfig.Version, info.Version)
-		assert.Equal(t, machine.Machine.IPAddress, info.IPAddress)
-		assert.Equal(t, machine.Machine.OS, info.OS.Name)
-		assert.Equal(t, machine.Machine.OSVersion, info.OS.Version)
-		assert.Equal(t, globals.EnvironmentConfig.PlatformName, info.Platform.Name)
-		assert.Equal(t, globals.EnvironmentConfig.PlatformVersion, info.Platform.Version)
-		assert.Equal(t, globals.EnvironmentConfig.Library, info.Library)
-		assert.NotNil(t, info.Packages)
-		assert.Empty(t, info.Packages, "Packages should be an empty map")
-		assert.Empty(t, info.NodeEnv, "NodeEnv should be empty string")
 	})
 }

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -20,6 +20,29 @@ const (
 	eventsAPIRoute  = "/api/runtime/events"
 )
 
+type AgentInfo struct {
+	DryMode                   bool              `json:"dryMode"`
+	Hostname                  string            `json:"hostname"`
+	Version                   string            `json:"version"`
+	IPAddress                 string            `json:"ipAddress"`
+	OS                        OSInfo            `json:"os"`
+	Platform                  PlatformInfo      `json:"platform"`
+	Packages                  map[string]string `json:"packages"`
+	PreventPrototypePollution bool              `json:"preventedPrototypePollution"`
+	NodeEnv                   string            `json:"nodeEnv"`
+	Library                   string            `json:"library"`
+}
+
+type OSInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type PlatformInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
 func (c *Client) sendCloudRequest(endpoint string, route string, method string, payload any) ([]byte, error) {
 	if c.token == "" {
 		return nil, ErrNoTokenSet

--- a/internal/agent/cloud/event_detected_attack.go
+++ b/internal/agent/cloud/event_detected_attack.go
@@ -49,13 +49,13 @@ func shouldSendAttackDetectedEvent() bool {
 	return true
 }
 
-func (c *Client) SendAttackDetectedEvent(attack *aikido_types.DetectedAttack) {
+func (c *Client) SendAttackDetectedEvent(agentInfo aikido_types.AgentInfo, attack *aikido_types.DetectedAttack) {
 	if !shouldSendAttackDetectedEvent() {
 		return
 	}
 	detectedAttackEvent := aikido_types.DetectedAttack{
 		Type:    "detected_attack",
-		Agent:   getAgentInfo(),
+		Agent:   agentInfo,
 		Request: attack.Request,
 		Attack:  attack.Attack,
 		Time:    utils.GetTime(),

--- a/internal/agent/cloud/event_detected_attack.go
+++ b/internal/agent/cloud/event_detected_attack.go
@@ -49,15 +49,23 @@ func shouldSendAttackDetectedEvent() bool {
 	return true
 }
 
-func (c *Client) SendAttackDetectedEvent(agentInfo aikido_types.AgentInfo, attack *aikido_types.DetectedAttack) {
+type DetectedAttackEvent struct {
+	Type    string                     `json:"type"`
+	Request aikido_types.RequestInfo   `json:"request"`
+	Attack  aikido_types.AttackDetails `json:"attack"`
+	Agent   AgentInfo                  `json:"agent"`
+	Time    int64                      `json:"time"`
+}
+
+func (c *Client) SendAttackDetectedEvent(agentInfo AgentInfo, request aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
 	if !shouldSendAttackDetectedEvent() {
 		return
 	}
-	detectedAttackEvent := aikido_types.DetectedAttack{
+	detectedAttackEvent := DetectedAttackEvent{
 		Type:    "detected_attack",
 		Agent:   agentInfo,
-		Request: attack.Request,
-		Attack:  attack.Attack,
+		Request: request,
+		Attack:  attack,
 		Time:    utils.GetTime(),
 	}
 

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -119,9 +119,20 @@ func GetMiddlewareInstalled() bool {
 	return atomic.LoadUint32(&globals.MiddlewareInstalled) == 1
 }
 
+type HeartbeatEvent struct {
+	Type                string                  `json:"type"`
+	Stats               aikido_types.Stats      `json:"stats"`
+	Hostnames           []aikido_types.Hostname `json:"hostnames"`
+	Routes              []aikido_types.Route    `json:"routes"`
+	Users               []aikido_types.User     `json:"users"`
+	Agent               AgentInfo               `json:"agent"`
+	Time                int64                   `json:"time"`
+	MiddlewareInstalled bool                    `json:"middlewareInstalled"`
+}
+
 // SendHeartbeatEvent sends a heartbeat event and returns the new heartbeat interval if config was updated.
-func (c *Client) SendHeartbeatEvent(agentInfo aikido_types.AgentInfo) time.Duration {
-	heartbeatEvent := aikido_types.Heartbeat{
+func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo) time.Duration {
+	heartbeatEvent := HeartbeatEvent{
 		Type:                "heartbeat",
 		Agent:               agentInfo,
 		Time:                utils.GetTime(),

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -120,10 +120,10 @@ func GetMiddlewareInstalled() bool {
 }
 
 // SendHeartbeatEvent sends a heartbeat event and returns the new heartbeat interval if config was updated.
-func (c *Client) SendHeartbeatEvent() time.Duration {
+func (c *Client) SendHeartbeatEvent(agentInfo aikido_types.AgentInfo) time.Duration {
 	heartbeatEvent := aikido_types.Heartbeat{
 		Type:                "heartbeat",
-		Agent:               getAgentInfo(),
+		Agent:               agentInfo,
 		Time:                utils.GetTime(),
 		Stats:               GetStatsAndClear(),
 		Hostnames:           GetHostnamesAndClear(),

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -1,12 +1,17 @@
 package cloud
 
 import (
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 )
 
-func (c *Client) SendStartEvent(agentInfo aikido_types.AgentInfo) {
-	startedEvent := aikido_types.Started{
+type StartEvent struct {
+	Type  string    `json:"type"`
+	Agent AgentInfo `json:"agent"`
+	Time  int64     `json:"time"`
+}
+
+func (c *Client) SendStartEvent(agentInfo AgentInfo) {
+	startedEvent := StartEvent{
 		Type:  "started",
 		Agent: agentInfo,
 		Time:  utils.GetTime(),

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -5,10 +5,10 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 )
 
-func (c *Client) SendStartEvent() {
+func (c *Client) SendStartEvent(agentInfo aikido_types.AgentInfo) {
 	startedEvent := aikido_types.Started{
 		Type:  "started",
-		Agent: getAgentInfo(),
+		Agent: agentInfo,
 		Time:  utils.GetTime(),
 	}
 

--- a/internal/vulnerabilities/attack.go
+++ b/internal/vulnerabilities/attack.go
@@ -52,13 +52,13 @@ func (i InterceptorResult) ToString() string {
 	return string(json)
 }
 
-func getAttackDetected(ctx context.Context, res InterceptorResult) *aikido_types.DetectedAttack {
+func getAttackDetected(ctx context.Context, res InterceptorResult) *agent.DetectedAttack {
 	reqCtx := request.GetContext(ctx)
 	if reqCtx == nil {
 		return nil
 	}
 
-	return &aikido_types.DetectedAttack{
+	return &agent.DetectedAttack{
 		Request: aikido_types.RequestInfo{
 			Method:    reqCtx.Method,
 			IPAddress: *reqCtx.RemoteAddress,


### PR DESCRIPTION
This gets closer to cloud having the single responsibility of calling the API. Here we're moving the type for the agent info into the cloud pkg, and accepting the agent info argument on methods that require it.