### PR TITLE
Add wrap rules to instrumentor

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -161,6 +161,7 @@ func writeTempFile(origPath string, content []byte, objdir string) (string, erro
 
 	// Use predictable name in objdir
 	outPath := filepath.Join(dir, base)
+	// #nosec G306 -- transformed source files need to be readable by the compiler
 	if err := os.WriteFile(outPath, content, 0o644); err != nil {
 		return "", err
 	}

--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -1,18 +1,45 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
+	"strings"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal"
 )
 
+// toolexecVersionQueryCommand handles the -V=full version query that Go uses to compute build IDs.
+// We intercept this and append our instrumentation hash to the version string, which
+// ensures that when instrumentation rules change, Go will compute different build IDs
+// and rebuild packages.
 func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
 	// Run the actual compiler to get its version string
 	cmd := exec.Command(tool, toolArgs...)
-	cmd.Stdout = stdout
+	var versionOutput bytes.Buffer
+	cmd.Stdout = &versionOutput
 	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
 		return err
+	}
+
+	// Compute hash of instrumentation rules
+	inst := internal.NewInstrumentor()
+	rulesHash := internal.ComputeInstrumentationHash(inst)
+
+	// Append our hash to the version string
+	versionStr := strings.TrimSpace(versionOutput.String())
+	modifiedVersion := versionStr + ":" + "zen-go@" + rulesHash
+
+	fmt.Fprint(stdout, modifiedVersion)
+	if !strings.HasSuffix(modifiedVersion, "\n") {
+		fmt.Fprint(stdout, "\n")
+	}
+
+	if isDebug() {
+		fmt.Fprintf(stderr, "zen-go: version query: %s -> %s\n", versionStr, modifiedVersion)
 	}
 
 	return nil

--- a/cmd/zen-go/go.mod
+++ b/cmd/zen-go/go.mod
@@ -8,7 +8,7 @@ require (
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/zen-go/go.sum
+++ b/cmd/zen-go/go.sum
@@ -1,7 +1,7 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.6.1 h1:j8Qq8NyUawj/7rTYdBGrxcH7A/j7/G8Q5LhWEW4G3Mo=

--- a/cmd/zen-go/internal/hash.go
+++ b/cmd/zen-go/internal/hash.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sort"
+)
+
+// ComputeInstrumentationHash computes a hash of all instrumentation rules.
+// This hash is used to modify the build ID so that when rules change, Go will rebuild packages.
+func ComputeInstrumentationHash(inst *Instrumentor) string {
+	h := sha256.New()
+
+	// Hash wrap rules
+	for _, rule := range inst.WrapRules {
+		fmt.Fprintf(h, "wrap:%s:%s:", rule.ID, rule.MatchCall)
+		// Sort imports for consistent hashing
+		importKeys := make([]string, 0, len(rule.Imports))
+		for k := range rule.Imports {
+			importKeys = append(importKeys, k)
+		}
+		sort.Strings(importKeys)
+		for _, k := range importKeys {
+			fmt.Fprintf(h, "%s=%s:", k, rule.Imports[k])
+		}
+		fmt.Fprintf(h, "%s\n", rule.WrapTmpl)
+	}
+
+	// Return base64-encoded hash (first 16 chars for brevity)
+	hash := h.Sum(nil)
+	return base64.URLEncoding.EncodeToString(hash[:])[:16]
+}
+

--- a/cmd/zen-go/internal/hash.go
+++ b/cmd/zen-go/internal/hash.go
@@ -29,6 +29,5 @@ func ComputeInstrumentationHash(inst *Instrumentor) string {
 
 	// Return base64-encoded hash (first 16 chars for brevity)
 	hash := h.Sum(nil)
-	return base64.URLEncoding.EncodeToString(hash[:])[:16]
+	return base64.URLEncoding.EncodeToString(hash)[:16]
 }
-

--- a/cmd/zen-go/internal/hash_test.go
+++ b/cmd/zen-go/internal/hash_test.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeInstrumentationHash(t *testing.T) {
+	inst := NewInstrumentor()
+	hash := ComputeInstrumentationHash(inst)
+
+	// Hash should be 16 characters (base64 encoded, truncated)
+	assert.Len(t, hash, 16)
+
+	// Hash should be consistent
+	hash2 := ComputeInstrumentationHash(inst)
+	assert.Equal(t, hash, hash2)
+}
+
+func TestComputeInstrumentationHash_DifferentRules(t *testing.T) {
+	inst1 := &Instrumentor{
+		WrapRules: []WrapRule{
+			{ID: "test1", MatchCall: "pkg.Func1"},
+		},
+	}
+
+	inst2 := &Instrumentor{
+		WrapRules: []WrapRule{
+			{ID: "test2", MatchCall: "pkg.Func2"},
+		},
+	}
+
+	hash1 := ComputeInstrumentationHash(inst1)
+	hash2 := ComputeInstrumentationHash(inst2)
+
+	assert.NotEqual(t, hash1, hash2)
+}
+
+func TestComputeInstrumentationHash_EmptyRules(t *testing.T) {
+	inst := &Instrumentor{
+		WrapRules: []WrapRule{},
+	}
+
+	hash := ComputeInstrumentationHash(inst)
+	assert.Len(t, hash, 16)
+}

