### PR TITLE
Merge tests on sending detected attack events

### DIFF
--- a/internal/agent/cloud/event_detected_attack_test.go
+++ b/internal/agent/cloud/event_detected_attack_test.go
@@ -191,11 +191,14 @@ func TestClient_SendAttackDetectedEvent(t *testing.T) {
 		},
 	}
 
-	t.Run("sends event successfully when rate limit allows", func(t *testing.T) {
+	t.Run("sends event successfully with correct structure", func(t *testing.T) {
 		resetAttackDetectedEvents()
 
 		var capturedPayload DetectedAttackEvent
+		var capturedPath string
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+
 			assert.Equal(t, "POST", r.Method, "should use POST method")
 			assert.Equal(t, "/api/runtime/events", r.URL.Path, "should use correct route")
 			assert.Equal(t, "test-token", r.Header.Get("Authorization"), "should include authorization header")
@@ -221,11 +224,21 @@ func TestClient_SendAttackDetectedEvent(t *testing.T) {
 
 		client.SendAttackDetectedEvent(agentInfo, requestInfo, attackDetails)
 
-		// Verify the event structure
+		// Verify the event structure and all fields
 		assert.Equal(t, "detected_attack", capturedPayload.Type, "should have correct type")
+		assert.Equal(t, "/api/runtime/events", capturedPath, "should use correct API route")
 		assert.Equal(t, agentInfo, capturedPayload.Agent, "should include agent info")
+		assert.Equal(t, agentInfo.Hostname, capturedPayload.Agent.Hostname)
+		assert.Equal(t, agentInfo.Version, capturedPayload.Agent.Version)
 		assert.Equal(t, requestInfo, capturedPayload.Request, "should include request info")
+		assert.Equal(t, requestInfo.Method, capturedPayload.Request.Method)
+		assert.Equal(t, requestInfo.URL, capturedPayload.Request.URL)
 		assert.Equal(t, attackDetails, capturedPayload.Attack, "should include attack details")
+		assert.Equal(t, attackDetails.Kind, capturedPayload.Attack.Kind)
+		assert.Equal(t, attackDetails.Blocked, capturedPayload.Attack.Blocked)
+		assert.Equal(t, attackDetails.Payload, capturedPayload.Attack.Payload)
+		require.NotNil(t, capturedPayload.Attack.User, "user should not be nil")
+		assert.Equal(t, attackDetails.User.ID, capturedPayload.Attack.User.ID)
 
 		// Verify timestamp is within a reasonable range (5 seconds)
 		eventTime := time.UnixMilli(capturedPayload.Time)
@@ -307,63 +320,5 @@ func TestClient_SendAttackDetectedEvent(t *testing.T) {
 		count := len(attackDetectedEventsSentAt)
 		attackDetectedEventsSentAtMutex.Unlock()
 		assert.Equal(t, 1, count, "should have attempted to send event")
-	})
-
-	t.Run("uses correct endpoint and route", func(t *testing.T) {
-		resetAttackDetectedEvents()
-
-		var capturedPath string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			capturedPath = r.URL.Path
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"status":"ok"}`))
-		}))
-		defer server.Close()
-
-		client := &Client{
-			httpClient:  &http.Client{Timeout: 30 * time.Second},
-			apiEndpoint: server.URL,
-			token:       "test-token",
-		}
-
-		client.SendAttackDetectedEvent(agentInfo, requestInfo, attackDetails)
-
-		assert.Equal(t, "/api/runtime/events", capturedPath, "should use correct API route")
-	})
-
-	t.Run("includes all event fields correctly", func(t *testing.T) {
-		resetAttackDetectedEvents()
-
-		var capturedPayload DetectedAttackEvent
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(body, &capturedPayload)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"status":"ok"}`))
-		}))
-		defer server.Close()
-
-		client := &Client{
-			httpClient:  &http.Client{Timeout: 30 * time.Second},
-			apiEndpoint: server.URL,
-			token:       "test-token",
-		}
-
-		client.SendAttackDetectedEvent(agentInfo, requestInfo, attackDetails)
-
-		// Verify all fields are populated correctly
-		assert.Equal(t, "detected_attack", capturedPayload.Type)
-		assert.Equal(t, agentInfo.Hostname, capturedPayload.Agent.Hostname)
-		assert.Equal(t, agentInfo.Version, capturedPayload.Agent.Version)
-		assert.Equal(t, requestInfo.Method, capturedPayload.Request.Method)
-		assert.Equal(t, requestInfo.URL, capturedPayload.Request.URL)
-		assert.Equal(t, attackDetails.Kind, capturedPayload.Attack.Kind)
-		assert.Equal(t, attackDetails.Blocked, capturedPayload.Attack.Blocked)
-		assert.Equal(t, attackDetails.Payload, capturedPayload.Attack.Payload)
-		require.NotNil(t, capturedPayload.Attack.User, "user should not be nil")
-		assert.Equal(t, attackDetails.User.ID, capturedPayload.Attack.User.ID)
-
-		eventTime := time.UnixMilli(capturedPayload.Time)
-		assert.WithinDuration(t, time.Now(), eventTime, 5*time.Second, "timestamp should be within 5 seconds of current time")
 	})
 }


### PR DESCRIPTION
Some assertions were split across tests, can just do it in a single one, reducing setup.