### PR TITLE
Don't attempt to parse empty request bodies

### DIFF
--- a/internal/http/body.go
+++ b/internal/http/body.go
@@ -19,6 +19,10 @@ type MultipartFormParser interface {
 
 // TryExtractBody attempts to extract body data from a request, trying JSON first, then forms
 func TryExtractBody(req *http.Request, parser MultipartFormParser) any {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil
+	}
+
 	bodyFromJSON := tryExtractJSON(req)
 	if bodyFromJSON != nil {
 		return bodyFromJSON
@@ -35,10 +39,6 @@ func TryExtractBody(req *http.Request, parser MultipartFormParser) any {
 
 // tryExtractFormBody attempts to extract form data (urlencoded or multipart)
 func tryExtractFormBody(req *http.Request, parser MultipartFormParser) url.Values {
-	if req.Body == nil {
-		return req.PostForm
-	}
-
 	// Use TeeReader to preserve the body while MultipartForm consumes it
 	var buf bytes.Buffer
 
@@ -59,6 +59,10 @@ func tryExtractFormBody(req *http.Request, parser MultipartFormParser) url.Value
 			log.Debug("error on parse multipart form", slog.Any("error", err))
 			return nil
 		}
+	}
+
+	if len(req.PostForm) == 0 {
+		return nil
 	}
 
 	return req.PostForm

--- a/internal/http/body_test.go
+++ b/internal/http/body_test.go
@@ -69,6 +69,28 @@ func TestTryExtractFormBody(t *testing.T) {
 	})
 }
 
+func TestTryExtractFormBody_EmptyData(t *testing.T) {
+	t.Run("nil body with populated PostForm returns PostForm", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		req.PostForm = url.Values{"username": []string{"alice"}}
+
+		parser := &mockParser{req: req}
+		result := tryExtractFormBody(req, parser)
+
+		assert.NotNil(t, result)
+		assert.Equal(t, "alice", result.Get("username"))
+	})
+
+	t.Run("nil body with nil PostForm returns nil", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+
+		parser := &mockParser{req: req}
+		result := tryExtractFormBody(req, parser)
+
+		assert.Nil(t, result)
+	})
+}
+
 func TestTryExtractBody(t *testing.T) {
 	t.Run("extracts JSON", func(t *testing.T) {
 		jsonBody := `{"username":"alice"}`
@@ -100,6 +122,15 @@ func TestTryExtractBody(t *testing.T) {
 	t.Run("returns nil when both fail", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader("some data"))
 		req.Header.Set("Content-Type", "multipart/form-data") // Missing boundary
+
+		parser := &mockParser{req: req}
+		result := TryExtractBody(req, parser)
+
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil when no body", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
 
 		parser := &mockParser{req: req}
 		result := TryExtractBody(req, parser)


### PR DESCRIPTION
Noticed that we were attempting to parse empty bodies, but also returning an empty `url.Values`.