### PR TITLE
Add tests for zen-go CLI entry point

### DIFF
--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -20,7 +21,7 @@ import (
 )
 `
 
-func initCommand() error {
+func initCommand(stdout io.Writer) error {
 	// Parse force flag: if enabled will overwrite existing files if necessary
 	force := false
 	if len(os.Args) > 2 {
@@ -36,8 +37,8 @@ func initCommand() error {
 	// Check if file already exists
 	if !force {
 		if _, err := os.Stat(filename); err == nil {
-			fmt.Printf("⚠️  %s already exists\n", filename)
-			fmt.Println("   Run with --force to overwrite, or delete the file first.")
+			fmt.Fprintf(stdout, "⚠️  %s already exists\n", filename)
+			fmt.Fprintln(stdout, "   Run with --force to overwrite, or delete the file first.")
 			return nil
 		}
 	}
@@ -49,11 +50,11 @@ func initCommand() error {
 	}
 
 	absPath, _ := filepath.Abs(filename)
-	fmt.Printf("✓ Created %s\n", filename)
-	fmt.Printf("  %s\n\n", absPath)
-	fmt.Println("Next steps:")
-	fmt.Println("  1. Run 'go mod tidy' to update your dependencies")
-	fmt.Println("  2. Build with 'orchestrion go build' to enable instrumentation")
+	fmt.Fprintf(stdout, "✓ Created %s\n", filename)
+	fmt.Fprintf(stdout, "  %s\n\n", absPath)
+	fmt.Fprintln(stdout, "Next steps:")
+	fmt.Fprintln(stdout, "  1. Run 'go mod tidy' to update your dependencies")
+	fmt.Fprintln(stdout, "  2. Build with 'orchestrion go build' to enable instrumentation")
 
 	return nil
 }

--- a/cmd/zen-go/cmd_init_test.go
+++ b/cmd/zen-go/cmd_init_test.go
@@ -22,7 +22,7 @@ func TestInitCommand_CreatesFile(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	os.Args = []string{"zen-go", "init"}
-	err = initCommand()
+	err = initCommand(os.Stdout)
 	require.NoError(t, err)
 
 	// Verify file was created
@@ -55,7 +55,7 @@ func TestInitCommand_DoesNotOverwriteExistingFile(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	os.Args = []string{"zen-go", "init"}
-	err = initCommand()
+	err = initCommand(os.Stdout)
 	require.NoError(t, err)
 
 	// Verify file content was not overwritten
@@ -83,7 +83,7 @@ func TestInitCommand_ForceOverwritesExistingFile(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	os.Args = []string{"zen-go", "init", "--force"}
-	err = initCommand()
+	err = initCommand(os.Stdout)
 	require.NoError(t, err)
 
 	// Verify file content was overwritten
@@ -112,7 +112,7 @@ func TestInitCommand_ForceShortFlag(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	os.Args = []string{"zen-go", "init", "-f"}
-	err = initCommand()
+	err = initCommand(os.Stdout)
 	require.NoError(t, err)
 
 	// Verify file content was overwritten

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -2,53 +2,62 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
 const version = "0.0.0"
 
 func main() {
-	if len(os.Args) < 2 {
-		printUsage()
-		os.Exit(1)
-	}
-
-	switch os.Args[1] {
-	case "init":
-		if err := initCommand(); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-	case "version", "-v", "--version":
-		fmt.Printf("zen-go version %s\n", version)
-	case "help", "-h", "--help":
-		printUsage()
-	default:
-		fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", os.Args[1])
-		printUsage()
+	if err := run(os.Args, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func printUsage() {
-	fmt.Println("zen-go - Aikido Zen CLI tool for Go")
-	fmt.Println()
-	fmt.Println("Usage:")
-	fmt.Println("  zen-go <command> [arguments]")
-	fmt.Println()
-	fmt.Println("Commands:")
-	fmt.Println("  init      Initialize Aikido Firewall (creates orchestrion.tool.go)")
-	fmt.Println("  version   Print version information")
-	fmt.Println("  help      Show this help message")
-	fmt.Println()
-	fmt.Println("Examples:")
-	fmt.Println("  # Initialize Aikido Firewall")
-	fmt.Println("  go run github.com/AikidoSec/firewall-go/cmd/zen-go@latest init")
-	fmt.Println()
-	fmt.Println("  # Or install globally")
-	fmt.Println("  go install github.com/AikidoSec/firewall-go/cmd/zen-go@latest")
-	fmt.Println("  zen-go init")
-	fmt.Println()
-	fmt.Println("  # Force overwrite existing file")
-	fmt.Println("  zen-go init --force")
+// run executes the command based on args and returns an error if the command fails
+// or if an unknown command is provided. Returns nil on success.
+func run(args []string, stdout, stderr io.Writer) error {
+	if len(args) < 2 {
+		printUsage(stdout)
+		return fmt.Errorf("no command provided")
+	}
+
+	switch args[1] {
+	case "init":
+		return initCommand(stdout)
+	case "version", "-v", "--version":
+		fmt.Fprintf(stdout, "zen-go version %s\n", version)
+		return nil
+	case "help", "-h", "--help":
+		printUsage(stdout)
+		return nil
+	default:
+		fmt.Fprintf(stderr, "Unknown command: %s\n\n", args[1])
+		printUsage(stdout)
+		return fmt.Errorf("unknown command: %s", args[1])
+	}
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "zen-go - Aikido Zen CLI tool for Go")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  zen-go <command> [arguments]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Commands:")
+	fmt.Fprintln(w, "  init      Initialize Aikido Firewall (creates orchestrion.tool.go)")
+	fmt.Fprintln(w, "  version   Print version information")
+	fmt.Fprintln(w, "  help      Show this help message")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Examples:")
+	fmt.Fprintln(w, "  # Initialize Aikido Firewall")
+	fmt.Fprintln(w, "  go run github.com/AikidoSec/firewall-go/cmd/zen-go@latest init")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Or install globally")
+	fmt.Fprintln(w, "  go install github.com/AikidoSec/firewall-go/cmd/zen-go@latest")
+	fmt.Fprintln(w, "  zen-go init")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  # Force overwrite existing file")
+	fmt.Fprintln(w, "  zen-go init --force")
 }

--- a/cmd/zen-go/main_test.go
+++ b/cmd/zen-go/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintUsage(t *testing.T) {
+	var buf bytes.Buffer
+	printUsage(&buf)
+	output := buf.String()
+
+	assert.Contains(t, output, "zen-go - Aikido Zen CLI tool for Go")
+	assert.Contains(t, output, "Usage:")
+	assert.Contains(t, output, "Commands:")
+	assert.Contains(t, output, "init")
+	assert.Contains(t, output, "version")
+	assert.Contains(t, output, "help")
+	assert.Contains(t, output, "Examples:")
+}
+
+func TestVersion(t *testing.T) {
+	assert.Equal(t, "0.0.0", version)
+}
+
+func TestRun(t *testing.T) {
+	testCases := []struct {
+		name           string
+		args           []string
+		wantError      bool
+		errorContains  string
+		stdoutContains []string
+		stderrContains []string
+		setupDir       func(*testing.T)
+	}{
+		{
+			name:           "no args",
+			args:           []string{"zen-go"},
+			wantError:      true,
+			errorContains:  "no command provided",
+			stdoutContains: []string{"zen-go - Aikido Zen CLI tool for Go"},
+		},
+		{
+			name:           "version command",
+			args:           []string{"zen-go", "version"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go version 0.0.0"},
+		},
+		{
+			name:           "version short flag -v",
+			args:           []string{"zen-go", "-v"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go version 0.0.0"},
+		},
+		{
+			name:           "version long flag --version",
+			args:           []string{"zen-go", "--version"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go version 0.0.0"},
+		},
+		{
+			name:           "help command",
+			args:           []string{"zen-go", "help"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go - Aikido Zen CLI tool for Go", "Usage:"},
+		},
+		{
+			name:           "help short flag -h",
+			args:           []string{"zen-go", "-h"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go - Aikido Zen CLI tool for Go", "Usage:"},
+		},
+		{
+			name:           "help long flag --help",
+			args:           []string{"zen-go", "--help"},
+			wantError:      false,
+			stdoutContains: []string{"zen-go - Aikido Zen CLI tool for Go", "Usage:"},
+		},
+		{
+			name:           "unknown command",
+			args:           []string{"zen-go", "unknown-command"},
+			wantError:      true,
+			errorContains:  "unknown command: unknown-command",
+			stderrContains: []string{"Unknown command: unknown-command"},
+			stdoutContains: []string{"zen-go - Aikido Zen CLI tool for Go"},
+		},
+		{
+			name:           "init command",
+			args:           []string{"zen-go", "init"},
+			wantError:      false,
+			stdoutContains: []string{"✓ Created orchestrion.tool.go"},
+			setupDir: func(t *testing.T) {
+				tmpDir := t.TempDir()
+				oldDir, err := os.Getwd()
+				require.NoError(t, err)
+				t.Cleanup(func() { _ = os.Chdir(oldDir) })
+				err = os.Chdir(tmpDir)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupDir != nil {
+				tc.setupDir(t)
+			}
+
+			var stdoutBuf, stderrBuf bytes.Buffer
+			err := run(tc.args, &stdoutBuf, &stderrBuf)
+
+			if tc.wantError {
+				require.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			for _, contains := range tc.stdoutContains {
+				assert.Contains(t, stdoutBuf.String(), contains)
+			}
+
+			for _, contains := range tc.stderrContains {
+				assert.Contains(t, stderrBuf.String(), contains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Now passing os.Stdout/os.Stderr as an argument to make testing easier.