### PR TITLE
Move cloud config updating logic to the agent

### DIFF
--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -140,11 +140,23 @@ type mockCloudClient struct {
 	mu                      sync.Mutex
 }
 
-func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) {}
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) time.Duration {
-	return 0
+func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
 }
-func (m *mockCloudClient) CheckConfigUpdatedAt() time.Duration { return 0 }
+
+func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchConfigUpdatedAt() time.Time { panic("not implemented") }
+func (m *mockCloudClient) FetchConfig() (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchListsConfig() (*aikido_types.ListsConfigData, error) {
+	panic("not implemented")
+}
+
 func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, request aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
 	m.mu.Lock()
 	m.capturedAgentInfo = agentInfo

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -28,11 +28,23 @@ type mockCloudClient struct {
 	capturedAttack          aikido_types.AttackDetails
 }
 
-func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) {}
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) time.Duration {
-	return 0
+func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
 }
-func (m *mockCloudClient) CheckConfigUpdatedAt() time.Duration { return 0 }
+
+func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchConfigUpdatedAt() time.Time { panic("not implemented") }
+func (m *mockCloudClient) FetchConfig() (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchListsConfig() (*aikido_types.ListsConfigData, error) {
+	panic("not implemented")
+}
+
 func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, request aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
 	m.capturedAgentInfo = agentInfo
 	m.capturedRequest = request

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -58,7 +58,7 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 			return
 		}
 
-		updateCloudConfig(client, cloudConfig)
+		applyCloudConfig(client, cloudConfig)
 	}()
 
 	startPolling()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -18,9 +17,8 @@ import (
 )
 
 var (
-	ErrCloudConfigNotUpdated = errors.New("cloud config was not updated")
-	cloudClient              CloudClient
-	cloudClientMutex         sync.RWMutex
+	cloudClient      CloudClient
+	cloudClientMutex sync.RWMutex
 
 	stateCollector = state.NewCollector()
 )

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,6 +54,7 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 	go func() {
 		cloudConfig, err := client.SendStartEvent(getAgentInfo())
 		if err != nil {
+			log.Warn("Error sending start event", slog.Any("error", err))
 			return
 		}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -13,11 +13,23 @@ import (
 
 type mockCloudClient struct{}
 
-func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) {}
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) time.Duration {
-	return 0
+func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
 }
-func (m *mockCloudClient) CheckConfigUpdatedAt() time.Duration { return 0 }
+
+func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchConfigUpdatedAt() time.Time { panic("not implemented") }
+func (m *mockCloudClient) FetchConfig() (*aikido_types.CloudConfigData, error) {
+	panic("not implemented")
+}
+
+func (m *mockCloudClient) FetchListsConfig() (*aikido_types.ListsConfigData, error) {
+	panic("not implemented")
+}
+
 func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, request aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
 }
 

