### PR TITLE
Store user in the request context

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -105,6 +105,9 @@ func OnRequestShutdown(method string, route string, statusCode int, user string,
 	go ratelimiting.UpdateCounts(method, route, user, ip)
 }
 
+// OnUser records or updates user activity in the global user registry.
+// It updates the user's name, IP address, and last seen timestamp while
+// preserving the original first seen time. Safe for concurrent use.
 func OnUser(id string, username string, ip string) aikido_types.User {
 	log.Debug("Received user event", slog.String("id", id))
 	return storeUser(id, username, ip)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -105,9 +105,9 @@ func OnRequestShutdown(method string, route string, statusCode int, user string,
 	go ratelimiting.UpdateCounts(method, route, user, ip)
 }
 
-func OnUser(id string, username string, ip string) {
+func OnUser(id string, username string, ip string) aikido_types.User {
 	log.Debug("Received user event", slog.String("id", id))
-	storeUser(id, username, ip)
+	return storeUser(id, username, ip)
 }
 
 type DetectedAttack struct {

--- a/internal/agent/users.go
+++ b/internal/agent/users.go
@@ -13,14 +13,6 @@ var (
 )
 
 func storeUser(id string, username string, ip string) aikido_types.User {
-	users[id] = aikido_types.User{
-		ID:            id,
-		Name:          username,
-		LastIpAddress: ip,
-		FirstSeenAt:   utils.GetTime(),
-		LastSeenAt:    utils.GetTime(),
-	}
-
 	usersMutex.Lock()
 	defer usersMutex.Unlock()
 

--- a/internal/agent/users.go
+++ b/internal/agent/users.go
@@ -12,36 +12,7 @@ var (
 	usersMutex sync.Mutex
 )
 
-func GetUserByID(userID string) *aikido_types.User {
-	if userID == "" {
-		return nil
-	}
-
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
-
-	user, exists := users[userID]
-	if !exists {
-		return nil
-	}
-	return &user
-}
-
-func storeUser(id string, username string, ip string) {
-	usersMutex.Lock()
-	defer usersMutex.Unlock()
-
-	if _, exists := users[id]; exists {
-		users[id] = aikido_types.User{
-			ID:            id,
-			Name:          username,
-			LastIpAddress: ip,
-			FirstSeenAt:   users[id].FirstSeenAt,
-			LastSeenAt:    utils.GetTime(),
-		}
-		return
-	}
-
+func storeUser(id string, username string, ip string) aikido_types.User {
 	users[id] = aikido_types.User{
 		ID:            id,
 		Name:          username,
@@ -49,6 +20,26 @@ func storeUser(id string, username string, ip string) {
 		FirstSeenAt:   utils.GetTime(),
 		LastSeenAt:    utils.GetTime(),
 	}
+
+	usersMutex.Lock()
+	defer usersMutex.Unlock()
+
+	now := utils.GetTime()
+	firstSeen := now
+
+	if existing, exists := users[id]; exists {
+		firstSeen = existing.FirstSeenAt
+	}
+
+	user := aikido_types.User{
+		ID:            id,
+		Name:          username,
+		LastIpAddress: ip,
+		FirstSeenAt:   firstSeen,
+		LastSeenAt:    now,
+	}
+	users[id] = user
+	return user
 }
 
 func GetUsersAndClear() []aikido_types.User {

--- a/internal/http/on_post_request.go
+++ b/internal/http/on_post_request.go
@@ -35,6 +35,6 @@ func OnPostRequest(ctx context.Context, statusCode int) {
 	apiSpec := apidiscovery.GetAPIInfo(reqCtx)
 
 	go OnRequestShutdownReporting(
-		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUserID(), reqCtx.GetIP(), apiSpec,
+		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUser().ID, reqCtx.GetIP(), apiSpec,
 	)
 }

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -51,13 +51,6 @@ func (ctx *Context) GetUser() aikido_types.User {
 	return ctx.user
 }
 
-func (ctx *Context) GetUserID() string {
-	ctx.mu.RLock()
-	defer ctx.mu.RUnlock()
-
-	return ctx.user.ID
-}
-
 // MarkMiddlewareExecuted marks the middleware as executed.
 // Returns true if the middleware was not already executed, false otherwise.
 func (ctx *Context) MarkMiddlewareExecuted() bool {

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -3,6 +3,8 @@ package request
 import (
 	"sync"
 	"sync/atomic"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 )
 
 type DeferredBlock struct {
@@ -21,7 +23,7 @@ type Context struct {
 	Source             string
 	Route              string
 	executedMiddleware bool
-	user               *User
+	user               aikido_types.User
 
 	deferredAttack *DeferredAttack
 
@@ -35,21 +37,25 @@ func (ctx *Context) GetUserAgent() string {
 	return "unknown"
 }
 
-func (ctx *Context) SetUser(user *User) {
+func (ctx *Context) SetUser(user aikido_types.User) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 
 	ctx.user = user
 }
 
+func (ctx *Context) GetUser() aikido_types.User {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+
+	return ctx.user
+}
+
 func (ctx *Context) GetUserID() string {
 	ctx.mu.RLock()
 	defer ctx.mu.RUnlock()
 
-	if ctx.user != nil {
-		return ctx.user.ID
-	}
-	return "" // Empty ID
+	return ctx.user.ID
 }
 
 // MarkMiddlewareExecuted marks the middleware as executed.

--- a/internal/request/context_test.go
+++ b/internal/request/context_test.go
@@ -54,16 +54,16 @@ func TestContext_GetUserAgent(t *testing.T) {
 	}
 }
 
-func TestContext_SetUser_GetUserID(t *testing.T) {
+func TestContext_SetUser_GetUser(t *testing.T) {
 	ctx := &Context{}
 
 	// Test initial state
-	assert.Empty(t, ctx.GetUserID())
+	assert.Empty(t, ctx.GetUser().ID)
 
 	// Test setting user
 	user := aikido_types.User{ID: "user123", Name: "Test User"}
 	ctx.SetUser(user)
-	assert.Equal(t, "user123", ctx.GetUserID())
+	assert.Equal(t, aikido_types.User{ID: "user123", Name: "Test User"}, ctx.GetUser())
 }
 
 func TestContext_MarkMiddlewareExecuted(t *testing.T) {

--- a/internal/request/context_test.go
+++ b/internal/request/context_test.go
@@ -3,6 +3,7 @@ package request
 import (
 	"testing"
 
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,13 +61,9 @@ func TestContext_SetUser_GetUserID(t *testing.T) {
 	assert.Empty(t, ctx.GetUserID())
 
 	// Test setting user
-	user := &User{ID: "user123", Name: "Test User"}
+	user := aikido_types.User{ID: "user123", Name: "Test User"}
 	ctx.SetUser(user)
 	assert.Equal(t, "user123", ctx.GetUserID())
-
-	// Test setting nil user
-	ctx.SetUser(nil)
-	assert.Empty(t, ctx.GetUserID())
 }
 
 func TestContext_MarkMiddlewareExecuted(t *testing.T) {

--- a/internal/request/user.go
+++ b/internal/request/user.go
@@ -1,6 +1,0 @@
-package request
-
-type User struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-}

--- a/internal/vulnerabilities/attack.go
+++ b/internal/vulnerabilities/attack.go
@@ -57,6 +57,8 @@ func getAttackDetected(ctx context.Context, res InterceptorResult) *agent.Detect
 		return nil
 	}
 
+	user := reqCtx.GetUser()
+
 	return &agent.DetectedAttack{
 		Request: aikido_types.RequestInfo{
 			Method:    reqCtx.Method,
@@ -75,7 +77,7 @@ func getAttackDetected(ctx context.Context, res InterceptorResult) *agent.Detect
 			Path:      res.PathToPayload,
 			Payload:   res.Payload,
 			Metadata:  maps.Clone(res.Metadata),
-			User:      agent.GetUserByID(reqCtx.GetUserID()),
+			User:      &user,
 		},
 	}
 }

--- a/zen/set_user.go
+++ b/zen/set_user.go
@@ -25,8 +25,8 @@ func SetUser(ctx context.Context, id string, name string) context.Context {
 		return ctx
 	}
 
-	reqCtx.SetUser(&request.User{ID: id, Name: name})
-	go agent.OnUser(id, name, reqCtx.GetIP())
+	user := agent.OnUser(id, name, reqCtx.GetIP())
+	reqCtx.SetUser(user)
 
 	return ctx
 }

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -128,7 +128,11 @@ func TestSetUser(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("POST", "/api/users", nil)
 		req.Header.Set("Content-Type", "application/json")
-		ctx := request.SetContext(context.Background(), req, "/api/users", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &ip,
+		})
 
 		userID := "user-123"
 		userName := "John Doe"

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -121,6 +122,24 @@ func TestSetUser(t *testing.T) {
 		// User should not be set
 		userID := reqCtx.GetUserID()
 		assert.Empty(t, userID, "Expected user ID to be empty when middleware already executed")
+	})
+
+	t.Run("UserAvailableImmediatelyForAttackDetection", func(t *testing.T) {
+		ip := "127.0.0.1"
+		req := httptest.NewRequest("POST", "/api/users", nil)
+		req.Header.Set("Content-Type", "application/json")
+		ctx := request.SetContext(context.Background(), req, "/api/users", "test", &ip, nil)
+
+		userID := "user-123"
+		userName := "John Doe"
+
+		// This would normally be called in the service middleware
+		ctx = zen.SetUser(ctx, userID, userName)
+
+		// Verify the user is set on the context
+		reqCtx := request.GetContext(ctx)
+		require.NotNil(t, reqCtx, "Request context should exist")
+		assert.Equal(t, userID, reqCtx.GetUserID(), "User ID should be set on context")
 	})
 }
 

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -34,8 +34,9 @@ func TestSetUser(t *testing.T) {
 		reqCtx := request.GetContext(resultCtx)
 		require.NotNil(t, reqCtx, "Expected request context to exist")
 
-		userID := reqCtx.GetUserID()
-		assert.Equal(t, "user123", userID, "Expected user ID to be 'user123'")
+		user := reqCtx.GetUser()
+		assert.Equal(t, "user123", user.ID, "Expected user ID to be 'user123'")
+		assert.Equal(t, "John Doe", user.Name, "Expected name to be 'John Doe'")
 	})
 
 	t.Run("EmptyID", func(t *testing.T) {
@@ -57,7 +58,7 @@ func TestSetUser(t *testing.T) {
 		reqCtx := request.GetContext(resultCtx)
 		require.NotNil(t, reqCtx, "Expected request context to exist")
 
-		userID := reqCtx.GetUserID()
+		userID := reqCtx.GetUser().ID
 		assert.Empty(t, userID, "Expected user ID to be empty")
 	})
 
@@ -80,7 +81,7 @@ func TestSetUser(t *testing.T) {
 		reqCtx := request.GetContext(resultCtx)
 		require.NotNil(t, reqCtx, "Expected request context to exist")
 
-		userID := reqCtx.GetUserID()
+		userID := reqCtx.GetUser().ID
 		assert.Empty(t, userID, "Expected user ID to be empty")
 	})
 
@@ -120,7 +121,7 @@ func TestSetUser(t *testing.T) {
 		require.NotNil(t, resultCtx, "Expected context to be returned")
 
 		// User should not be set
-		userID := reqCtx.GetUserID()
+		userID := reqCtx.GetUser().ID
 		assert.Empty(t, userID, "Expected user ID to be empty when middleware already executed")
 	})
 
@@ -143,7 +144,7 @@ func TestSetUser(t *testing.T) {
 		// Verify the user is set on the context
 		reqCtx := request.GetContext(ctx)
 		require.NotNil(t, reqCtx, "Request context should exist")
-		assert.Equal(t, userID, reqCtx.GetUserID(), "User ID should be set on context")
+		assert.Equal(t, userID, reqCtx.GetUser().ID, "User ID should be set on context")
 	})
 }
 

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -18,9 +18,9 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 
 	agent.OnMiddlewareInstalled() // Report middleware as installed, handy for dashboard.
 	// user-blocking :
-	userID := reqCtx.GetUserID()
-	if config.IsUserBlocked(userID) {
-		log.Info("User is blocked!", slog.String("user", userID))
+	user := reqCtx.GetUser()
+	if config.IsUserBlocked(user.ID) {
+		log.Info("User is blocked!", slog.String("user", user.ID))
 		return &BlockResponse{"blocked", "user", nil}
 	}
 	// rate-limiting :
@@ -31,7 +31,7 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 	for _, endpoint := range matches {
 		if endpoint.RateLimiting.Enabled {
 			rateLimitingStatus := agent.GetRateLimitingStatus(
-				endpoint.Method, endpoint.Route, reqCtx.GetUserID(), reqCtx.GetIP(),
+				endpoint.Method, endpoint.Route, reqCtx.GetUser().ID, reqCtx.GetIP(),
 			)
 			if rateLimitingStatus != nil && rateLimitingStatus.Block {
 				log.Info("Request is rate-limited",


### PR DESCRIPTION
Here we are separating the request context user and the global user store. This fixes a number of race conditions, such as where a user isn't stored before the attack is detected, or a heartbeat clears out the users map in-between the request middleware and the attack. 