### PR TITLE
Remove the remaining DB panics and test all methods

### DIFF
--- a/instrumentation/sinks/database/sql/fake_driver_test.go
+++ b/instrumentation/sinks/database/sql/fake_driver_test.go
@@ -3,6 +3,7 @@ package sql_test
 import (
 	"database/sql"
 	"database/sql/driver"
+	"io"
 )
 
 func init() {
@@ -18,18 +19,90 @@ func (d *testDriver) Open(name string) (driver.Conn, error) {
 type testConn struct{}
 
 func (c *testConn) Prepare(query string) (driver.Stmt, error) {
-	return &testStmt{}, nil
+	return &testStmt{query: query}, nil
 }
 
-func (c *testConn) Close() error { return nil }
+func (c *testConn) Close() error {
+	return nil
+}
 
 func (c *testConn) Begin() (driver.Tx, error) {
-	return nil, driver.ErrSkip // Not implementing transactions
+	return &testTx{}, nil
 }
 
-type testStmt struct{}
+type testTx struct{}
 
-func (s *testStmt) Close() error                                    { return nil }
-func (s *testStmt) NumInput() int                                   { return -1 }
-func (s *testStmt) Exec(args []driver.Value) (driver.Result, error) { return nil, nil }
-func (s *testStmt) Query(args []driver.Value) (driver.Rows, error)  { return nil, nil }
+func (t *testTx) Commit() error {
+	return nil
+}
+
+func (t *testTx) Rollback() error {
+	return nil
+}
+
+type testStmt struct {
+	query string
+}
+
+func (s *testStmt) Close() error {
+	return nil
+}
+
+func (s *testStmt) NumInput() int {
+	return -1 // Variable number of inputs
+}
+
+func (s *testStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return &testResult{}, nil
+}
+
+func (s *testStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &testRows{}, nil
+}
+
+type testResult struct{}
+
+func (r *testResult) LastInsertId() (int64, error) {
+	return 1, nil
+}
+
+func (r *testResult) RowsAffected() (int64, error) {
+	return 1, nil
+}
+
+// testRows implements driver.Rows
+type testRows struct {
+	closed    bool
+	nextCount int
+}
+
+func (r *testRows) Columns() []string {
+	return []string{"id", "name", "email"}
+}
+
+func (r *testRows) Close() error {
+	r.closed = true
+	return nil
+}
+
+// Next is called to populate the next row of data into the provided slice.
+// Returns io.EOF when there are no more rows.
+func (r *testRows) Next(dest []driver.Value) error {
+	if r.closed {
+		return io.EOF
+	}
+
+	// Return one row, then EOF
+	if r.nextCount > 0 {
+		return io.EOF
+	}
+
+	r.nextCount++
+
+	// Populate with dummy data
+	dest[0] = int64(1)
+	dest[1] = "test_user"
+	dest[2] = "test@example.com"
+
+	return nil
+}

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -21,12 +21,518 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func setupTestWithBlocking(t *testing.T) (*mockCloudClient, context.Context, *sql.DB, func()) {
+	t.Helper()
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}, 10),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	db, err := sql.Open("test", "")
+	require.NoError(t, err)
+
+	cleanup := func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	}
+
+	return client, ctx, db, cleanup
+}
+
+func setupTestWithoutBlocking(t *testing.T) (*mockCloudClient, context.Context, *sql.DB, func()) {
+	t.Helper()
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}, 10),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	db, err := sql.Open("test", "")
+	require.NoError(t, err)
+
+	cleanup := func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	}
+
+	return client, ctx, db, cleanup
+}
+
+func assertAttackBlocked(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+
+	var detectedErr *vulnerabilities.AttackDetectedError
+	require.ErrorAs(t, err, &detectedErr)
+
+	var attackBlockedErr *zen.AttackBlockedError
+	require.ErrorAs(t, err, &attackBlockedErr)
+	require.Equal(t, zen.KindSQLInjection, attackBlockedErr.Kind)
+}
+
+func waitForAttackEvent(t *testing.T, client *mockCloudClient) {
+	t.Helper()
+
+	// Wait for event
+	select {
+	case <-client.attackDetectedEventSent:
+		// Success - verify basic attack details
+		assert.Equal(t, "sql_injection", client.capturedAttack.Kind)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func waitForAttackEventAndVerifyOnlyOnce(t *testing.T, client *mockCloudClient) {
+	t.Helper()
+
+	// Wait for first event
+	select {
+	case <-client.attackDetectedEventSent:
+		// Success - verify basic attack details
+		assert.Equal(t, "sql_injection", client.capturedAttack.Kind)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+
+	// Verify no duplicate event arrives
+	select {
+	case <-client.attackDetectedEventSent:
+		t.Fatal("attack was reported more than once")
+	case <-time.After(100 * time.Millisecond):
+		// Success! No duplicate
+	}
+}
+
+type dbTestCase struct {
+	name      string
+	operation string
+	testFunc  func(t *testing.T, ctx context.Context, db *sql.DB)
+}
+
+func TestDBMethodsReturnErrors(t *testing.T) {
+	testCases := []dbTestCase{
+		{
+			name:      "Query",
+			operation: "db.Query",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				result, err := db.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryContext",
+			operation: "db.QueryContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				result, err := db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryRow",
+			operation: "db.QueryRow",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				row := db.QueryRow("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.NotNil(t, row)
+				var id int
+				err := row.Scan(&id)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryRowContext",
+			operation: "db.QueryRowContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				row := db.QueryRowContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.NotNil(t, row)
+				var id int
+				err := row.Scan(&id)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "Exec",
+			operation: "db.Exec",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				result, err := db.Exec("DELETE FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "ExecContext",
+			operation: "db.ExecContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				result, err := db.ExecContext(ctx, "DELETE FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "Prepare",
+			operation: "db.Prepare",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				stmt, err := db.Prepare("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, stmt)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "PrepareContext",
+			operation: "db.PrepareContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				stmt, err := db.PrepareContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, stmt)
+				assertAttackBlocked(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, ctx, db, cleanup := setupTestWithBlocking(t)
+			defer cleanup()
+
+			request.WrapWithGLS(ctx, func() {
+				tc.testFunc(t, ctx, db)
+			})
+
+			waitForAttackEvent(t, client)
+		})
+	}
+}
+
+func TestDBMethodsReportOnlyOnce(t *testing.T) {
+	testCases := []dbTestCase{
+		{
+			name:      "Query",
+			operation: "db.Query",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "QueryContext",
+			operation: "db.QueryContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "QueryRow",
+			operation: "db.QueryRow",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				row := db.QueryRow("SELECT * FROM users WHERE id = '1' OR 1=1")
+				var id int
+				_ = row.Scan(&id)
+			},
+		},
+		{
+			name:      "QueryRowContext",
+			operation: "db.QueryRowContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				row := db.QueryRowContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				var id int
+				_ = row.Scan(&id)
+			},
+		},
+		{
+			name:      "Exec",
+			operation: "db.Exec",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.Exec("DELETE FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "ExecContext",
+			operation: "db.ExecContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.ExecContext(ctx, "DELETE FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "Prepare",
+			operation: "db.Prepare",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.Prepare("SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "PrepareContext",
+			operation: "db.PrepareContext",
+			testFunc: func(t *testing.T, ctx context.Context, db *sql.DB) {
+				t.Helper()
+				_, _ = db.PrepareContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, ctx, db, cleanup := setupTestWithoutBlocking(t)
+			defer cleanup()
+
+			request.WrapWithGLS(ctx, func() {
+				tc.testFunc(t, ctx, db)
+			})
+
+			waitForAttackEventAndVerifyOnlyOnce(t, client)
+		})
+	}
+}
+
+type txTestCase struct {
+	name      string
+	operation string
+	testFunc  func(t *testing.T, ctx context.Context, tx *sql.Tx)
+}
+
+func TestTxMethodsReturnErrors(t *testing.T) {
+	testCases := []txTestCase{
+		{
+			name:      "Query",
+			operation: "tx.Query",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				result, err := tx.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryContext",
+			operation: "tx.QueryContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				result, err := tx.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryRow",
+			operation: "tx.QueryRow",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				row := tx.QueryRow("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.NotNil(t, row)
+				var id int
+				err := row.Scan(&id)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "QueryRowContext",
+			operation: "tx.QueryRowContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				row := tx.QueryRowContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.NotNil(t, row)
+				var id int
+				err := row.Scan(&id)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "Exec",
+			operation: "tx.Exec",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				result, err := tx.Exec("DELETE FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "ExecContext",
+			operation: "tx.ExecContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				result, err := tx.ExecContext(ctx, "DELETE FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, result)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "Prepare",
+			operation: "tx.Prepare",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				stmt, err := tx.Prepare("SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, stmt)
+				assertAttackBlocked(t, err)
+			},
+		},
+		{
+			name:      "PrepareContext",
+			operation: "tx.PrepareContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				stmt, err := tx.PrepareContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				require.Nil(t, stmt)
+				assertAttackBlocked(t, err)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, ctx, db, cleanup := setupTestWithBlocking(t)
+			defer cleanup()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			defer tx.Rollback()
+
+			request.WrapWithGLS(ctx, func() {
+				tc.testFunc(t, ctx, tx)
+			})
+
+			waitForAttackEvent(t, client)
+		})
+	}
+}
+
+func TestTxMethodsReportOnlyOnce(t *testing.T) {
+	testCases := []txTestCase{
+		{
+			name:      "Query",
+			operation: "tx.Query",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "QueryContext",
+			operation: "tx.QueryContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "QueryRow",
+			operation: "tx.QueryRow",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				row := tx.QueryRow("SELECT * FROM users WHERE id = '1' OR 1=1")
+				var id int
+				_ = row.Scan(&id)
+			},
+		},
+		{
+			name:      "QueryRowContext",
+			operation: "tx.QueryRowContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				row := tx.QueryRowContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+				var id int
+				_ = row.Scan(&id)
+			},
+		},
+		{
+			name:      "Exec",
+			operation: "tx.Exec",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.Exec("DELETE FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "ExecContext",
+			operation: "tx.ExecContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.ExecContext(ctx, "DELETE FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "Prepare",
+			operation: "tx.Prepare",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.Prepare("SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+		{
+			name:      "PrepareContext",
+			operation: "tx.PrepareContext",
+			testFunc: func(t *testing.T, ctx context.Context, tx *sql.Tx) {
+				t.Helper()
+				_, _ = tx.PrepareContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, ctx, db, cleanup := setupTestWithoutBlocking(t)
+			defer cleanup()
+
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			defer tx.Rollback()
+
+			request.WrapWithGLS(ctx, func() {
+				tc.testFunc(t, ctx, tx)
+			})
+
+			waitForAttackEventAndVerifyOnlyOnce(t, client)
+		})
+	}
+}
+
 func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 	require.NoError(t, zen.Protect())
 
 	originalClient := agent.GetCloudClient()
 
-	// Enable blocking so that Zen should cause QueryContext to panic
+	// Enable blocking so that Zen should cause QueryContext to return an error
 	original := config.IsBlockingEnabled()
 	config.SetBlocking(true)
 
@@ -52,9 +558,16 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 	require.NoError(t, err)
 
 	request.WrapWithGLS(ctx, func() {
-		require.Panics(t, func() {
-			_, _ = db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
-		})
+		result, err := db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+		require.Nil(t, result)
+		require.Error(t, err)
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+
+		var attackBlockedErr *zen.AttackBlockedError
+		require.ErrorAs(t, err, &attackBlockedErr)
+		require.Equal(t, zen.KindSQLInjection, attackBlockedErr.Kind)
 	})
 
 	select {
@@ -83,60 +596,6 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for attack event")
-	}
-}
-
-func TestQueryShouldReportAttackOnlyOnce(t *testing.T) {
-	require.NoError(t, zen.Protect())
-
-	originalClient := agent.GetCloudClient()
-
-	// Disabling blocking so that we would see attack being detected twice.
-	// Through both Query and QueryContext
-	original := config.IsBlockingEnabled()
-	config.SetBlocking(false)
-
-	t.Cleanup(func() {
-		config.SetBlocking(original)
-		agent.SetCloudClient(originalClient)
-	})
-
-	client := &mockCloudClient{
-		attackDetectedEventSent: make(chan struct{}),
-	}
-
-	agent.SetCloudClient(client)
-
-	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
-	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-	})
-
-	db, err := sql.Open("test", "")
-	require.NoError(t, err)
-
-	request.WrapWithGLS(ctx, func() {
-		require.NotPanics(t, func() {
-			_, _ = db.Query("SELECT * FROM users WHERE id = '1' OR 1=1")
-		})
-	})
-
-	// Wait for first event
-	select {
-	case <-client.attackDetectedEventSent:
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for first attack event")
-	}
-
-	// Check that no second event arrives
-	select {
-	case <-client.attackDetectedEventSent:
-		t.Fatal("attack was reported more than once")
-	case <-time.After(100 * time.Millisecond):
-		// Success! No duplicate
 	}
 }
 
@@ -173,48 +632,4 @@ func (m *mockCloudClient) SendAttackDetectedEvent(agentInfo cloud.AgentInfo, req
 	m.mu.Unlock()
 
 	m.attackDetectedEventSent <- struct{}{}
-}
-
-func TestExecContextShouldReturnError(t *testing.T) {
-	require.NoError(t, zen.Protect())
-
-	originalClient := agent.GetCloudClient()
-
-	// Enable blocking so that Zen should cause ExecContext to return an error
-	original := config.IsBlockingEnabled()
-	config.SetBlocking(true)
-
-	t.Cleanup(func() {
-		config.SetBlocking(original)
-		agent.SetCloudClient(originalClient)
-	})
-
-	client := &mockCloudClient{
-		attackDetectedEventSent: make(chan struct{}),
-	}
-	agent.SetCloudClient(client)
-
-	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", nil)
-	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-	})
-
-	db, err := sql.Open("test", "")
-	require.NoError(t, err)
-
-	request.WrapWithGLS(ctx, func() {
-		result, err := db.ExecContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
-		require.Nil(t, result)
-		require.Error(t, err)
-
-		var detectedErr *vulnerabilities.AttackDetectedError
-		require.ErrorAs(t, err, &detectedErr)
-
-		var attackBlockedErr *zen.AttackBlockedError
-		require.ErrorAs(t, err, &attackBlockedErr)
-		require.Equal(t, zen.KindSQLInjection, attackBlockedErr.Kind)
-	})
 }

--- a/instrumentation/sinks/database/sql/orchestrion.yml
+++ b/instrumentation/sinks/database/sql/orchestrion.yml
@@ -17,26 +17,9 @@ aspects:
           imports:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.QueryContext")
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.Query(Row)Context")
             if _aikido_block != nil {
               return nil, _aikido_block
-            }
-
-  # DB.QueryRowContext returns *Row (no error) - return Row with error
-  - id: database/sql.DB.QueryRowContext
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.DB"
-          - name: QueryRowContext
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.QueryRowContext")
-            if _aikido_block != nil {
-              return &Row{err: _aikido_block}
             }
 
   # DB.ExecContext returns (Result, error) - should return error
@@ -85,26 +68,9 @@ aspects:
           imports:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.QueryContext")
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.Query(Row)Context")
             if _aikido_block != nil {
               return nil, _aikido_block
-            }
-
-  # Tx.QueryRowContext returns *Row (no error) - return Row with error
-  - id: database/sql.Tx.QueryRowContext
-    join-point:
-      function-body:
-        function:
-          - receiver: "*database/sql.Tx"
-          - name: QueryRowContext
-    advice:
-      - prepend-statements:
-          imports:
-            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
-          template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.QueryRowContext")
-            if _aikido_block != nil {
-              return &Row{err: _aikido_block}
             }
 
   # Tx.ExecContext returns (Result, error) - should return error

--- a/instrumentation/sinks/database/sql/orchestrion.yml
+++ b/instrumentation/sinks/database/sql/orchestrion.yml
@@ -5,26 +5,41 @@ meta:
     Protection from SQL Injection.
 
 aspects:
+  # DB.QueryContext returns (*Rows, error) - should return error
   - id: database/sql.DB.QueryContext
     join-point:
-      one-of:
-        - function-body:
-            function:
-              - receiver: "*database/sql.DB"
-              - name: QueryContext
-        - function-body:
-            function:
-              - receiver: "*database/sql.DB"
-              - name: QueryRowContext
+      function-body:
+        function:
+          - receiver: "*database/sql.DB"
+          - name: QueryContext
     advice:
       - prepend-statements:
           imports:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.Query(Row)Context")
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.QueryContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block
             }
