### PR TITLE
Pass context data as struct instead of arguments

### DIFF
--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -42,7 +42,11 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)
@@ -105,7 +109,11 @@ func TestQueryShouldReportAttackOnlyOnce(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)
@@ -188,7 +196,11 @@ func TestExecContextShouldReturnError(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)

--- a/instrumentation/sinks/os/exec/integration_test.go
+++ b/instrumentation/sinks/os/exec/integration_test.go
@@ -27,7 +27,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		// Simple test to verify each exec method is instrumented
 		req := httptest.NewRequest("GET", "/route?cmd=ls%20.", nil)
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, "/route?cmd=ls%20.", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/route",
+			RemoteAddress: &ip,
+		})
 
 		t.Run("Run", func(t *testing.T) {
 			request.WrapWithGLS(ctx, func() {
@@ -122,7 +126,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				req := httptest.NewRequest("GET", "/route?"+tc.queryParam, nil)
 				ip := "127.0.0.1"
-				ctx := request.SetContext(context.Background(), req, "/route?"+tc.queryParam, "test", &ip, nil)
+				ctx := request.SetContext(context.Background(), req, request.ContextData{
+					Source:        "test",
+					Route:         "/route",
+					RemoteAddress: &ip,
+				})
 
 				request.WrapWithGLS(ctx, func() {
 					cmd := exec.Command(tc.command[0], tc.command[1:]...)
@@ -141,7 +149,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("shell injection via positional parameters", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?target=8.8.8.8%3Bcat%20/etc/passwd", nil)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, "/route?target=8.8.8.8%3Bcat%20/etc/passwd", "test", &ip, nil)
+			ctx := request.SetContext(context.Background(), req, request.ContextData{
+				Source:        "test",
+				Route:         "/route",
+				RemoteAddress: &ip,
+			})
 
 			request.WrapWithGLS(ctx, func() {
 				// This is vulnerable because the command uses $0 which references the next argument
@@ -157,7 +169,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("multiple positional parameters with injection", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?arg1=safe&arg2=malicious%3Brm%20-rf%20/", nil)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, "/route?arg1=safe&arg2=malicious%3Brm%20-rf%20/", "test", &ip, nil)
+			ctx := request.SetContext(context.Background(), req, request.ContextData{
+				Source:        "test",
+				Route:         "/route",
+				RemoteAddress: &ip,
+			})
 
 			request.WrapWithGLS(ctx, func() {
 				// Command references multiple positional parameters
@@ -174,7 +190,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("safe positional parameter not referenced", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?unused=malicious%3Brm%20-rf%20/", nil)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, "/route?unused=malicious%3Brm%20-rf%20/", "test", &ip, nil)
+			ctx := request.SetContext(context.Background(), req, request.ContextData{
+				Source:        "test",
+				Route:         "/route",
+				RemoteAddress: &ip,
+			})
 
 			request.WrapWithGLS(ctx, func() {
 				// Even though userInput is malicious, it's never used by the command

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -73,7 +73,11 @@ func TestOpenFileIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		_, err := os.OpenFile("/tmp/"+"../test.txt", os.O_RDONLY, 0o600)
@@ -133,7 +137,11 @@ func TestOpenFileIsNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		_, err := os.OpenFile("/tmp/"+"../test.txt", os.O_RDONLY, 0o600)

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -86,7 +86,11 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")
@@ -145,7 +149,11 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")
@@ -203,7 +211,11 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		// Call filepath.Join but don't call os.OpenFile
@@ -240,7 +252,11 @@ func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -16,8 +16,12 @@ func GetMiddleware() gin.HandlerFunc {
 
 		ip := c.ClientIP()
 
-		reqCtx := request.SetContext(c.Request.Context(), c.Request, c.FullPath(), "gin", &ip,
-			http.TryExtractBody(c.Request, c))
+		reqCtx := request.SetContext(c.Request.Context(), c.Request, request.ContextData{
+			Source:        "gin",
+			Route:         c.FullPath(),
+			RemoteAddress: &ip,
+			Body:          http.TryExtractBody(c.Request, c),
+		})
 		c.Request = c.Request.WithContext(reqCtx)
 
 		// Write a response using Gin :

--- a/instrumentation/sources/labstack/echo/middleware.go
+++ b/instrumentation/sources/labstack/echo/middleware.go
@@ -19,8 +19,12 @@ func GetMiddleware() echo.MiddlewareFunc {
 			}
 
 			ip := c.RealIP()
-			reqCtx := request.SetContext(httpRequest.Context(), httpRequest, c.Path(), "echo", &ip,
-				http.TryExtractBody(httpRequest, c))
+			reqCtx := request.SetContext(httpRequest.Context(), httpRequest, request.ContextData{
+				Source:        "echo",
+				Route:         c.Path(),
+				RemoteAddress: &ip,
+				Body:          http.TryExtractBody(httpRequest, c),
+			})
 			c.SetRequest(httpRequest.WithContext(reqCtx))
 
 			// Write a possible response (i.e. geo-blocking bot blocking)

--- a/internal/http/on_init_request_test.go
+++ b/internal/http/on_init_request_test.go
@@ -38,7 +38,11 @@ func TestOnInitRequest(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/route", nil)
 		req.RemoteAddr = "127.0.0.1:1234"
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/route",
+			RemoteAddress: &ip,
+		})
 
 		resp := OnInitRequest(ctx)
 
@@ -53,7 +57,11 @@ func TestOnInitRequest(t *testing.T) {
 		req.Header.Set("User-Agent", "bot-test")
 		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/route",
+			RemoteAddress: &ip,
+		})
 
 		resp := OnInitRequest(ctx)
 
@@ -66,7 +74,11 @@ func TestOnInitRequest(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/admin", nil)
 		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, "/admin", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/admin",
+			RemoteAddress: &ip,
+		})
 
 		resp := OnInitRequest(ctx)
 
@@ -79,7 +91,11 @@ func TestOnInitRequest(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/admin", nil)
 		req.RemoteAddr = "192.168.0.1:4321"
 		ip := "192.168.0.1"
-		ctx := request.SetContext(context.Background(), req, "/admin", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/admin",
+			RemoteAddress: &ip,
+		})
 
 		resp := OnInitRequest(ctx)
 
@@ -96,7 +112,11 @@ func TestOnInitRequest(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/route", nil)
 		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, "/route", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/route",
+			RemoteAddress: &ip,
+		})
 
 		resp := OnInitRequest(ctx)
 

--- a/internal/request/gls_test.go
+++ b/internal/request/gls_test.go
@@ -24,7 +24,11 @@ func TestWrapWithGLS(t *testing.T) {
 				req.RemoteAddr = "192.168.1.1:8080"
 
 				ctx := context.Background()
-				return SetContext(ctx, req, "/test", "test-source", &req.RemoteAddr, nil)
+				return SetContext(ctx, req, ContextData{
+					Source:        "test-source",
+					Route:         "/test",
+					RemoteAddress: &req.RemoteAddr,
+				})
 			},
 			wantNil: false,
 		},
@@ -92,7 +96,11 @@ func TestWrapWithGLS_ConcurrentAccess(t *testing.T) {
 		go func(id int) {
 			req, _ := http.NewRequest("GET", fmt.Sprintf("https://example.com/req%d", id), nil)
 			req.RemoteAddr = fmt.Sprintf("192.168.1.%d:8080", id)
-			ctx := SetContext(context.Background(), req, fmt.Sprintf("/req%d", id), fmt.Sprintf("source%d", id), &req.RemoteAddr, nil)
+			ctx := SetContext(context.Background(), req, ContextData{
+				Source:        fmt.Sprintf("source%d", id),
+				Route:         fmt.Sprintf("/req%d", id),
+				RemoteAddress: &req.RemoteAddr,
+			})
 
 			WrapWithGLS(ctx, func() {
 				// Block here until we're told to proceed

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -11,7 +11,15 @@ type contextKey struct{}
 
 var reqCtxKey contextKey
 
-func SetContext(ctx context.Context, r *http.Request, route string, source string, remoteAddress *string, body any) context.Context {
+type ContextData struct {
+	Source        string
+	Route         string
+	RemoteAddress *string
+	Body          any
+}
+
+func SetContext(ctx context.Context, r *http.Request, data ContextData) context.Context {
+	route := data.Route
 	if len(route) == 0 {
 		route = r.URL.Path // Use path from URL as default.
 	}
@@ -22,10 +30,10 @@ func SetContext(ctx context.Context, r *http.Request, route string, source strin
 		Query:              r.URL.Query(),
 		Headers:            headersToMap(r.Header),
 		RouteParams:        nil,
-		RemoteAddress:      remoteAddress,
-		Body:               body,
+		RemoteAddress:      data.RemoteAddress,
+		Body:               data.Body,
 		Cookies:            cookiesToMap(r.Cookies()),
-		Source:             source,
+		Source:             data.Source,
 		Route:              route,
 		executedMiddleware: false, // We start with no middleware executed.
 	}

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -63,7 +63,12 @@ func TestSetContext(t *testing.T) {
 
 			// Set context
 			ctx := context.Background()
-			resultCtx := SetContext(ctx, req, tt.route, tt.source, tt.remoteAddress, tt.body)
+			resultCtx := SetContext(ctx, req, ContextData{
+				Source:        tt.source,
+				Route:         tt.route,
+				RemoteAddress: tt.remoteAddress,
+				Body:          tt.body,
+			})
 
 			// Get context back
 			reqCtx := GetContext(resultCtx)

--- a/internal/vulnerabilities/attack_test.go
+++ b/internal/vulnerabilities/attack_test.go
@@ -95,7 +95,12 @@ func TestGetAttackDetected(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/users", nil)
 	req.Header.Set("Content-Type", "application/json")
 
-	ctx := request.SetContext(context.Background(), req, "/api/users", "test", &ip, map[string]interface{}{"name": "test"})
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/api/users",
+		RemoteAddress: &ip,
+		Body:          map[string]interface{}{"name": "test"},
+	})
 
 	result := InterceptorResult{
 		Kind:          KindSQLInjection,
@@ -155,7 +160,11 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("stores attack and error in context", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", nil)
-		ctx := request.SetContext(context.Background(), req, "/test", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &ip,
+		})
 
 		result := &InterceptorResult{
 			Kind:          KindPathTraversal,
@@ -188,7 +197,11 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("does not store error when blocking is disabled", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", nil)
-		ctx := request.SetContext(context.Background(), req, "/test", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &ip,
+		})
 
 		result := &InterceptorResult{
 			Kind:          KindPathTraversal,
@@ -253,7 +266,11 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", nil)
-		ctx := request.SetContext(context.Background(), req, "/test", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &ip,
+		})
 
 		reportDeferredAttack(ctx)
 
@@ -280,7 +297,11 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", nil)
-		ctx := request.SetContext(context.Background(), req, "/test", "test", &ip, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &ip,
+		})
 
 		result := &InterceptorResult{
 			Kind:          KindPathTraversal,

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -16,10 +16,13 @@ import (
 func TestSetUser(t *testing.T) {
 	t.Run("ValidInput", func(t *testing.T) {
 		// Setup
-		ctx := context.Background()
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx = request.SetContext(ctx, req, "/test", "test", &remoteAddr, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &remoteAddr,
+		})
 
 		// Execute
 		resultCtx := zen.SetUser(ctx, "user123", "John Doe")
@@ -36,10 +39,13 @@ func TestSetUser(t *testing.T) {
 
 	t.Run("EmptyID", func(t *testing.T) {
 		// Setup
-		ctx := context.Background()
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx = request.SetContext(ctx, req, "/test", "test", &remoteAddr, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &remoteAddr,
+		})
 
 		// Execute
 		resultCtx := zen.SetUser(ctx, "", "John Doe")
@@ -56,10 +62,13 @@ func TestSetUser(t *testing.T) {
 
 	t.Run("EmptyName", func(t *testing.T) {
 		// Setup
-		ctx := context.Background()
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx = request.SetContext(ctx, req, "/test", "test", &remoteAddr, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &remoteAddr,
+		})
 
 		// Execute
 		resultCtx := zen.SetUser(ctx, "user123", "")
@@ -90,10 +99,13 @@ func TestSetUser(t *testing.T) {
 
 	t.Run("MiddlewareAlreadyExecuted", func(t *testing.T) {
 		// Setup
-		ctx := context.Background()
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx = request.SetContext(ctx, req, "/test", "test", &remoteAddr, nil)
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "test",
+			Route:         "/test",
+			RemoteAddress: &remoteAddr,
+		})
 
 		// Mark middleware as executed
 		reqCtx := request.GetContext(ctx)

--- a/zen/should_block_request_test.go
+++ b/zen/should_block_request_test.go
@@ -26,7 +26,11 @@ func TestShouldBlockRequest(t *testing.T) {
 func TestShouldBlockRequest_BlockedUser(t *testing.T) {
 	req := httptest.NewRequest("GET", "/route", nil)
 	ip := "127.0.0.1"
-	reqCtx := request.SetContext(context.Background(), req, "/route", "/test", &ip, nil)
+	reqCtx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
 
 	zen.SetUser(reqCtx, "banned", "Banned User")
 
@@ -52,7 +56,11 @@ func ExampleShouldBlockRequest() {
 			// Set up proper request context
 			ctx := context.Background()
 			remoteAddr := "127.0.0.1"
-			ctx = request.SetContext(ctx, r, "/test", "GET", &remoteAddr, nil)
+			ctx = request.SetContext(ctx, r, request.ContextData{
+				Source:        "test",
+				Route:         "/test",
+				RemoteAddress: &remoteAddr,
+			})
 
 			// Set user in context
 			ctx = zen.SetUser(ctx, "user123", "John Doe")


### PR DESCRIPTION
Need to add more to the context and this makes it easier to adjust the context instead of having lots of function parameters.