### PR TITLE
Ensure SQL injection attacks are only reported once

### DIFF
--- a/instrumentation/sinks/database/sql/fake_driver_test.go
+++ b/instrumentation/sinks/database/sql/fake_driver_test.go
@@ -1,0 +1,35 @@
+package sql_test
+
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
+func init() {
+	sql.Register("test", &testDriver{})
+}
+
+type testDriver struct{}
+
+func (d *testDriver) Open(name string) (driver.Conn, error) {
+	return &testConn{}, nil
+}
+
+type testConn struct{}
+
+func (c *testConn) Prepare(query string) (driver.Stmt, error) {
+	return &testStmt{}, nil
+}
+
+func (c *testConn) Close() error { return nil }
+
+func (c *testConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip // Not implementing transactions
+}
+
+type testStmt struct{}
+
+func (s *testStmt) Close() error                                    { return nil }
+func (s *testStmt) NumInput() int                                   { return -1 }
+func (s *testStmt) Exec(args []driver.Value) (driver.Result, error) { return nil, nil }
+func (s *testStmt) Query(args []driver.Value) (driver.Rows, error)  { return nil, nil }

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package sql_test
+
+import (
+	"context"
+	"database/sql"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AikidoSec/firewall-go/internal/agent"
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/zen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	// Enable blocking so that Zen should cause QueryContext to panic
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+
+	db, err := sql.Open("test", "")
+	require.NoError(t, err)
+
+	request.WrapWithGLS(ctx, func() {
+		require.Panics(t, func() {
+			_, _ = db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+		})
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		// Success
+		assert.Equal(t, "GET", client.capturedRequest.Method)
+		assert.Equal(t, "127.0.0.1", client.capturedRequest.IPAddress)
+		assert.Equal(t, "unknown", client.capturedRequest.UserAgent)
+		assert.Equal(t, "http://example.com/route?query=1%27%20OR%201%3D1", client.capturedRequest.URL)
+		assert.Equal(t, "test", client.capturedRequest.Source)
+		assert.Equal(t, "/route", client.capturedRequest.Route)
+
+		assert.Equal(t, "sql_injection", client.capturedAttack.Kind)
+		assert.True(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "database/sql.DB.Query(Row)Context", client.capturedAttack.Operation)
+		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, ".query", client.capturedAttack.Path)
+		assert.Equal(t, "1' OR 1=1", client.capturedAttack.Payload)
+		assert.Equal(t, map[string]string{
+			"dialect": "default",
+			"sql":     "SELECT * FROM users WHERE id = '1' OR 1=1",
+		}, client.capturedAttack.Metadata)
+		assert.Nil(t, nil, client.capturedAttack.User)
+
+		assert.NotEmpty(t, client.capturedAgentInfo)
+
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestQueryShouldReportAttackOnlyOnce(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	// Disabling blocking so that we would see attack being detected twice.
+	// Through both Query and QueryContext
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}),
+	}
+
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+
+	db, err := sql.Open("test", "")
+	require.NoError(t, err)
+
+	request.WrapWithGLS(ctx, func() {
+		require.NotPanics(t, func() {
+			_, _ = db.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
+		})
+	})
+
+	// Wait for first event
+	select {
+	case <-client.attackDetectedEventSent:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for first attack event")
+	}
+
+	// Check that no second event arrives
+	select {
+	case <-client.attackDetectedEventSent:
+		t.Fatal("attack was reported more than once")
+	case <-time.After(100 * time.Millisecond):
+		// Success! No duplicate
+	}
+}
+
+type mockCloudClient struct {
+	attackDetectedEventSent chan struct{}
+	capturedAgentInfo       cloud.AgentInfo
+	capturedRequest         aikido_types.RequestInfo
+	capturedAttack          aikido_types.AttackDetails
+	mu                      sync.Mutex
+}
+
+func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo)                   {}
+func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo) time.Duration { return 0 }
+func (m *mockCloudClient) CheckConfigUpdatedAt() time.Duration                        { return 0 }
+func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, request aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
+	m.mu.Lock()
+	m.capturedAgentInfo = agentInfo
+	m.capturedRequest = request
+	m.capturedAttack = attack
+	m.mu.Unlock()
+
+	m.attackDetectedEventSent <- struct{}{}
+}

--- a/instrumentation/sinks/database/sql/orchestrion.yml
+++ b/instrumentation/sinks/database/sql/orchestrion.yml
@@ -25,26 +25,6 @@ aspects:
             if _aikido_block != nil {
               panic(_aikido_block)
             }
-  - id: database/sql.DB.Query
-    join-point:
-      one-of:
-        - function-body:
-            function:
-              - receiver: "*database/sql.DB"
-              - name: Query
-        - function-body:
-            function:
-              - receiver: "*database/sql.DB"
-              - name: QueryRow
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.DB.Query(Row)")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
   - id: database/sql.DB.ExecContext
     join-point:
       function-body:
@@ -60,21 +40,6 @@ aspects:
             if _aikido_block != nil {
               panic(_aikido_block)
             }
-  - id: database/sql.DB.Exec
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.DB"
-          - name: Exec
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.DB.Exec")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
   - id: database/sql.DB.PrepareContext
     join-point:
       function-body:
@@ -87,21 +52,6 @@ aspects:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.PrepareContext")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
-  - id: database/sql.DB.Prepare
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.DB"
-          - name: Prepare
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.DB.Prepare")
             if _aikido_block != nil {
               panic(_aikido_block)
             }
@@ -125,26 +75,6 @@ aspects:
             if _aikido_block != nil {
               panic(_aikido_block)
             }
-  - id: database/sql.Tx.Query
-    join-point:
-      one-of:
-        - function-body:
-            function:
-              - receiver: "*database/sql.Tx"
-              - name: Query
-        - function-body:
-            function:
-              - receiver: "*database/sql.Tx"
-              - name: QueryRow
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.Tx.Query(Row)")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
   - id: database/sql.Tx.ExecContext
     join-point:
       function-body:
@@ -160,21 +90,6 @@ aspects:
             if _aikido_block != nil {
               panic(_aikido_block)
             }
-  - id: database/sql.Tx.Exec
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.Tx"
-          - name: Exec
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.Tx.Exec")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
   - id: database/sql.Tx.PrepareContext
     join-point:
       function-body:
@@ -187,21 +102,6 @@ aspects:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.PrepareContext")
-            if _aikido_block != nil {
-              panic(_aikido_block)
-            }
-  - id: database/sql.Tx.Prepare
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.Tx"
-          - name: Prepare
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.Examine({{ .Function.Argument 0}}, "database/sql.Tx.Prepare")
             if _aikido_block != nil {
               panic(_aikido_block)
             }


### PR DESCRIPTION
Previously both the context and non-context methods (e.g. Query and QueryContext) were being instrumented. As Query calls the context method within it, it meant we were reporting attacks twice.