### PR TITLE
Add toolexec command with simple passthrough

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+)
+
+func toolexecCompileCommand(cmd *cli.Command, stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
+	// If has -V=full or just -V, then it's a version query
+	// Check for -V flag, with optional "full" value
+	for _, arg := range toolArgs {
+		if arg == "-V=full" || arg == "-V" {
+			return toolexecVersionQueryCommand(
+				stdout,
+				stderr,
+				tool, toolArgs,
+			)
+		}
+	}
+
+	var pkgPath, importcfgPath, outputPath string
+	for i := range len(toolArgs) {
+		if val, ok := extractFlag(toolArgs, i, "-p"); ok {
+			pkgPath = val
+		} else if val, ok := extractFlag(toolArgs, i, "-importcfg"); ok {
+			importcfgPath = val
+		} else if val, ok := extractFlag(toolArgs, i, "-o"); ok {
+			outputPath = val
+		}
+	}
+
+	if isDebug() {
+		fmt.Fprintf(stderr, "zen-go: compiling package %s\n", pkgPath)
+		fmt.Fprintf(stderr, "%s, %s", importcfgPath, outputPath)
+	}
+
+	// Run the compiler
+	err := passthrough(tool, toolArgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func extractFlag(args []string, i int, flag string) (string, bool) {
+	if args[i] == flag && i+1 < len(args) {
+		return args[i+1], true
+	}
+	if val, ok := strings.CutPrefix(args[i], flag+"="); ok {
+		return val, true
+	}
+	return "", false
+}
+
+// passthrough runs the given Golang tool
+// For example, it will run the compiler with the arguments originally passed our toolexec command
+func passthrough(tool string, args []string) error {
+	cmd := exec.Command(tool, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/cmd/zen-go/cmd_toolexec_test.go
+++ b/cmd/zen-go/cmd_toolexec_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createMockTool creates a mock tool script that can be used for testing
+func createMockTool(t *testing.T, name string, behavior string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	var script string
+	if runtime.GOOS == "windows" {
+		// Windows batch script
+		script = "@echo off\n"
+		switch behavior {
+		case "success":
+			script += "echo compiled successfully\n"
+			script += "exit /b 0\n"
+		case "failure":
+			script += "echo compilation failed\n"
+			script += "exit /b 1\n"
+		case "echo":
+			script += "echo %*\n"
+		}
+	} else {
+		// Unix shell script
+		script = "#!/bin/sh\n"
+		switch behavior {
+		case "success":
+			script += "echo 'compiled successfully'\n"
+			script += "exit 0\n"
+		case "failure":
+			script += "echo 'compilation failed' >&2\n"
+			script += "exit 1\n"
+		case "echo":
+			script += "echo \"$@\"\n"
+			script += "exit 0\n"
+		}
+	}
+
+	toolPath := filepath.Join(tmpDir, name)
+	if runtime.GOOS == "windows" {
+		toolPath += ".bat"
+	}
+
+	// #nosec G306 - mock tool needs to be executable
+	err := os.WriteFile(toolPath, []byte(script), 0o755)
+	require.NoError(t, err)
+
+	return toolPath
+}
+
+func TestExtractFlag(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     []string
+		index    int
+		flag     string
+		expected string
+		found    bool
+	}{
+		{
+			name:     "flag with space separator",
+			args:     []string{"-p", "main"},
+			index:    0,
+			flag:     "-p",
+			expected: "main",
+			found:    true,
+		},
+		{
+			name:     "flag with equals separator",
+			args:     []string{"-p=main"},
+			index:    0,
+			flag:     "-p",
+			expected: "main",
+			found:    true,
+		},
+		{
+			name:     "flag not found",
+			args:     []string{"-o", "output.o"},
+			index:    0,
+			flag:     "-p",
+			expected: "",
+			found:    false,
+		},
+		{
+			name:     "flag at end without value",
+			args:     []string{"-p"},
+			index:    0,
+			flag:     "-p",
+			expected: "",
+			found:    false,
+		},
+		{
+			name:     "equals separator with multiple args",
+			args:     []string{"-importcfg=/tmp/cfg", "-o", "out.o"},
+			index:    0,
+			flag:     "-importcfg",
+			expected: "/tmp/cfg",
+			found:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			val, found := extractFlag(tc.args, tc.index, tc.flag)
+			assert.Equal(t, tc.found, found)
+			if found {
+				assert.Equal(t, tc.expected, val)
+			}
+		})
+	}
+}
+
+func TestPassthrough(t *testing.T) {
+	mockTool := createMockTool(t, "tool", "echo")
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	toolArgs := []string{"arg1", "arg2", "arg3"}
+	err = passthrough(mockTool, toolArgs)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "arg1")
+	assert.Contains(t, output, "arg2")
+	assert.Contains(t, output, "arg3")
+}
+
+func TestPassthrough_Error(t *testing.T) {
+	mockTool := createMockTool(t, "tool", "failure")
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	_, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	toolArgs := []string{}
+	err = passthrough(mockTool, toolArgs)
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	require.Error(t, err)
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+}
+
+func TestToolexecCLI_UnknownToolPassthrough(t *testing.T) {
+	// Test that unknown tools are passed through correctly
+	mockTool := createMockTool(t, "link", "echo")
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	args := []string{"zen-go", "toolexec", mockTool, "arg1", "arg2"}
+	cmd := newCommand()
+	cmd.Writer = os.Stdout
+	cmd.ErrWriter = os.Stderr
+
+	err = cmd.Run(context.Background(), args)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "arg1")
+	assert.Contains(t, output, "arg2")
+}
+
+func TestPassthrough_PreservesExitCode(t *testing.T) {
+	testCases := []struct {
+		name         string
+		behavior     string
+		expectedCode int
+	}{
+		{
+			name:         "success exit code 0",
+			behavior:     "success",
+			expectedCode: 0,
+		},
+		{
+			name:         "failure exit code 1",
+			behavior:     "failure",
+			expectedCode: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockTool := createMockTool(t, "tool", tc.behavior)
+
+			// Capture stderr for error output
+			oldStderr := os.Stderr
+			_, w, err := os.Pipe()
+			require.NoError(t, err)
+			os.Stderr = w
+
+			toolArgs := []string{}
+			err = passthrough(mockTool, toolArgs)
+
+			w.Close()
+			os.Stderr = oldStderr
+
+			if tc.expectedCode == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				var exitErr *exec.ExitError
+				require.ErrorAs(t, err, &exitErr)
+				assert.Equal(t, tc.expectedCode, exitErr.ExitCode())
+			}
+		})
+	}
+}
+
+func TestPassthrough_WithComplexArgs(t *testing.T) {
+	mockTool := createMockTool(t, "tool", "echo")
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	// Test with complex arguments that might appear in real compile commands
+	toolArgs := []string{
+		"-p", "github.com/example/pkg",
+		"-importcfg", "/tmp/importcfg",
+		"-o", "/tmp/output.o",
+		"-trimpath", "/tmp",
+		"input.go",
+	}
+	err = passthrough(mockTool, toolArgs)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// Verify all arguments are passed through
+	assert.Contains(t, output, "-p")
+	assert.Contains(t, output, "github.com/example/pkg")
+	assert.Contains(t, output, "-importcfg")
+	assert.Contains(t, output, "/tmp/importcfg")
+	assert.Contains(t, output, "-o")
+	assert.Contains(t, output, "/tmp/output.o")
+	assert.Contains(t, output, "-trimpath")
+	assert.Contains(t, output, "input.go")
+}

--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"io"
+	"os/exec"
+)
+
+func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
+	// Run the actual compiler to get its version string
+	cmd := exec.Command(tool, toolArgs...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Starting with a simple passthrough with some basic parsing that will be required, such as intercepting version queries.

**Example running on itself:**
<img width="698" height="509" alt="image" src="https://github.com/user-attachments/assets/a6e9c0f9-b5bf-42d7-a1de-943f4daa15da" />
