### PR TITLE
Return error when attack is blocked on DB.ExecContext

### DIFF
--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -2,9 +2,11 @@ package sql
 
 import (
 	"context"
+	"errors"
 
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 	"github.com/AikidoSec/firewall-go/internal/vulnerabilities/sqlinjection"
+	"github.com/AikidoSec/firewall-go/zen"
 )
 
 // Examine checks for SQL injection on non-context database methods.
@@ -17,8 +19,13 @@ func Examine(query string, op string) error {
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.
 func ExamineContext(ctx context.Context, query string, op string) error {
-	return vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
+	err := vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
 		Statement: query,
 		Dialect:   "default",
 	})
+	if err != nil {
+		return errors.Join(zen.ErrAttackBlocked, err)
+	}
+
+	return nil
 }

--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -24,7 +24,13 @@ func ExamineContext(ctx context.Context, query string, op string) error {
 		Dialect:   "default",
 	})
 	if err != nil {
-		return errors.Join(zen.ErrAttackBlocked, err)
+		// Extract attack kind from error if available, otherwise default to SQL injection
+		attackKind := vulnerabilities.KindSQLInjection
+		var attackErr *vulnerabilities.AttackDetectedError
+		if errors.As(err, &attackErr) {
+			attackKind = attackErr.Kind
+		}
+		return errors.Join(zen.ErrAttackBlocked(attackKind), err)
 	}
 
 	return nil

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,4 +151,42 @@ func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, req
 	m.mu.Unlock()
 
 	m.attackDetectedEventSent <- struct{}{}
+}
+
+func TestExecContextShouldReturnError(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	// Enable blocking so that Zen should cause ExecContext to return an error
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+
+	db, err := sql.Open("test", "")
+	require.NoError(t, err)
+
+	request.WrapWithGLS(ctx, func() {
+		result, err := db.ExecContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+		require.Nil(t, result)
+		require.Error(t, err)
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+
+		require.ErrorIs(t, err, zen.ErrAttackBlocked)
+	})
 }

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -187,6 +187,8 @@ func TestExecContextShouldReturnError(t *testing.T) {
 		var detectedErr *vulnerabilities.AttackDetectedError
 		require.ErrorAs(t, err, &detectedErr)
 
-		require.ErrorIs(t, err, zen.ErrAttackBlocked)
+		var attackBlockedErr *zen.AttackBlockedError
+		require.ErrorAs(t, err, &attackBlockedErr)
+		require.Equal(t, zen.KindSQLInjection, attackBlockedErr.Kind)
 	})
 }

--- a/instrumentation/sinks/database/sql/orchestrion.yml
+++ b/instrumentation/sinks/database/sql/orchestrion.yml
@@ -38,7 +38,7 @@ aspects:
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.ExecContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block 
             }
   - id: database/sql.DB.PrepareContext
     join-point:

--- a/zen/main.go
+++ b/zen/main.go
@@ -3,6 +3,7 @@
 package zen
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"runtime"
@@ -15,6 +16,8 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
+
+var ErrAttackBlocked = errors.New("zen blocked attack")
 
 var (
 	protectOnce sync.Once

--- a/zen/main.go
+++ b/zen/main.go
@@ -3,7 +3,7 @@
 package zen
 
 import (
-	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"runtime"
@@ -15,9 +15,38 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
 )
 
-var ErrAttackBlocked = errors.New("zen blocked attack")
+// AttackKind represents the type of attack that was detected.
+type AttackKind string
+
+const (
+	// KindSQLInjection indicates a SQL injection attack was detected.
+	KindSQLInjection AttackKind = "sql_injection"
+	// KindPathTraversal indicates a path traversal attack was detected.
+	KindPathTraversal AttackKind = "path_traversal"
+	// KindShellInjection indicates a shell injection attack was detected.
+	KindShellInjection AttackKind = "shell_injection"
+	// KindSSRF indicates a server-side request forgery attack was detected.
+	KindSSRF AttackKind = "ssrf"
+)
+
+// AttackBlockedError represents an error when an attack is blocked by Zen.
+type AttackBlockedError struct {
+	Kind AttackKind
+}
+
+func (e *AttackBlockedError) Error() string {
+	return fmt.Sprintf("zen blocked %s attack", e.Kind)
+}
+
+// ErrAttackBlocked returns an error indicating that an attack was blocked.
+// The error includes the attack type and can be checked using errors.As
+// with *AttackBlockedError to extract the attack kind.
+func ErrAttackBlocked(kind vulnerabilities.AttackKind) error {
+	return &AttackBlockedError{Kind: AttackKind(kind)}
+}
 
 var (
 	protectOnce sync.Once


### PR DESCRIPTION
Moving the SQL sink to return errors instead of panics.
This just returns an error which can be handled more gracefully within the service instead of panics.
The error is wrapped in `ErrAttackBlocked` incase the consumer wishes to handle them in a specific way.