--- a/internal/agent/aikido_types/init_data.go
+++ b/internal/agent/aikido_types/init_data.go
@@ -1,6 +1,9 @@
 package aikido_types
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 type EnvironmentConfigData struct {
 	PlatformName     string `json:"platform_name"`               // Platform name (fpm-fcgi, cli-server, ...)
@@ -45,6 +48,10 @@ type CloudConfigData struct {
 	BypassedIPs           []string   `json:"allowedIPAddresses"`
 	ReceivedAnyStats      bool       `json:"receivedAnyStats"`
 	Block                 *bool      `json:"block,omitempty"`
+}
+
+func (c *CloudConfigData) UpdatedAt() time.Time {
+	return time.UnixMilli(c.ConfigUpdatedAt)
 }
 
 type BlockedIPsData struct {

--- a/internal/agent/cloud/config.go
+++ b/internal/agent/cloud/config.go
@@ -2,12 +2,10 @@ package cloud
 
 import (
 	"encoding/json"
-	"log/slog"
+	"errors"
 	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
-	"github.com/AikidoSec/firewall-go/internal/agent/config"
-	"github.com/AikidoSec/firewall-go/internal/agent/ratelimiting"
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
@@ -18,39 +16,49 @@ const (
 	configAPIRoute          = "/api/runtime/config"
 	listsAPIMethod          = "GET"
 	listsAPIRoute           = "/api/runtime/firewall/lists"
-
-	minHeartbeatIntervalInMS = 120000
 )
 
-// CheckConfigUpdatedAt checks if the config has been updated and returns the new heartbeat interval if updated.
-func (c *Client) CheckConfigUpdatedAt() time.Duration {
+var ErrParsingConfig = errors.New("failed to parse cloud config")
+
+// FetchConfigUpdatedAt returns the time at which the cloud config was last updated
+func (c *Client) FetchConfigUpdatedAt() time.Time {
 	response, err := c.sendCloudRequest(c.realtimeEndpoint, configUpdatedAtAPIRoute, configUpdatedAtMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending polling config request: ", err)
-		return 0
+		return time.Time{}
 	}
 
 	cloudConfigUpdatedAt := aikido_types.CloudConfigUpdatedAt{}
 	err = json.Unmarshal(response, &cloudConfigUpdatedAt)
 	if err != nil {
-		return 0
+		return time.Time{}
 	}
 
-	if cloudConfigUpdatedAt.ConfigUpdatedAt <= config.GetCloudConfigUpdatedAt() {
-		return 0
-	}
+	return time.UnixMilli(cloudConfigUpdatedAt.ConfigUpdatedAt)
+}
 
+func (c *Client) FetchConfig() (*aikido_types.CloudConfigData, error) {
 	configResponse, err := c.sendCloudRequest(c.apiEndpoint, configAPIRoute, configAPIMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending config request: ", err)
-		return 0
+		return nil, err
 	}
 
-	return c.storeCloudConfig(configResponse)
+	return parseCloudConfigResponse(configResponse)
 }
 
-// fetchListsConfig fetches firewall blocklists to keep local security rules synchronized with cloud configuration.
-func (c *Client) fetchListsConfig() (*aikido_types.ListsConfigData, error) {
+func parseCloudConfigResponse(resp []byte) (*aikido_types.CloudConfigData, error) {
+	cloudConfig := &aikido_types.CloudConfigData{}
+	err := json.Unmarshal(resp, &cloudConfig)
+	if err != nil {
+		return nil, ErrParsingConfig
+	}
+
+	return cloudConfig, nil
+}
+
+// FetchListsConfig fetches firewall blocklists to keep local security rules synchronized with cloud configuration.
+func (c *Client) FetchListsConfig() (*aikido_types.ListsConfigData, error) {
 	response, err := c.sendCloudRequest(c.apiEndpoint, listsAPIRoute, listsAPIMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending lists request: ", err)
@@ -65,62 +73,4 @@ func (c *Client) fetchListsConfig() (*aikido_types.ListsConfigData, error) {
 	}
 
 	return &listsConfig, err
-}
-
-// storeCloudConfig applies cloud configuration if newer than the current
-// version. Returns the calculated heartbeat interval (0 if unchanged or error).
-func (c *Client) storeCloudConfig(configResponse []byte) time.Duration {
-	cloudConfig := &aikido_types.CloudConfigData{}
-	err := json.Unmarshal(configResponse, &cloudConfig)
-	if err != nil {
-		log.Warn("Failed to unmarshal cloud config!", slog.Any("error", err))
-		return 0
-	}
-	if cloudConfig.ConfigUpdatedAt <= config.GetCloudConfigUpdatedAt() {
-		return 0
-	}
-
-	listsConfig, err := c.fetchListsConfig()
-	if err != nil {
-		log.Warn("Failed to fetch lists config", slog.Any("error", err))
-		return 0
-	}
-	updateRateLimitingConfig(cloudConfig.Endpoints)
-
-	config.UpdateServiceConfig(cloudConfig, listsConfig)
-	return calculateHeartbeatInterval(cloudConfig.HeartbeatIntervalInMS, cloudConfig.ReceivedAnyStats)
-}
-
-// calculateHeartbeatInterval calculates the heartbeat interval based on config.
-// Returns 1 minute if no stats received, or the provided interval if it meets the minimum threshold.
-func calculateHeartbeatInterval(heartbeatIntervalInMS int, receivedAnyStats bool) time.Duration {
-	if !receivedAnyStats {
-		return 1 * time.Minute
-	} else if heartbeatIntervalInMS >= minHeartbeatIntervalInMS {
-		log.Info("Calculating heartbeat interval!", slog.Int("interval", heartbeatIntervalInMS))
-		return time.Duration(heartbeatIntervalInMS) * time.Millisecond
-	}
-	return 0
-}
-
-// updateRateLimitingConfig applies endpoint rate limiting configuration
-// from the cloud config.
-func updateRateLimitingConfig(endpoints []aikido_types.Endpoint) {
-	endpointConfigs := make([]ratelimiting.EndpointConfig, len(endpoints))
-	for i, endpoint := range endpoints {
-		endpointConfigs[i] = ratelimiting.EndpointConfig{
-			Method: endpoint.Method,
-			Route:  endpoint.Route,
-			RateLimiting: struct {
-				Enabled        bool
-				MaxRequests    int
-				WindowSizeInMS int
-			}{
-				Enabled:        endpoint.RateLimiting.Enabled,
-				MaxRequests:    endpoint.RateLimiting.MaxRequests,
-				WindowSizeInMS: endpoint.RateLimiting.WindowSizeInMS,
-			},
-		}
-	}
-	ratelimiting.UpdateConfig(endpointConfigs)
 }

--- a/internal/agent/cloud/config_test.go
+++ b/internal/agent/cloud/config_test.go
@@ -1,0 +1,413 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchConfigUpdatedAt(t *testing.T) {
+	t.Run("successful fetch", func(t *testing.T) {
+		updatedAt := time.Now().UnixMilli()
+		response := aikido_types.CloudConfigUpdatedAt{
+			ServiceID:       123,
+			ConfigUpdatedAt: updatedAt,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, configUpdatedAtAPIRoute, r.URL.Path)
+			assert.Equal(t, "test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			RealtimeEndpoint: server.URL,
+			Token:            "test-token",
+		})
+
+		result := client.FetchConfigUpdatedAt()
+
+		expected := time.UnixMilli(updatedAt)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("network error returns zero time", func(t *testing.T) {
+		client := NewClient(&ClientConfig{
+			RealtimeEndpoint: "http://localhost:1", // Invalid endpoint
+			Token:            "test-token",
+		})
+
+		result := client.FetchConfigUpdatedAt()
+
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("invalid JSON returns zero time", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid json}`))
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			RealtimeEndpoint: server.URL,
+			Token:            "test-token",
+		})
+
+		result := client.FetchConfigUpdatedAt()
+
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("non-200 status returns zero time", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			RealtimeEndpoint: server.URL,
+			Token:            "test-token",
+		})
+
+		result := client.FetchConfigUpdatedAt()
+
+		assert.True(t, result.IsZero())
+	})
+
+	t.Run("no token set returns zero time", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not make request without token")
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			RealtimeEndpoint: server.URL,
+			Token:            "",
+		})
+
+		result := client.FetchConfigUpdatedAt()
+
+		assert.True(t, result.IsZero())
+	})
+}
+
+func TestFetchConfig(t *testing.T) {
+	t.Run("successful fetch", func(t *testing.T) {
+		blockTrue := true
+		expectedConfig := &aikido_types.CloudConfigData{
+			Success:               true,
+			ServiceID:             456,
+			ConfigUpdatedAt:       time.Now().UnixMilli(),
+			HeartbeatIntervalInMS: 300000,
+			Endpoints: []aikido_types.Endpoint{
+				{
+					Method:             "POST",
+					Route:              "/api/users",
+					ForceProtectionOff: false,
+					RateLimiting: aikido_types.RateLimiting{
+						Enabled:        true,
+						MaxRequests:    100,
+						WindowSizeInMS: 60000,
+					},
+				},
+			},
+			BlockedUserIds:   []string{"user1", "user2"},
+			BypassedIPs:      []string{"192.168.1.1"},
+			ReceivedAnyStats: true,
+			Block:            &blockTrue,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, configAPIRoute, r.URL.Path)
+			assert.Equal(t, "test-token", r.Header.Get("Authorization"))
+
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(expectedConfig)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchConfig()
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedConfig.ServiceID, result.ServiceID)
+		assert.Equal(t, expectedConfig.HeartbeatIntervalInMS, result.HeartbeatIntervalInMS)
+		assert.Equal(t, expectedConfig.ReceivedAnyStats, result.ReceivedAnyStats)
+		assert.Len(t, result.Endpoints, 1)
+		assert.Equal(t, "POST", result.Endpoints[0].Method)
+		assert.Equal(t, "/api/users", result.Endpoints[0].Route)
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		client := NewClient(&ClientConfig{
+			APIEndpoint: "http://localhost:1",
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchConfig()
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid JSON returns parsing error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid json}`))
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchConfig()
+
+		assert.ErrorIs(t, err, ErrParsingConfig)
+		assert.Nil(t, result)
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchConfig()
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("no token set returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not make request without token")
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "",
+		})
+
+		result, err := client.FetchConfig()
+
+		assert.ErrorIs(t, err, ErrNoTokenSet)
+		assert.Nil(t, result)
+	})
+}
+
+func TestParseCloudConfigResponse(t *testing.T) {
+	t.Run("valid JSON with all fields", func(t *testing.T) {
+		blockFalse := false
+		input := &aikido_types.CloudConfigData{
+			Success:               true,
+			ServiceID:             789,
+			ConfigUpdatedAt:       time.Now().UnixMilli(),
+			HeartbeatIntervalInMS: 120000,
+			Endpoints: []aikido_types.Endpoint{
+				{
+					Method: "GET",
+					Route:  "/api/health",
+					RateLimiting: aikido_types.RateLimiting{
+						Enabled:        false,
+						MaxRequests:    0,
+						WindowSizeInMS: 0,
+					},
+				},
+			},
+			BlockedUserIds:   []string{},
+			BypassedIPs:      []string{},
+			ReceivedAnyStats: false,
+			Block:            &blockFalse,
+		}
+		jsonBytes, _ := json.Marshal(input)
+
+		result, err := parseCloudConfigResponse(jsonBytes)
+
+		require.NoError(t, err)
+		assert.Equal(t, input.ServiceID, result.ServiceID)
+		assert.Equal(t, input.HeartbeatIntervalInMS, result.HeartbeatIntervalInMS)
+		assert.False(t, result.ReceivedAnyStats)
+		assert.NotNil(t, result.Block)
+		assert.False(t, *result.Block)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		invalidJSON := []byte(`{"invalid": json}`)
+
+		result, err := parseCloudConfigResponse(invalidJSON)
+
+		assert.ErrorIs(t, err, ErrParsingConfig)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty JSON object", func(t *testing.T) {
+		emptyJSON := []byte(`{}`)
+
+		result, err := parseCloudConfigResponse(emptyJSON)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, 0, result.ServiceID)
+		assert.False(t, result.Success)
+	})
+
+	t.Run("minimal valid config", func(t *testing.T) {
+		minimalJSON := []byte(`{
+			"success": true,
+			"serviceId": 100,
+			"configUpdatedAt": 1234567890,
+			"heartbeatIntervalInMS": 60000,
+			"endpoints": [],
+			"blockedUserIds": [],
+			"allowedIPAddresses": [],
+			"receivedAnyStats": false
+		}`)
+
+		result, err := parseCloudConfigResponse(minimalJSON)
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, 100, result.ServiceID)
+		assert.Equal(t, int64(1234567890), result.ConfigUpdatedAt)
+		assert.Len(t, result.Endpoints, 0)
+	})
+}
+
+func TestFetchListsConfig(t *testing.T) {
+	t.Run("successful fetch", func(t *testing.T) {
+		expectedLists := &aikido_types.ListsConfigData{
+			Success:   true,
+			ServiceID: 999,
+			BlockedIPAddresses: []aikido_types.BlockedIPsData{
+				{
+					Source:      "threat-intel",
+					Description: "Known malicious IPs",
+					IPs:         []string{"10.0.0.1", "10.0.0.2"},
+				},
+			},
+			BlockedUserAgents: "BadBot|EvilCrawler",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, listsAPIRoute, r.URL.Path)
+			assert.Equal(t, "test-token", r.Header.Get("Authorization"))
+
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(expectedLists)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchListsConfig()
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedLists.ServiceID, result.ServiceID)
+		assert.Len(t, result.BlockedIPAddresses, 1)
+		assert.Equal(t, "threat-intel", result.BlockedIPAddresses[0].Source)
+		assert.Equal(t, "BadBot|EvilCrawler", result.BlockedUserAgents)
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		client := NewClient(&ClientConfig{
+			APIEndpoint: "http://localhost:1",
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchListsConfig()
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{not valid json}`))
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchListsConfig()
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchListsConfig()
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty lists config", func(t *testing.T) {
+		emptyLists := &aikido_types.ListsConfigData{
+			Success:            true,
+			ServiceID:          111,
+			BlockedIPAddresses: []aikido_types.BlockedIPsData{},
+			BlockedUserAgents:  "",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(emptyLists)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.FetchListsConfig()
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Len(t, result.BlockedIPAddresses, 0)
+		assert.Empty(t, result.BlockedUserAgents)
+	})
+}

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"slices"
-	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
@@ -85,7 +84,7 @@ type HeartbeatData struct {
 }
 
 // SendHeartbeatEvent sends a heartbeat event and returns the new heartbeat interval if config was updated.
-func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) time.Duration {
+func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	heartbeatEvent := HeartbeatEvent{
 		Type:                "heartbeat",
 		Agent:               agentInfo,
@@ -100,9 +99,10 @@ func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) tim
 	response, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, heartbeatEvent)
 	if err != nil {
 		logCloudRequestError("Error in sending heartbeat event: ", err)
-		return 0
+		return nil, err
 	}
-	return c.storeCloudConfig(response)
+
+	return parseCloudConfigResponse(response)
 }
 
 func computeAverage(times []int64) float64 {

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -83,7 +83,7 @@ type HeartbeatData struct {
 	MiddlewareInstalled bool
 }
 
-// SendHeartbeatEvent sends a heartbeat event and returns the new heartbeat interval if config was updated.
+// SendHeartbeatEvent sends a heartbeat to the cloud and returns the latest configuration.
 func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	heartbeatEvent := HeartbeatEvent{
 		Type:                "heartbeat",

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 )
 
@@ -10,7 +11,7 @@ type StartEvent struct {
 	Time  int64     `json:"time"`
 }
 
-func (c *Client) SendStartEvent(agentInfo AgentInfo) {
+func (c *Client) SendStartEvent(agentInfo AgentInfo) (*aikido_types.CloudConfigData, error) {
 	startedEvent := StartEvent{
 		Type:  "started",
 		Agent: agentInfo,
@@ -20,7 +21,8 @@ func (c *Client) SendStartEvent(agentInfo AgentInfo) {
 	response, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, startedEvent)
 	if err != nil {
 		logCloudRequestError("Error in sending start event: ", err)
-		return
+		return nil, err
 	}
-	_ = c.storeCloudConfig(response)
+
+	return parseCloudConfigResponse(response)
 }

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -20,7 +20,6 @@ func (c *Client) SendStartEvent(agentInfo AgentInfo) (*aikido_types.CloudConfigD
 
 	response, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, startedEvent)
 	if err != nil {
-		logCloudRequestError("Error in sending start event: ", err)
 		return nil, err
 	}
 

--- a/internal/agent/cloud/event_started_test.go
+++ b/internal/agent/cloud/event_started_test.go
@@ -1,0 +1,183 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendStartEvent(t *testing.T) {
+	t.Run("successful send", func(t *testing.T) {
+		agentInfo := AgentInfo{
+			DryMode:   true,
+			Hostname:  "prod-server",
+			Version:   "2.5.1",
+			IPAddress: "10.0.0.50",
+			OS: OSInfo{
+				Name:    "darwin",
+				Version: "13.0",
+			},
+			Platform: PlatformInfo{
+				Name:    "go",
+				Version: "1.22.0",
+			},
+			Packages: map[string]string{
+				"github.com/gorilla/mux": "v1.8.0",
+				"go.uber.org/zap":        "v1.24.0",
+			},
+			PreventPrototypePollution: true,
+			NodeEnv:                   "staging",
+			Library:                   "firewall-go",
+		}
+
+		blockTrue := true
+		expectedConfig := &aikido_types.CloudConfigData{
+			Success:               true,
+			ServiceID:             123,
+			ConfigUpdatedAt:       time.Now().UnixMilli(),
+			HeartbeatIntervalInMS: 300000,
+			Endpoints:             []aikido_types.Endpoint{},
+			BlockedUserIds:        []string{},
+			BypassedIPs:           []string{},
+			ReceivedAnyStats:      false,
+			Block:                 &blockTrue,
+		}
+
+		var receivedEvent StartEvent
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, eventsAPIMethod, r.Method)
+			assert.Equal(t, eventsAPIRoute, r.URL.Path)
+			assert.Equal(t, "test-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			// Decode and validate the request body
+			err := json.NewDecoder(r.Body).Decode(&receivedEvent)
+			require.NoError(t, err)
+
+			// Validate all event fields
+			assert.Equal(t, "started", receivedEvent.Type)
+			assert.Equal(t, true, receivedEvent.Agent.DryMode)
+			assert.Equal(t, "prod-server", receivedEvent.Agent.Hostname)
+			assert.Equal(t, "2.5.1", receivedEvent.Agent.Version)
+			assert.Equal(t, "10.0.0.50", receivedEvent.Agent.IPAddress)
+			assert.Equal(t, "darwin", receivedEvent.Agent.OS.Name)
+			assert.Equal(t, "13.0", receivedEvent.Agent.OS.Version)
+			assert.Equal(t, "go", receivedEvent.Agent.Platform.Name)
+			assert.Equal(t, "1.22.0", receivedEvent.Agent.Platform.Version)
+			assert.Len(t, receivedEvent.Agent.Packages, 2)
+			assert.Equal(t, "v1.8.0", receivedEvent.Agent.Packages["github.com/gorilla/mux"])
+			assert.Equal(t, "v1.24.0", receivedEvent.Agent.Packages["go.uber.org/zap"])
+			assert.True(t, receivedEvent.Agent.PreventPrototypePollution)
+			assert.Equal(t, "staging", receivedEvent.Agent.NodeEnv)
+			assert.Equal(t, "firewall-go", receivedEvent.Agent.Library)
+			assert.Greater(t, receivedEvent.Time, int64(0))
+
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(expectedConfig)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.SendStartEvent(agentInfo)
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, expectedConfig.ServiceID, result.ServiceID)
+		assert.Equal(t, expectedConfig.HeartbeatIntervalInMS, result.HeartbeatIntervalInMS)
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		agentInfo := AgentInfo{
+			Hostname:  "test-host",
+			Version:   "1.0.0",
+			IPAddress: "192.168.1.100",
+		}
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: "http://localhost:1",
+			Token:       "test-token",
+		})
+
+		result, err := client.SendStartEvent(agentInfo)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid response JSON", func(t *testing.T) {
+		agentInfo := AgentInfo{
+			Hostname: "test-host",
+			Version:  "1.0.0",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid json}`))
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.SendStartEvent(agentInfo)
+
+		assert.ErrorIs(t, err, ErrParsingConfig)
+		assert.Nil(t, result)
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		agentInfo := AgentInfo{
+			Hostname: "test-host",
+			Version:  "1.0.0",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "test-token",
+		})
+
+		result, err := client.SendStartEvent(agentInfo)
+
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("no token set returns error", func(t *testing.T) {
+		agentInfo := AgentInfo{
+			Hostname: "test-host",
+			Version:  "1.0.0",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not make request without token")
+		}))
+		defer server.Close()
+
+		client := NewClient(&ClientConfig{
+			APIEndpoint: server.URL,
+			Token:       "",
+		})
+
+		result, err := client.SendStartEvent(agentInfo)
+
+		assert.ErrorIs(t, err, ErrNoTokenSet)
+		assert.Nil(t, result)
+	})
+}

