### PR TITLE
Return rate limit data directly instead of key

### DIFF
--- a/internal/agent/ratelimiting/rate_limiting.go
+++ b/internal/agent/ratelimiting/rate_limiting.go
@@ -190,15 +190,15 @@ func (rl *RateLimiter) findMatchingRateLimitEndpoint(method string, route string
 
 	for _, match := range matches {
 		key := endpointKey{Method: match.Method, Route: match.Route}
-		data := rl.rateLimitingMap[key]
-		if data.Config.WindowSizeInMS == 0 {
+		endpoint := rl.rateLimitingMap[key]
+		if endpoint.Config.WindowSizeInMS == 0 {
 			continue
 		}
 
-		rate := float64(data.Config.MaxRequests) / float64(data.Config.WindowSizeInMS)
+		rate := float64(endpoint.Config.MaxRequests) / float64(endpoint.Config.WindowSizeInMS)
 
 		if mostRestrictive == nil || rate < lowestRate {
-			mostRestrictive = data
+			mostRestrictive = endpoint
 			lowestRate = rate
 		}
 	}

--- a/internal/agent/ratelimiting/rate_limiting_test.go
+++ b/internal/agent/ratelimiting/rate_limiting_test.go
@@ -23,6 +23,25 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		assert.Empty(t, status.Trigger)
 	})
 
+	t.Run("no user, group or ip should not block", func(t *testing.T) {
+		rl := New()
+		key := endpointKey{Method: "GET", Route: "/api/test"}
+		rl.rateLimitingMap[key] = &endpointData{
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
+			Counts: make(map[entityKey]*slidingwindow.Window),
+		}
+
+		_ = rl.ShouldRateLimitRequest("GET", "/api/test", "", "", "")
+		_ = rl.ShouldRateLimitRequest("GET", "/api/test", "", "", "")
+		_ = rl.ShouldRateLimitRequest("GET", "/api/test", "", "", "")
+
+		status := rl.ShouldRateLimitRequest("GET", "/api/test", "", "", "")
+
+		assert.NotNil(t, status)
+		assert.False(t, status.Block)
+		assert.Empty(t, status.Trigger)
+	})
+
 	t.Run("user below threshold not blocked", func(t *testing.T) {
 		rl := New()
 		key := endpointKey{Method: "GET", Route: "/api/test"}


### PR DESCRIPTION
Unnecessary two step operation to get rate limiting config instead of just returning it directly.