--- a/cmd/zen-go/internal/importcfg.go
+++ b/cmd/zen-go/internal/importcfg.go
@@ -1,0 +1,122 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func ExtendImportcfg(origPath string, addedImports map[string]string, objdir string, stderr io.Writer, debug bool) (string, error) {
+	content, err := os.ReadFile(origPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Parse existing entries
+	existing := make(map[string]bool)
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.HasPrefix(line, "packagefile ") {
+			parts := strings.SplitN(strings.TrimPrefix(line, "packagefile "), "=", 2)
+			if len(parts) == 2 {
+				existing[parts[0]] = true
+			}
+		}
+	}
+
+	// Find export paths for added imports
+	var newLines []string
+	for alias, importPath := range addedImports {
+		if debug {
+			fmt.Fprintf(stderr, "zen-go: processing import: key=%s value=%s\n", alias, importPath)
+		}
+
+		if existing[importPath] {
+			continue
+		}
+
+		exportPath, err := getPackageExport(importPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "zen-go: warning: could not find export for %s: %v\n", importPath, err)
+			continue
+		}
+
+		newLines = append(newLines, fmt.Sprintf("packagefile %s=%s", importPath, exportPath))
+		existing[importPath] = true
+
+		if debug {
+			fmt.Fprintf(stderr, "zen-go: adding to importcfg: %s=%s\n", importPath, exportPath)
+		}
+	}
+
+	if len(newLines) == 0 {
+		if debug {
+			fmt.Fprintf(stderr, "zen-go: no new imports to add to importcfg\n")
+		}
+		return "", nil
+	}
+
+	// Write new importcfg
+	newContent := strings.TrimSuffix(string(content), "\n") + "\n" + strings.Join(newLines, "\n") + "\n"
+
+	tmpFile, err := createTempFile(objdir)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := tmpFile.WriteString(newContent); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return "", err
+	}
+	tmpFile.Close()
+
+	if debug {
+		fmt.Fprintf(stderr, "zen-go: wrote extended importcfg to %s\n", tmpFile.Name())
+	}
+
+	return tmpFile.Name(), nil
+}
+
+func createTempFile(objdir string) (*os.File, error) {
+	if objdir != "" {
+		dir := filepath.Join(objdir, "zen-go")
+		if err := os.MkdirAll(dir, 0o755); err == nil {
+			return os.Create(filepath.Join(dir, "importcfg.txt"))
+		}
+	}
+	return os.CreateTemp("", "importcfg_*.txt")
+}
+
+func getPackageExport(importPath string) (string, error) {
+	cmd := exec.Command("go", "list", "-export", "-f", "{{.Export}}", importPath)
+	if modDir := findModuleRoot(); modDir != "" {
+		cmd.Dir = modDir
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func findModuleRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/cmd/zen-go/internal/importcfg_test.go
+++ b/cmd/zen-go/internal/importcfg_test.go
@@ -1,0 +1,127 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtendImportcfg_ExistingPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	importcfgPath := filepath.Join(tmpDir, "importcfg")
+
+	content := `# import config
+packagefile fmt=/usr/local/go/pkg/darwin_arm64/fmt.a
+packagefile os=/usr/local/go/pkg/darwin_arm64/os.a
+`
+	require.NoError(t, os.WriteFile(importcfgPath, []byte(content), 0600))
+
+	result, err := ExtendImportcfg(importcfgPath, map[string]string{
+		"fmt": "fmt",
+	}, tmpDir, os.Stderr, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtendImportcfg_EmptyImports(t *testing.T) {
+	tmpDir := t.TempDir()
+	importcfgPath := filepath.Join(tmpDir, "importcfg")
+
+	content := `# import config
+packagefile fmt=/usr/local/go/pkg/darwin_arm64/fmt.a
+`
+	require.NoError(t, os.WriteFile(importcfgPath, []byte(content), 0600))
+
+	result, err := ExtendImportcfg(importcfgPath, map[string]string{}, tmpDir, os.Stderr, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestExtendImportcfg_NonExistentFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	importcfgPath := filepath.Join(tmpDir, "nonexistent")
+
+	_, err := ExtendImportcfg(importcfgPath, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	}, tmpDir, os.Stderr, false)
+
+	assert.Error(t, err)
+}
+
+func TestCreateTempFile_WithObjdir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	f, err := createTempFile(tmpDir)
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	assert.Contains(t, f.Name(), filepath.Join(tmpDir, "zen-go"))
+	assert.True(t, strings.HasSuffix(f.Name(), "importcfg.txt"))
+}
+
+func TestCreateTempFile_WithoutObjdir(t *testing.T) {
+	f, err := createTempFile("")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	assert.Contains(t, f.Name(), "importcfg_")
+}
+
+func TestFindModuleRoot(t *testing.T) {
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	tmpDir := t.TempDir()
+	goModPath := filepath.Join(tmpDir, "go.mod")
+	require.NoError(t, os.WriteFile(goModPath, []byte("module test\n"), 0600))
+
+	subDir := filepath.Join(tmpDir, "subdir", "deeper")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	require.NoError(t, os.Chdir(subDir))
+
+	root := findModuleRoot()
+
+	expectedRoot, _ := filepath.EvalSymlinks(tmpDir)
+	actualRoot, _ := filepath.EvalSymlinks(root)
+	assert.Equal(t, expectedRoot, actualRoot)
+}
+
+func TestFindModuleRoot_NoGoMod(t *testing.T) {
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir))
+
+	root := findModuleRoot()
+	assert.Empty(t, root)
+}
+
+func TestExtendImportcfg_ParsesExistingEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	importcfgPath := filepath.Join(tmpDir, "importcfg")
+
+	content := `# import config
+packagefile fmt=/path/to/fmt.a
+packagefile os=/path/to/os.a
+packagefile github.com/gin-gonic/gin=/path/to/gin.a
+`
+	require.NoError(t, os.WriteFile(importcfgPath, []byte(content), 0600))
+
+	result, err := ExtendImportcfg(importcfgPath, map[string]string{
+		"gin": "github.com/gin-gonic/gin",
+	}, tmpDir, os.Stderr, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/cmd/zen-go/internal/imports.go
+++ b/cmd/zen-go/internal/imports.go
@@ -1,14 +1,23 @@
 package internal
 
 import (
+	"fmt"
 	"go/ast"
 	"go/token"
 	"strconv"
 )
 
-func addImports(f *ast.File, imports map[string]string) {
+type DuplicateImportAliasError struct {
+	alias string
+}
+
+func (e *DuplicateImportAliasError) Error() string {
+	return fmt.Sprintf("duplicate import alias: %s", e.alias)
+}
+
+func addImports(f *ast.File, imports map[string]string) error {
 	if len(imports) == 0 {
-		return
+		return nil
 	}
 
 	var importDecl *ast.GenDecl
@@ -24,18 +33,29 @@ func addImports(f *ast.File, imports map[string]string) {
 		f.Decls = append([]ast.Decl{importDecl}, f.Decls...)
 	}
 
-	existing := make(map[string]bool)
+	existingAliases := make(map[string]string)
 	for _, spec := range importDecl.Specs {
 		if is, ok := spec.(*ast.ImportSpec); ok {
 			path, _ := strconv.Unquote(is.Path.Value)
-			existing[path] = true
+			if is.Name != nil {
+				existingAliases[is.Name.String()] = path
+			}
 		}
 	}
 
 	for alias, path := range imports {
-		if existing[path] {
-			continue
+		if existingAliases[alias] != "" {
+			// If the path is the same, then we're trying to import the same package with the same alias
+			if existingAliases[alias] == path {
+				continue
+			}
+
+			// If not, we're trying to use the same alias for different packages
+			return &DuplicateImportAliasError{
+				alias: alias,
+			}
 		}
+
 		spec := &ast.ImportSpec{
 			Name: &ast.Ident{Name: alias},
 			Path: &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(path)},
@@ -46,4 +66,6 @@ func addImports(f *ast.File, imports map[string]string) {
 	if len(importDecl.Specs) > 1 {
 		importDecl.Lparen = 1
 	}
+
+	return nil
 }

--- a/cmd/zen-go/internal/imports.go
+++ b/cmd/zen-go/internal/imports.go
@@ -20,6 +20,7 @@ func addImports(f *ast.File, imports map[string]string) error {
 		return nil
 	}
 
+	// Find the first import block to add new imports
 	var importDecl *ast.GenDecl
 	for _, decl := range f.Decls {
 		if gd, ok := decl.(*ast.GenDecl); ok && gd.Tok == token.IMPORT {
@@ -28,6 +29,7 @@ func addImports(f *ast.File, imports map[string]string) error {
 		}
 	}
 
+	// If can't find an import block, then create one
 	if importDecl == nil {
 		importDecl = &ast.GenDecl{Tok: token.IMPORT}
 		f.Decls = append([]ast.Decl{importDecl}, f.Decls...)

--- a/cmd/zen-go/internal/imports.go
+++ b/cmd/zen-go/internal/imports.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+)
+
+func addImports(f *ast.File, imports map[string]string) {
+	if len(imports) == 0 {
+		return
+	}
+
+	var importDecl *ast.GenDecl
+	for _, decl := range f.Decls {
+		if gd, ok := decl.(*ast.GenDecl); ok && gd.Tok == token.IMPORT {
+			importDecl = gd
+			break
+		}
+	}
+
+	if importDecl == nil {
+		importDecl = &ast.GenDecl{Tok: token.IMPORT}
+		f.Decls = append([]ast.Decl{importDecl}, f.Decls...)
+	}
+
+	existing := make(map[string]bool)
+	for _, spec := range importDecl.Specs {
+		if is, ok := spec.(*ast.ImportSpec); ok {
+			path, _ := strconv.Unquote(is.Path.Value)
+			existing[path] = true
+		}
+	}
+
+	for alias, path := range imports {
+		if existing[path] {
+			continue
+		}
+		spec := &ast.ImportSpec{
+			Name: &ast.Ident{Name: alias},
+			Path: &ast.BasicLit{Kind: token.STRING, Value: strconv.Quote(path)},
+		}
+		importDecl.Specs = append(importDecl.Specs, spec)
+	}
+
+	if len(importDecl.Specs) > 1 {
+		importDecl.Lparen = 1
+	}
+}

--- a/cmd/zen-go/internal/imports_test.go
+++ b/cmd/zen-go/internal/imports_test.go
@@ -1,0 +1,185 @@
+package internal
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddImports_NewImport(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	})
+
+	var buf strings.Builder
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	result := buf.String()
+	assert.Contains(t, result, `zengin "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin"`)
+}
+
+func TestAddImports_ExistingImport(t *testing.T) {
+	src := `package main
+
+import (
+	"fmt"
+	zengin "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin"
+)
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	})
+
+	var buf strings.Builder
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	result := buf.String()
+	// Should only appear once (not duplicated)
+	count := strings.Count(result, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin")
+	assert.Equal(t, 1, count)
+}
+
+func TestAddImports_NoImportDecl(t *testing.T) {
+	src := `package main
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	})
+
+	var buf strings.Builder
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	result := buf.String()
+	assert.Contains(t, result, `zengin "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin"`)
+}
+
+func TestAddImports_MultipleImports(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+		"zensql": "github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql",
+	})
+
+	var buf strings.Builder
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	result := buf.String()
+	assert.Contains(t, result, "zengin")
+	assert.Contains(t, result, "zensql")
+}
+
+func TestAddImports_EmptyMap(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	originalDecls := len(f.Decls)
+	addImports(f, map[string]string{})
+
+	// Should not modify the file
+	assert.Equal(t, originalDecls, len(f.Decls))
+}
+
+func TestAddImports_PreservesExistingImports(t *testing.T) {
+	src := `package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	})
+
+	var buf strings.Builder
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	result := buf.String()
+	assert.Contains(t, result, `"fmt"`)
+	assert.Contains(t, result, `"os"`)
+	assert.Contains(t, result, "zengin")
+}
+
+func TestAddImports_GroupedImports(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, parser.ParseComments)
+	require.NoError(t, err)
+
+	addImports(f, map[string]string{
+		"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+	})
+
+	// Check that import decl has Lparen set (grouped imports)
+	var importDecl *ast.GenDecl
+	for _, decl := range f.Decls {
+		if gd, ok := decl.(*ast.GenDecl); ok && gd.Tok == token.IMPORT {
+			importDecl = gd
+			break
+		}
+	}
+
+	require.NotNil(t, importDecl)
+	assert.True(t, importDecl.Lparen.IsValid(), "import should be grouped with parentheses")
+}
+

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -109,7 +109,10 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 	}
 
 	// Add new imports
-	addImports(file, importsToAdd)
+	err = addImports(file, importsToAdd)
+	if err != nil {
+		return InstrumentFileResult{}, err
+	}
 
 	var out bytes.Buffer
 	if err := printer.Fprint(&out, fset, file); err != nil {

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -63,6 +63,9 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 	for _, imp := range file.Imports {
 		path, _ := strconv.Unquote(imp.Path.Value)
 		name := ""
+
+		// The import name refers to the alias
+		// If an alias isn't set, then we use the package name
 		if imp.Name != nil {
 			name = imp.Name.String()
 		} else {
@@ -77,11 +80,17 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 
 	// Apply wrap rules
 	for _, rule := range i.WrapRules {
+		// Matching is based on package.Func
+		// e.g. "github.com/gin-gonic/gin.New"
 		lastDot := strings.LastIndex(rule.MatchCall, ".")
 		if lastDot == -1 {
 			continue
 		}
+
+		// e.g. "github.com/gin-gonic/gin"
 		pkg := rule.MatchCall[:lastDot]
+
+		// e.g. "New"
 		funcName := rule.MatchCall[lastDot+1:]
 
 		localPkgName, ok := imports[pkg]

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -98,7 +98,10 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 			continue
 		}
 
-		transformDeclsWrap(file.Decls, fset, localPkgName, funcName, rule, &modified, importsToAdd)
+		err := transformDeclsWrap(file.Decls, fset, localPkgName, funcName, rule, &modified, importsToAdd)
+		if err != nil {
+			return InstrumentFileResult{}, err
+		}
 	}
 
 	if !modified {

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -1,0 +1,102 @@
+package internal
+
+import (
+	"bytes"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+// WrapRule wraps a function call expression
+type WrapRule struct {
+	ID        string
+	MatchCall string
+	Imports   map[string]string
+	WrapTmpl  string
+}
+
+type Instrumentor struct {
+	WrapRules []WrapRule
+}
+
+func NewInstrumentor() *Instrumentor {
+	return &Instrumentor{
+		WrapRules: []WrapRule{
+			{
+				ID:        "gin.Default",
+				MatchCall: "github.com/gin-gonic/gin.Default",
+				Imports: map[string]string{
+					"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+				},
+				WrapTmpl: `func() *gin.Engine { e := {{.}}; e.Use(zengin.GetMiddleware()); return e }()`,
+			},
+			{
+				ID:        "gin.New",
+				MatchCall: "github.com/gin-gonic/gin.New",
+				Imports: map[string]string{
+					"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+				},
+				WrapTmpl: `func() *gin.Engine { e := {{.}}; e.Use(zengin.GetMiddleware()); return e }()`,
+			},
+		},
+	}
+}
+
+func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) ([]byte, bool, map[string]string, error) {
+	// Parse the file using go/parser
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, false, nil, err
+	}
+
+	// Build map of existing imports
+	imports := make(map[string]string)
+	for _, imp := range file.Imports {
+		path, _ := strconv.Unquote(imp.Path.Value)
+		name := ""
+		if imp.Name != nil {
+			name = imp.Name.String()
+		} else {
+			parts := strings.Split(path, "/")
+			name = parts[len(parts)-1]
+		}
+		imports[path] = name
+	}
+
+	modified := false
+	importsToAdd := make(map[string]string)
+
+	// Apply wrap rules
+	for _, rule := range i.WrapRules {
+		lastDot := strings.LastIndex(rule.MatchCall, ".")
+		if lastDot == -1 {
+			continue
+		}
+		pkg := rule.MatchCall[:lastDot]
+		funcName := rule.MatchCall[lastDot+1:]
+
+		localPkgName, ok := imports[pkg]
+		if !ok {
+			continue
+		}
+
+		transformDeclsWrap(file.Decls, fset, localPkgName, funcName, rule, &modified, importsToAdd)
+	}
+
+	if !modified {
+		return nil, false, nil, nil
+	}
+
+	// Add new imports
+	addImports(file, importsToAdd)
+
+	var out bytes.Buffer
+	if err := printer.Fprint(&out, fset, file); err != nil {
+		return nil, false, nil, err
+	}
+
+	return out.Bytes(), true, importsToAdd, nil
+}

--- a/cmd/zen-go/internal/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor_test.go
@@ -22,7 +22,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -49,7 +49,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -73,7 +73,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -95,7 +95,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -122,7 +122,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -149,7 +149,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -175,7 +175,7 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
 	result, err := inst.InstrumentFile(tmpFile, "main")
@@ -206,9 +206,41 @@ func main() {
 `
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "main.go")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	inst := NewInstrumentor()
+	result, err := inst.InstrumentFile(tmpFile, "main")
+
+	assert.Error(t, err)
+	assert.False(t, result.Modified)
+	assert.Nil(t, result.Imports)
+}
+
+func TestInstrumentFile_InvalidTemplateSyntax(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	r.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	inst := NewInstrumentor()
+	inst.WrapRules = []WrapRule{
+		{
+			ID:        "gin.Default",
+			MatchCall: "github.com/gin-gonic/gin.Default",
+			Imports: map[string]string{
+				"zengin": "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin",
+			},
+			WrapTmpl: `{.}}`,
+		},
+	}
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)