--- a/internal/agent/cloud_config.go
+++ b/internal/agent/cloud_config.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"log/slog"
+	"sync"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/ratelimiting"
+	"github.com/AikidoSec/firewall-go/internal/log"
+)
+
+var cloudConfigMutex sync.Mutex
+
+func updateCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigData) {
+	cloudConfigMutex.Lock()
+	defer cloudConfigMutex.Unlock()
+
+	// If cloud config was updated before or at the same time, then just return 0 indicating no changes
+	if !cloudConfig.UpdatedAt().After(config.GetCloudConfigUpdatedAt()) {
+		return
+	}
+
+	// Fetch lists
+	listsConfig, err := client.FetchListsConfig()
+	if err != nil {
+		log.Warn("Error fetching lists config", slog.Any("error", err))
+		return
+	}
+
+	updateRateLimitingConfig(cloudConfig.Endpoints)
+	config.UpdateServiceConfig(cloudConfig, listsConfig)
+
+	newInterval := calculateHeartbeatInterval(cloudConfig.HeartbeatIntervalInMS, cloudConfig.ReceivedAnyStats)
+	if newInterval > 0 {
+		resetHeartbeatTicker(newInterval)
+	}
+}
+
+// updateRateLimitingConfig applies endpoint rate limiting configuration
+// from the cloud config.
+func updateRateLimitingConfig(endpoints []aikido_types.Endpoint) {
+	endpointConfigs := make([]ratelimiting.EndpointConfig, len(endpoints))
+	for i, endpoint := range endpoints {
+		endpointConfigs[i] = ratelimiting.EndpointConfig{
+			Method: endpoint.Method,
+			Route:  endpoint.Route,
+			RateLimiting: struct {
+				Enabled        bool
+				MaxRequests    int
+				WindowSizeInMS int
+			}{
+				Enabled:        endpoint.RateLimiting.Enabled,
+				MaxRequests:    endpoint.RateLimiting.MaxRequests,
+				WindowSizeInMS: endpoint.RateLimiting.WindowSizeInMS,
+			},
+		}
+	}
+	ratelimiting.UpdateConfig(endpointConfigs)
+}