+
+  # DB.QueryRowContext returns *Row (no error) - return Row with error
+  - id: database/sql.DB.QueryRowContext
+    join-point:
+      function-body:
+        function:
+          - receiver: "*database/sql.DB"
+          - name: QueryRowContext
+    advice:
+      - prepend-statements:
+          imports:
+            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
+          template: |-
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.QueryRowContext")
+            if _aikido_block != nil {
+              return &Row{err: _aikido_block}
+            }
+
+  # DB.ExecContext returns (Result, error) - should return error
   - id: database/sql.DB.ExecContext
     join-point:
       function-body:
@@ -40,6 +55,8 @@ aspects:
             if _aikido_block != nil {
               return nil, _aikido_block 
             }
+
+  # DB.PrepareContext returns (*Stmt, error) - should return error
   - id: database/sql.DB.PrepareContext
     join-point:
       function-body:
@@ -53,28 +70,44 @@ aspects:
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.DB.PrepareContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block
             }
+
+  # Tx.QueryContext returns (*Rows, error) - should return error
   - id: database/sql.Tx.QueryContext
     join-point:
-      one-of:
-        - function-body:
-            function:
-              - receiver: "*database/sql.Tx"
-              - name: QueryContext
-        - function-body:
-            function:
-              - receiver: "*database/sql.Tx"
-              - name: QueryRowContext
+      function-body:
+        function:
+          - receiver: "*database/sql.Tx"
+          - name: QueryContext
     advice:
       - prepend-statements:
           imports:
             sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
           template: |-