--- a/cmd/zen-go/internal/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor_test.go
@@ -1,0 +1,214 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrumentFile_GinDefault(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	r.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+	assert.Contains(t, imports, "zengin")
+	assert.Equal(t, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin", imports["zengin"])
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, "GetMiddleware()")
+	assert.Contains(t, resultStr, "e.Use(zengin.")
+}
+
+func TestInstrumentFile_GinNew(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.New()
+	r.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+	assert.Contains(t, imports, "zengin")
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, "GetMiddleware()")
+}
+
+func TestInstrumentFile_NoGin(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.False(t, modified)
+	assert.Nil(t, result)
+	assert.Nil(t, imports)
+}
+
+func TestInstrumentFile_GinWithAlias(t *testing.T) {
+	src := `package main
+
+import g "github.com/gin-gonic/gin"
+
+func main() {
+	r := g.Default()
+	r.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+	assert.Contains(t, imports, "zengin")
+
+	resultStr := string(result)
+	assert.Contains(t, resultStr, "GetMiddleware()")
+}
+
+func TestInstrumentFile_MultipleGinCalls(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r1 := gin.Default()
+	r2 := gin.New()
+	r1.Run()
+	r2.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	resultStr := string(result)
+	// Should have two middleware insertions
+	assert.Equal(t, 2, strings.Count(resultStr, "GetMiddleware()"))
+}
+
+func TestInstrumentFile_GinInIfStatement(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	if true {
+		r := gin.Default()
+		r.Run()
+	}
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+	assert.Contains(t, string(result), "GetMiddleware()")
+}
+
+func TestInstrumentFile_GinInFunction(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func createRouter() *gin.Engine {
+	return gin.Default()
+}
+
+func main() {
+	r := createRouter()
+	r.Run()
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, modified)
+	assert.Contains(t, string(result), "GetMiddleware()")
+}
+
+func TestInstrumentFile_InvalidFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "nonexistent.go")
+
+	inst := NewInstrumentor()
+	_, _, _, err := inst.InstrumentFile(tmpFile, "main")
+
+	assert.Error(t, err)
+}
+
+func TestInstrumentFile_InvalidSyntax(t *testing.T) {
+	src := `package main
+
+func main() {
+	this is not valid go
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
+
+	inst := NewInstrumentor()
+	_, _, _, err := inst.InstrumentFile(tmpFile, "main")
+
+	assert.Error(t, err)
+}

--- a/cmd/zen-go/internal/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor_test.go
@@ -25,14 +25,14 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
-	assert.Contains(t, imports, "zengin")
-	assert.Equal(t, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin", imports["zengin"])
+	assert.True(t, result.Modified)
+	assert.Contains(t, result.Imports, "zengin")
+	assert.Equal(t, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin", result.Imports["zengin"])
 
-	resultStr := string(result)
+	resultStr := string(result.Code)
 	assert.Contains(t, resultStr, "GetMiddleware()")
 	assert.Contains(t, resultStr, "e.Use(zengin.")
 }
@@ -52,13 +52,13 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
-	assert.Contains(t, imports, "zengin")
+	assert.True(t, result.Modified)
+	assert.Contains(t, result.Imports, "zengin")
 
-	resultStr := string(result)
+	resultStr := string(result.Code)
 	assert.Contains(t, resultStr, "GetMiddleware()")
 }
 
@@ -76,12 +76,11 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.False(t, modified)
-	assert.Nil(t, result)
-	assert.Nil(t, imports)
+	assert.False(t, result.Modified)
+	assert.Empty(t, result.Imports)
 }
 
 func TestInstrumentFile_GinWithAlias(t *testing.T) {
@@ -99,13 +98,13 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, imports, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
-	assert.Contains(t, imports, "zengin")
+	assert.True(t, result.Modified)
+	assert.Contains(t, result.Imports, "zengin")
 
-	resultStr := string(result)
+	resultStr := string(result.Code)
 	assert.Contains(t, resultStr, "GetMiddleware()")
 }
 