--- a/internal/agent/cloud_config.go
+++ b/internal/agent/cloud_config.go
@@ -12,7 +12,9 @@ import (
 
 var cloudConfigMutex sync.Mutex
 
-func updateCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigData) {
+// applyCloudConfig applies a new cloud config if it's newer than the current one.
+// This includes updating service config, rate limiting rules, and heartbeat interval.
+func applyCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigData) {
 	cloudConfigMutex.Lock()
 	defer cloudConfigMutex.Unlock()
 

--- a/internal/agent/cloud_config.go
+++ b/internal/agent/cloud_config.go
@@ -18,7 +18,6 @@ func applyCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigD
 	cloudConfigMutex.Lock()
 	defer cloudConfigMutex.Unlock()
 
-	// If cloud config was updated before or at the same time, then just return 0 indicating no changes
 	if !cloudConfig.UpdatedAt().After(config.GetCloudConfigUpdatedAt()) {
 		return
 	}

--- a/internal/agent/cloud_config.go
+++ b/internal/agent/cloud_config.go
@@ -18,7 +18,7 @@ func applyCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigD
 	cloudConfigMutex.Lock()
 	defer cloudConfigMutex.Unlock()
 
-	if !cloudConfig.UpdatedAt().After(config.GetCloudConfigUpdatedAt()) {
+	if cloudConfig == nil || !cloudConfig.UpdatedAt().After(config.GetCloudConfigUpdatedAt()) {
 		return
 	}
 
@@ -38,8 +38,6 @@ func applyCloudConfig(client CloudClient, cloudConfig *aikido_types.CloudConfigD
 	}
 }
 
-// updateRateLimitingConfig applies endpoint rate limiting configuration
-// from the cloud config.
 func updateRateLimitingConfig(endpoints []aikido_types.Endpoint) {
 	endpointConfigs := make([]ratelimiting.EndpointConfig, len(endpoints))
 	for i, endpoint := range endpoints {

--- a/internal/agent/config/service_config.go
+++ b/internal/agent/config/service_config.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"regexp"
 	"sync"
+	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
@@ -40,7 +41,7 @@ type IPBlockList struct {
 }
 
 type ServiceConfigData struct {
-	ConfigUpdatedAt   int64
+	ConfigUpdatedAt   time.Time
 	Endpoints         []aikido_types.Endpoint
 	BlockedUserIDs    map[string]bool
 	BypassedIPs       map[string]bool
@@ -81,7 +82,7 @@ func setServiceConfig(cloudConfigFromAgent *aikido_types.CloudConfigData, blockL
 	serviceConfigMutex.Lock()
 	defer serviceConfigMutex.Unlock()
 
-	serviceConfig.ConfigUpdatedAt = cloudConfigFromAgent.ConfigUpdatedAt
+	serviceConfig.ConfigUpdatedAt = time.UnixMilli(cloudConfigFromAgent.ConfigUpdatedAt)
 
 	var endpoints []aikido_types.Endpoint
 	for _, ep := range cloudConfigFromAgent.Endpoints {
@@ -136,7 +137,7 @@ func UpdateServiceConfig(cloudConfig *aikido_types.CloudConfigData, blockListCon
 
 var CollectAPISchema bool
 
-func GetCloudConfigUpdatedAt() int64 {
+func GetCloudConfigUpdatedAt() time.Time {
 	serviceConfigMutex.RLock()
 	defer serviceConfigMutex.RUnlock()
 

--- a/internal/agent/config/service_config_test.go
+++ b/internal/agent/config/service_config_test.go
@@ -46,11 +46,11 @@ func TestUpdateServiceConfig(t *testing.T) {
 		resetServiceConfig()
 
 		blockTrue := true
-		now := time.Now().UnixMilli()
+		now := time.Now()
 		cloudConfig := &aikido_types.CloudConfigData{
 			Success:               true,
 			ServiceID:             123,
-			ConfigUpdatedAt:       now,
+			ConfigUpdatedAt:       now.UnixMilli(),
 			HeartbeatIntervalInMS: 300000,
 			Endpoints: []aikido_types.Endpoint{
 				{
@@ -88,7 +88,7 @@ func TestUpdateServiceConfig(t *testing.T) {
 
 		// Verify config was updated
 		updatedAt := GetCloudConfigUpdatedAt()
-		assert.Equal(t, now, updatedAt)
+		assert.WithinDuration(t, now, updatedAt, time.Second)
 
 		// Verify endpoints
 		endpoints := GetEndpoints()
@@ -124,7 +124,7 @@ func TestUpdateServiceConfig(t *testing.T) {
 
 		// Config should remain empty
 		updatedAt := GetCloudConfigUpdatedAt()
-		assert.Equal(t, int64(0), updatedAt)
+		assert.Zero(t, updatedAt)
 	})
 
 	t.Run("uses aikido config blocking when cloud config block is nil", func(t *testing.T) {
@@ -587,22 +587,22 @@ func TestGetCloudConfigUpdatedAt(t *testing.T) {
 	t.Run("returns updated timestamp", func(t *testing.T) {
 		resetServiceConfig()
 
-		now := time.Now().UnixMilli()
+		now := time.Now()
 		cloudConfig := &aikido_types.CloudConfigData{
-			ConfigUpdatedAt: now,
+			ConfigUpdatedAt: now.UnixMilli(),
 		}
 
 		UpdateServiceConfig(cloudConfig, nil)
 
 		updatedAt := GetCloudConfigUpdatedAt()
-		assert.Equal(t, now, updatedAt)
+		assert.WithinDuration(t, now, updatedAt, time.Second)
 	})
 
 	t.Run("returns zero time when not initialized", func(t *testing.T) {
 		resetServiceConfig()
 
 		updatedAt := GetCloudConfigUpdatedAt()
-		assert.Equal(t, int64(0), updatedAt)
+		assert.Zero(t, updatedAt)
 	})
 }
 

--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/utils"
+	"github.com/AikidoSec/firewall-go/internal/log"
+)
+
+var (
+	heartbeatRoutineChannel     = make(chan struct{})
+	heartbeatTicker             *time.Ticker
+	configPollingRoutineChannel = make(chan struct{})
+	configPollingTicker         *time.Ticker
+
+	minHeartbeatIntervalInMS = 120000
+)
+
+func startPolling() {
+	heartbeatTicker = time.NewTicker(10 * time.Minute)
+	configPollingTicker = time.NewTicker(1 * time.Minute)
+
+	utils.StartPollingRoutine(heartbeatRoutineChannel, heartbeatTicker, sendHeartbeatEvent)
+	utils.StartPollingRoutine(configPollingRoutineChannel, configPollingTicker, refreshCloudConfig)
+}
+
+func stopPolling() {
+	utils.StopPollingRoutine(heartbeatRoutineChannel)
+	utils.StopPollingRoutine(configPollingRoutineChannel)
+
+	if heartbeatTicker != nil {
+		heartbeatTicker.Stop()
+	}
+	if configPollingTicker != nil {
+		configPollingTicker.Stop()
+	}
+}
+
+func refreshCloudConfig() {
+	client := GetCloudClient()
+	if client == nil {
+		return
+	}
+
+	// Check if cloud config has been updated
+	lastUpdatedAt := client.FetchConfigUpdatedAt()
+
+	// If cloud config was updated before or at the same time, then just return 0 indicating no changes
+	if !lastUpdatedAt.After(config.GetCloudConfigUpdatedAt()) {
+		return
+	}
+
+	// Something has changed, so fetch the full cloud config
+	cloudConfig, err := client.FetchConfig()
+	if err != nil {
+		log.Warn("Error fetching cloud config", slog.Any("error", err))
+		return
+	}
+
+	updateCloudConfig(client, cloudConfig)
+}
+
+func sendHeartbeatEvent() {
+	client := GetCloudClient()
+	if client == nil {
+		return
+	}
+
+	cloudConfig, err := client.SendHeartbeatEvent(getAgentInfo(),
+		cloud.HeartbeatData{
+			Hostnames:           stateCollector.GetAndClearHostnames(),
+			Routes:              stateCollector.GetRoutesAndClear(),
+			Users:               GetUsersAndClear(),
+			MiddlewareInstalled: stateCollector.IsMiddlewareInstalled(),
+		})
+	if err != nil {
+		log.Warn("Error sending heartbeat event", slog.Any("error", err))
+		return
+	}
+
+	updateCloudConfig(client, cloudConfig)
+}
+
+// calculateHeartbeatInterval calculates the heartbeat interval based on config.
+// Returns 1 minute if no stats received, or the provided interval if it meets the minimum threshold.
+func calculateHeartbeatInterval(heartbeatIntervalInMS int, receivedAnyStats bool) time.Duration {
+	if !receivedAnyStats {
+		return 1 * time.Minute
+	} else if heartbeatIntervalInMS >= minHeartbeatIntervalInMS {
+		log.Info("Calculating heartbeat interval!", slog.Int("interval", heartbeatIntervalInMS))
+		return time.Duration(heartbeatIntervalInMS) * time.Millisecond
+	}
+	return 0
+}
+
+func resetHeartbeatTicker(newInterval time.Duration) {
+	if heartbeatTicker != nil && newInterval > 0 {
+		log.Info("Resetting HeartbeatTicker!", slog.String("interval", newInterval.String()))
+		heartbeatTicker.Reset(newInterval)
+	}
+}

--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -39,7 +39,8 @@ func stopPolling() {
 	}
 }
 
-// refreshCloudConfig checks if the local service config is stale and updates if necessary
+// refreshCloudConfig checks if config has changed before fetching the full config
+// to avoid unnecessary calls to the API
 func refreshCloudConfig() {
 	client := GetCloudClient()
 	if client == nil {
@@ -48,8 +49,6 @@ func refreshCloudConfig() {
 
 	// Check if cloud config has been updated
 	lastUpdatedAt := client.FetchConfigUpdatedAt()
-
-	// If cloud config was updated before or at the same time, then just return 0 indicating no changes
 	if !lastUpdatedAt.After(config.GetCloudConfigUpdatedAt()) {
 		return
 	}

--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -39,6 +39,7 @@ func stopPolling() {
 	}
 }
 
+// refreshCloudConfig checks if the local service config is stale and updates if necessary
 func refreshCloudConfig() {
 	client := GetCloudClient()
 	if client == nil {
@@ -60,7 +61,7 @@ func refreshCloudConfig() {
 		return
 	}
 
-	updateCloudConfig(client, cloudConfig)
+	applyCloudConfig(client, cloudConfig)
 }
 
 func sendHeartbeatEvent() {
@@ -81,7 +82,7 @@ func sendHeartbeatEvent() {
 		return
 	}
 
-	updateCloudConfig(client, cloudConfig)
+	applyCloudConfig(client, cloudConfig)
 }
 
 // calculateHeartbeatInterval calculates the heartbeat interval based on config.

--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -84,8 +84,9 @@ func sendHeartbeatEvent() {
 	applyCloudConfig(client, cloudConfig)
 }
 
-// calculateHeartbeatInterval calculates the heartbeat interval based on config.
-// Returns 1 minute if no stats received, or the provided interval if it meets the minimum threshold.
+// calculateHeartbeatInterval returns a faster polling interval (1 minute) for new agents
+// until they send their first stats, then switches to the cloud-configured interval
+// (minimum 2 minutes) to reduce unnecessary load.
 func calculateHeartbeatInterval(heartbeatIntervalInMS int, receivedAnyStats bool) time.Duration {
 	if !receivedAnyStats {
 		return 1 * time.Minute


### PR DESCRIPTION
Moving logic for when to update the config to the agent instead of within the cloud client.