-            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.Query(Row)Context")
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.QueryContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block
             }
+
+  # Tx.QueryRowContext returns *Row (no error) - return Row with error
+  - id: database/sql.Tx.QueryRowContext
+    join-point:
+      function-body:
+        function:
+          - receiver: "*database/sql.Tx"
+          - name: QueryRowContext
+    advice:
+      - prepend-statements:
+          imports:
+            sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
+          template: |-
+            _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.QueryRowContext")
+            if _aikido_block != nil {
+              return &Row{err: _aikido_block}
+            }
+
+  # Tx.ExecContext returns (Result, error) - should return error
   - id: database/sql.Tx.ExecContext
     join-point:
       function-body:
@@ -88,8 +121,10 @@ aspects:
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.ExecContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block
             }
+
+  # Tx.PrepareContext returns (*Stmt, error) - should return error
   - id: database/sql.Tx.PrepareContext
     join-point:
       function-body:
@@ -103,5 +138,5 @@ aspects:
           template: |-
             _aikido_block := sink.ExamineContext({{ .Function.Argument 0}}, {{ .Function.Argument 1}}, "database/sql.Tx.PrepareContext")
             if _aikido_block != nil {
-              panic(_aikido_block)
+              return nil, _aikido_block
             }


### PR DESCRIPTION
- Blocked DB calls now return errors instead of panics.
- Removed unnecessarily instrumented methods.
  - For example, `QueryRowContext` calls `QueryContext` which would lead to attacks being reported twice.
- Added tests for each of the methods including ensuring attacks are only reported once.