@@ -126,12 +125,12 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
+	assert.True(t, result.Modified)
 
-	resultStr := string(result)
+	resultStr := string(result.Code)
 	// Should have two middleware insertions
 	assert.Equal(t, 2, strings.Count(resultStr, "GetMiddleware()"))
 }
@@ -153,11 +152,11 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
-	assert.Contains(t, string(result), "GetMiddleware()")
+	assert.True(t, result.Modified)
+	assert.Contains(t, string(result.Code), "GetMiddleware()")
 }
 
 func TestInstrumentFile_GinInFunction(t *testing.T) {
@@ -179,11 +178,11 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	result, modified, _, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
-	assert.True(t, modified)
-	assert.Contains(t, string(result), "GetMiddleware()")
+	assert.True(t, result.Modified)
+	assert.Contains(t, string(result.Code), "GetMiddleware()")
 }
 
 func TestInstrumentFile_InvalidFile(t *testing.T) {
@@ -191,9 +190,11 @@ func TestInstrumentFile_InvalidFile(t *testing.T) {
 	tmpFile := filepath.Join(tmpDir, "nonexistent.go")
 
 	inst := NewInstrumentor()
-	_, _, _, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
+	assert.False(t, result.Modified)
+	assert.Nil(t, result.Imports)
 }
 
 func TestInstrumentFile_InvalidSyntax(t *testing.T) {
@@ -208,7 +209,9 @@ func main() {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0600))
 
 	inst := NewInstrumentor()
-	_, _, _, err := inst.InstrumentFile(tmpFile, "main")
+	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
+	assert.False(t, result.Modified)
+	assert.Nil(t, result.Imports)
 }

