### PR TITLE
Split blocklists from cloud config

### DIFF
--- a/internal/agent/aikido_types/init_data.go
+++ b/internal/agent/aikido_types/init_data.go
@@ -35,11 +35,6 @@ type Endpoint struct {
 	RateLimiting       RateLimiting `json:"rateLimiting"`
 }
 
-type IPBlocklist struct {
-	Description string
-	Ips         []string
-}
-
 type CloudConfigData struct {
 	Success               bool       `json:"success"`
 	ServiceID             int        `json:"serviceId"`
@@ -50,20 +45,18 @@ type CloudConfigData struct {
 	BypassedIPs           []string   `json:"allowedIPAddresses"`
 	ReceivedAnyStats      bool       `json:"receivedAnyStats"`
 	Block                 *bool      `json:"block,omitempty"`
-	BlockedIPsList        map[string]IPBlocklist
-	BlockedUserAgents     string
 }
 
-type BlockedIpsData struct {
+type BlockedIPsData struct {
 	Source      string   `json:"source"`
 	Description string   `json:"description"`
-	Ips         []string `json:"ips"`
+	IPs         []string `json:"ips"`
 }
 
 type ListsConfigData struct {
 	Success            bool             `json:"success"`
 	ServiceID          int              `json:"serviceId"`
-	BlockedIPAddresses []BlockedIpsData `json:"blockedIPAddresses"`
+	BlockedIPAddresses []BlockedIPsData `json:"blockedIPAddresses"`
 	BlockedUserAgents  string           `json:"blockedUserAgents"`
 }
 


### PR DESCRIPTION
Blocklists are being set within the cloud config response. Instead just passing it as a separate argument to make it easier to follow where data is coming from.