### PR TITLE
Add support for wildcards in rate limiting

### DIFF
--- a/internal/agent/endpoints/match.go
+++ b/internal/agent/endpoints/match.go
@@ -1,4 +1,4 @@
-package config
+package endpoints
 
 import (
 	"regexp"
@@ -15,10 +15,9 @@ type RouteMetadata struct {
 	Route  string
 }
 
-// MatchEndpoints finds matching endpoints based on the provided context.
-func MatchEndpoints(context RouteMetadata) []aikido_types.Endpoint {
-	endpoints := GetEndpoints()
-
+// FindMatches finds matching endpoints from a provided list based on the context.
+// This is the core matching logic that can be reused with any endpoint list.
+func FindMatches(endpoints []aikido_types.Endpoint, context RouteMetadata) []aikido_types.Endpoint {
 	var matches []aikido_types.Endpoint
 
 	if context.Method == "" {

--- a/internal/agent/ratelimiting/rate_limiting_test.go
+++ b/internal/agent/ratelimiting/rate_limiting_test.go
@@ -10,29 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMillisecondsToMinutes(t *testing.T) {
-	testCases := []struct {
-		name     string
-		ms       int
-		expected int
-	}{
-		{"1 minute", 60000, 1},
-		{"5 minutes", 300000, 5},
-		{"10 minutes", 600000, 10},
-		{"30 minutes", 1800000, 30},
-		{"1 hour", 3600000, 60},
-		{"2 hours", 7200000, 120},
-		{"0 ms", 0, 0},
-		{"500 ms", 500, 0}, // Less than a minute rounds down
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := millisecondsToMinutes(tc.ms)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
+var fiveMinutesInMS = int(time.Duration(5 * time.Minute).Milliseconds())
 
 func TestShouldRateLimitRequest(t *testing.T) {
 	t.Run("non-existent route returns no block", func(t *testing.T) {
@@ -49,7 +27,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		rl := New()
 		key := endpointKey{Method: "GET", Route: "/api/test"}
 		rl.rateLimitingMap[key] = &endpointData{
-			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMinutes: 5},
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
 			Counts: make(map[entityKey]*slidingwindow.Window),
 		}
 
@@ -63,7 +41,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		rl := New()
 		key := endpointKey{Method: "GET", Route: "/api/test"}
 		rl.rateLimitingMap[key] = &endpointData{
-			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMinutes: 5},
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
 			Counts: make(map[entityKey]*slidingwindow.Window),
 		}
 
@@ -81,7 +59,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		rl := New()
 		key := endpointKey{Method: "GET", Route: "/api/test"}
 		rl.rateLimitingMap[key] = &endpointData{
-			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMinutes: 5},
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
 			Counts: make(map[entityKey]*slidingwindow.Window),
 		}
 
@@ -99,7 +77,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		rl := New()
 		key := endpointKey{Method: "POST", Route: "/api/other"}
 		rl.rateLimitingMap[key] = &endpointData{
-			Config: rateLimitConfig{MaxRequests: 5, WindowSizeInMinutes: 5},
+			Config: rateLimitConfig{MaxRequests: 5, WindowSizeInMS: fiveMinutesInMS},
 			Counts: make(map[entityKey]*slidingwindow.Window),
 		}
 
@@ -115,21 +93,21 @@ func TestCleanupInactive(t *testing.T) {
 	rl := New()
 	key := endpointKey{Method: "GET", Route: "/api/test"}
 	rl.rateLimitingMap[key] = &endpointData{
-		Config: rateLimitConfig{MaxRequests: 10, WindowSizeInMinutes: 5},
+		Config: rateLimitConfig{MaxRequests: 10, WindowSizeInMS: fiveMinutesInMS},
 		Counts: make(map[entityKey]*slidingwindow.Window),
 	}
 
-	now := time.Now().Unix()
-	veryOld := now - int64(5*60) - 100
-	recent := now - 60
+	now := time.Now().UnixMilli()
+	veryOld := now - int64(5*60*1000) - (100 * 1000)
+	recent := now - (60 * 1000)
 
-	inactiveWindow := slidingwindow.New(5*60, 10)
+	inactiveWindow := slidingwindow.New(5*60*1000, 10)
 	inactiveWindow.TryRecord(veryOld)
 
-	activeWindow := slidingwindow.New(5*60, 10)
+	activeWindow := slidingwindow.New(5*60*1000, 10)
 	activeWindow.TryRecord(recent)
 
-	emptyWindow := slidingwindow.New(5*60, 10)
+	emptyWindow := slidingwindow.New(5*60*1000, 10)
 
 	// Add various states
 	rl.rateLimitingMap[key].Counts[entityKey{Value: "inactive"}] = inactiveWindow
@@ -150,8 +128,8 @@ func TestShouldRateLimitRequest_Concurrent(t *testing.T) {
 	key := endpointKey{Method: "GET", Route: "/api/test"}
 	rl.rateLimitingMap[key] = &endpointData{
 		Config: rateLimitConfig{
-			MaxRequests:         100,
-			WindowSizeInMinutes: 5,
+			MaxRequests:    100,
+			WindowSizeInMS: fiveMinutesInMS,
 		},
 		Counts: make(map[entityKey]*slidingwindow.Window),
 	}
@@ -171,7 +149,7 @@ func TestShouldRateLimitRequest_Concurrent(t *testing.T) {
 	wg.Wait()
 
 	value := rl.rateLimitingMap[key]
-	assert.Equal(t, 100, value.Counts[entityKey{Kind: entityKindUser, Value: "user1"}].Count(time.Now().Unix()))
+	assert.Equal(t, 100, value.Counts[entityKey{Kind: entityKindUser, Value: "user1"}].Count(time.Now().UnixMilli()))
 }
 
 func TestUpdateConfig(t *testing.T) {
@@ -203,14 +181,14 @@ func TestUpdateConfig(t *testing.T) {
 		value1 := rl.rateLimitingMap[key1]
 		require.NotNil(t, value1)
 		assert.Equal(t, 10, value1.Config.MaxRequests)
-		assert.Equal(t, 5, value1.Config.WindowSizeInMinutes)
+		assert.Equal(t, 300000, value1.Config.WindowSizeInMS)
 		assert.NotNil(t, value1.Counts)
 
 		key2 := endpointKey{Method: "POST", Route: "/api/create"}
 		value2 := rl.rateLimitingMap[key2]
 		require.NotNil(t, value2)
 		assert.Equal(t, 5, value2.Config.MaxRequests)
-		assert.Equal(t, 10, value2.Config.WindowSizeInMinutes)
+		assert.Equal(t, 600000, value2.Config.WindowSizeInMS)
 	})
 
 	t.Run("preserves data when config unchanged", func(t *testing.T) {
@@ -224,7 +202,7 @@ func TestUpdateConfig(t *testing.T) {
 		originalValue := rl.rateLimitingMap[key]
 
 		// Add some data
-		now := time.Now().Unix()
+		now := time.Now().UnixMilli()
 
 		userWindow := slidingwindow.New(10, 10)
 		for i := range 5 {
@@ -258,7 +236,7 @@ func TestUpdateConfig(t *testing.T) {
 		key := endpointKey{Method: "GET", Route: "/api/test"}
 
 		// Add some data
-		now := time.Now().Unix()
+		now := time.Now().UnixMilli()
 		userWindow := slidingwindow.New(10, 10)
 		for i := range 5 {
 			userWindow.TryRecord(now - int64(i))

--- a/internal/http/on_init_request.go
+++ b/internal/http/on_init_request.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
 
@@ -37,8 +38,9 @@ func OnInitRequest(ctx context.Context) *Response {
 		return &Response{403, msg}
 	}
 
-	matches := config.MatchEndpoints(
-		config.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
+	matches := endpoints.FindMatches(
+		config.GetEndpoints(),
+		endpoints.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
 	)
 	// IP Allowlists per route
 	if !ipAllowedToAccessRoute(ip, matches) {

--- a/internal/vulnerabilities/scan.go
+++ b/internal/vulnerabilities/scan.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
@@ -39,11 +40,14 @@ func ScanWithOptions[T any](ctx context.Context, operation string, vulnerability
 	}
 
 	// Check if route has force protection off, if so, we don't run any scans
-	matches := config.MatchEndpoints(config.RouteMetadata{
-		URL:    reqCtx.URL,
-		Method: reqCtx.Method,
-		Route:  reqCtx.Route,
-	})
+	matches := endpoints.FindMatches(
+		config.GetEndpoints(),
+		endpoints.RouteMetadata{
+			URL:    reqCtx.URL,
+			Method: reqCtx.Method,
+			Route:  reqCtx.Route,
+		},
+	)
 	for _, match := range matches {
 		if match.ForceProtectionOff {
 			return nil

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
@@ -24,8 +25,9 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 		return &BlockResponse{"blocked", "user", nil}
 	}
 	// rate-limiting :
-	matches := config.MatchEndpoints(
-		config.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
+	matches := endpoints.FindMatches(
+		config.GetEndpoints(),
+		endpoints.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
 	)
 
 	for _, endpoint := range matches {

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
-	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
@@ -24,30 +23,21 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 		log.Info("User is blocked!", slog.String("user", user.ID))
 		return &BlockResponse{"blocked", "user", nil}
 	}
-	// rate-limiting :
-	matches := endpoints.FindMatches(
-		config.GetEndpoints(),
-		endpoints.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
+
+	rateLimitingStatus := agent.GetRateLimitingStatus(
+		reqCtx.Method, reqCtx.Route, reqCtx.GetUser().ID, reqCtx.GetIP(),
 	)
+	if rateLimitingStatus != nil && rateLimitingStatus.Block {
+		log.Info("Request is rate-limited",
+			slog.String("ip", reqCtx.GetIP()), slog.String("trigger", rateLimitingStatus.Trigger))
 
-	for _, endpoint := range matches {
-		if endpoint.RateLimiting.Enabled {
-			rateLimitingStatus := agent.GetRateLimitingStatus(
-				endpoint.Method, endpoint.Route, reqCtx.GetUser().ID, reqCtx.GetIP(),
-			)
-			if rateLimitingStatus != nil && rateLimitingStatus.Block {
-				log.Info("Request is rate-limited",
-					slog.String("ip", reqCtx.GetIP()), slog.String("trigger", rateLimitingStatus.Trigger))
-
-				if rateLimitingStatus.Trigger == "ip" {
-					return &BlockResponse{
-						"rate-limited", rateLimitingStatus.Trigger, reqCtx.RemoteAddress,
-					}
-				}
-				return &BlockResponse{
-					"rate-limited", rateLimitingStatus.Trigger, nil,
-				}
+		if rateLimitingStatus.Trigger == "ip" {
+			return &BlockResponse{
+				"rate-limited", rateLimitingStatus.Trigger, reqCtx.RemoteAddress,
 			}
+		}
+		return &BlockResponse{
+			"rate-limited", rateLimitingStatus.Trigger, nil,
 		}
 	}
 


### PR DESCRIPTION
- Added endpoints package to make it easy to use matching from multiple places
- Add wildcard support based on node implementation:
  - https://github.com/AikidoSec/firewall-node/blob/2f39052390e6ceff845a8f3addfefe7237b42f8d/library/ratelimiting/getRateLimitedEndpoint.ts