--- a/cmd/zen-go/internal/transform.go
+++ b/cmd/zen-go/internal/transform.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+// transformDeclsWrap walks through all declarations in a file looking for function
+// declarations, then recursively transforms any matching function calls within them.
 func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) {
 	for _, decl := range decls {
 		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
@@ -17,6 +19,14 @@ func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName
 	}
 }
 
+// transformStmtsWrap recursively walks the statement tree, finding all expressions
+// that might contain function calls and attempting to transform them.
+//
+// It handles:
+// - Assignments (x := pkg.Func())
+// - Expression statements (pkg.Func())
+// - Return statements (return pkg.Func())
+// - Control flow blocks (if/for/switch/select bodies)
 func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) {
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
@@ -75,33 +85,60 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 	}
 }
 
+// tryTransformCall attempts to transform a function call expression that matches
+// the target package and function name by wrapping it according to the rule.
+//
+// AST Navigation:
+//   - We're looking for expressions like: pkgName.funcName(args...)
+//   - In Go's AST, this is represented as:
+//     CallExpr { Fun: SelectorExpr { X: Ident(pkgName), Sel: Ident(funcName) } }
+//
+// Process:
+// 1. Check if expr is a CallExpr (a function call)
+// 2. Check if the function being called is a SelectorExpr (e.g., pkg.Func)
+// 3. Verify the selector's receiver is an Ident matching our target package
+// 4. Verify the selector's field matches our target function
+// 5. If all match, wrap the call using the rule's template
+//
+// Returns the wrapped expression if transformation occurred, nil otherwise.
 func tryTransformCall(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) ast.Expr {
+	// Step 1: Check if this is a function call at all
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {
 		return nil
 	}
 
+	// Step 2: Check if the call is in the form "something.method()"
+	// (as opposed to just "function()")
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return nil
 	}
 
+	// Step 3: Check if "something" is a simple identifier (package name)
+	// This ensures we're dealing with pkgName.funcName, not x.y.z.funcName
 	ident, ok := sel.X.(*ast.Ident)
 	if !ok || ident.Name != pkgName || sel.Sel.Name != funcName {
 		return nil
 	}
 
+	// Step 4: Serialize the original call expression back to source code
+	// e.g., "http.Get(url)" becomes the string "http.Get(url)"
 	var origBuf bytes.Buffer
 	printer.Fprint(&origBuf, fset, call)
 	origCode := origBuf.String()
 
+	// Step 5: Apply the wrapping template
+	// e.g., if template is "instrument.Wrap({{.}})", we get "instrument.Wrap(http.Get(url))"
 	wrapped := strings.Replace(rule.WrapTmpl, "{{.}}", origCode, 1)
 
+	// Step 6: Parse the wrapped string back into an AST expression
 	wrappedExpr, err := parser.ParseExpr(wrapped)
 	if err != nil {
 		return nil
 	}
 
+	// Step 7: Mark that we modified the file and register any new imports needed
 	*modified = true
 	for alias, path := range rule.Imports {
 		importsToAdd[alias] = path

--- a/cmd/zen-go/internal/transform.go
+++ b/cmd/zen-go/internal/transform.go
@@ -1,0 +1,111 @@
+package internal
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"strings"
+)
+
+func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) {
+	for _, decl := range decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+			transformStmtsWrap(fn.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+		}
+	}
+}
+
+func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.AssignStmt:
+			for i, rhs := range s.Rhs {
+				if newExpr := tryTransformCall(rhs, fset, pkgName, funcName, rule, modified, importsToAdd); newExpr != nil {
+					s.Rhs[i] = newExpr
+				}
+			}
+		case *ast.ExprStmt:
+			if newExpr := tryTransformCall(s.X, fset, pkgName, funcName, rule, modified, importsToAdd); newExpr != nil {
+				s.X = newExpr
+			}
+		case *ast.ReturnStmt:
+			for i, result := range s.Results {
+				if newExpr := tryTransformCall(result, fset, pkgName, funcName, rule, modified, importsToAdd); newExpr != nil {
+					s.Results[i] = newExpr
+				}
+			}
+		case *ast.IfStmt:
+			if s.Body != nil {
+				transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+			}
+			if s.Else != nil {
+				if block, ok := s.Else.(*ast.BlockStmt); ok {
+					transformStmtsWrap(block.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+				}
+			}
+		case *ast.ForStmt:
+			if s.Body != nil {
+				transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+			}
+		case *ast.RangeStmt:
+			if s.Body != nil {
+				transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+			}
+		case *ast.SwitchStmt:
+			if s.Body != nil {
+				for _, clause := range s.Body.List {
+					if cc, ok := clause.(*ast.CaseClause); ok {
+						transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
+					}
+				}
+			}
+		case *ast.SelectStmt:
+			if s.Body != nil {
+				for _, clause := range s.Body.List {
+					if cc, ok := clause.(*ast.CommClause); ok {
+						transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
+					}
+				}
+			}
+		case *ast.BlockStmt:
+			transformStmtsWrap(s.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+		}
+	}
+}
+
+func tryTransformCall(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) ast.Expr {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok || ident.Name != pkgName || sel.Sel.Name != funcName {
+		return nil
+	}
+
+	var origBuf bytes.Buffer
+	printer.Fprint(&origBuf, fset, call)
+	origCode := origBuf.String()
+
+	wrapped := strings.Replace(rule.WrapTmpl, "{{.}}", origCode, 1)
+
+	wrappedExpr, err := parser.ParseExpr(wrapped)
+	if err != nil {
+		return nil
+	}
+
+	*modified = true
+	for alias, path := range rule.Imports {
+		importsToAdd[alias] = path
+	}
+
+	return wrappedExpr
+}

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -50,13 +50,7 @@ func newCommand() *cli.Command {
 
 					switch toolName {
 					case "compile":
-						return toolexecCompileCommand(
-							cmd,
-							cmd.Root().Writer,
-							cmd.Root().ErrWriter,
-							tool,
-							toolArgs,
-						)
+						return toolexecCompileCommand(os.Stdout, os.Stderr, tool, toolArgs)
 					default:
 						return passthrough(tool, toolArgs)
 					}

--- a/instrumentation/main.go
+++ b/instrumentation/main.go
@@ -1,1 +1,1 @@
-package main
+package instrumentation

--- a/instrumentation/orchestrion.tool.go
+++ b/instrumentation/orchestrion.tool.go
@@ -1,4 +1,4 @@
-package main
+package instrumentation
 
 import (
 	_ "github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql"


### PR DESCRIPTION
Add some support for wrap rules, this is used for example adding middleware to Gin.

An example of running this locally on the `gin-postgres` sample app (requires a small modification to get things building):
```bash
go build -toolexec "$HOME/dev/firewall-go/cmd/zen-go/zen-go toolexec" -work .
```

Snippet of `go build` output with debug enabled:
```
# gin-postgres
zen-go: compiling package main
zen-go: transformed ./main.go -> $WORK/b001/zen-go/src/main.go
zen-go: added import zengin -> github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
zen-go: processing import: key=zengin value=github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
zen-go: adding to importcfg: github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin=/Users/tom/Library/Caches/go-build/99/99d90327049bfc90bbd0a77931377145352be9e9b936b5e811713b47cf6809e3-d
zen-go: wrote extended importcfg to $WORK/b001/zen-go/importcfg.txt
zen-go: replaced importcfg with $WORK/b001/zen-go/importcfg.txt
```

And result looks like:
```go
func main() {
	err := zen.Protect()
	if err != nil {
		log.Fatal(err)
	}

	db = NewDatabaseHelper()
	// Set up Gin router
	r := func() *gin.Engine {
		e := gin.
			Default()
		e.
			Use(zengin.
				GetMiddleware())
		return e
	}()
	
	// ...
}