### PR TITLE
Switch user to pointer to return nil when not set

### DIFF
--- a/internal/http/on_post_request.go
+++ b/internal/http/on_post_request.go
@@ -35,6 +35,6 @@ func OnPostRequest(ctx context.Context, statusCode int) {
 	apiSpec := apidiscovery.GetAPIInfo(reqCtx)
 
 	go OnRequestShutdownReporting(
-		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUser().ID, reqCtx.GetIP(), apiSpec,
+		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUserID(), reqCtx.GetIP(), apiSpec,
 	)
 }

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -24,7 +24,7 @@ type Context struct {
 	Route              string
 	executedMiddleware bool
 
-	user           aikido_types.User
+	user           *aikido_types.User
 	rateLimitGroup string
 
 	deferredAttack *DeferredAttack
@@ -39,18 +39,27 @@ func (ctx *Context) GetUserAgent() string {
 	return "unknown"
 }
 
-func (ctx *Context) SetUser(user aikido_types.User) {
+func (ctx *Context) SetUser(user *aikido_types.User) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
 
 	ctx.user = user
 }
 
-func (ctx *Context) GetUser() aikido_types.User {
+func (ctx *Context) GetUser() *aikido_types.User {
 	ctx.mu.RLock()
 	defer ctx.mu.RUnlock()
 
 	return ctx.user
+}
+
+func (ctx *Context) GetUserID() string {
+	user := ctx.GetUser()
+	if user == nil {
+		return ""
+	}
+
+	return user.ID
 }
 
 func (ctx *Context) SetRateLimitGroup(id string) {

--- a/internal/request/context_test.go
+++ b/internal/request/context_test.go
@@ -58,12 +58,26 @@ func TestContext_SetUser_GetUser(t *testing.T) {
 	ctx := &Context{}
 
 	// Test initial state
-	assert.Empty(t, ctx.GetUser().ID)
+	assert.Nil(t, ctx.GetUser())
 
 	// Test setting user
-	user := aikido_types.User{ID: "user123", Name: "Test User"}
+	user := &aikido_types.User{ID: "user123", Name: "Test User"}
 	ctx.SetUser(user)
-	assert.Equal(t, aikido_types.User{ID: "user123", Name: "Test User"}, ctx.GetUser())
+	assert.Equal(t, &aikido_types.User{ID: "user123", Name: "Test User"}, ctx.GetUser())
+}
+
+func TestContext_GetUserID(t *testing.T) {
+	ctx := &Context{}
+
+	// If no user is set, then should return empty string
+	assert.Empty(t, ctx.GetUserID())
+
+	ctx.SetUser(&aikido_types.User{
+		ID:   "user123",
+		Name: "Test User",
+	})
+
+	assert.Equal(t, "user123", ctx.GetUserID())
 }
 
 func TestContext_SetRateLimitGroup_GetRateLimitGroup(t *testing.T) {

--- a/internal/vulnerabilities/attack.go
+++ b/internal/vulnerabilities/attack.go
@@ -77,7 +77,7 @@ func getAttackDetected(ctx context.Context, res InterceptorResult) *agent.Detect
 			Path:      res.PathToPayload,
 			Payload:   res.Payload,
 			Metadata:  maps.Clone(res.Metadata),
-			User:      &user,
+			User:      user,
 		},
 	}
 }

--- a/zen/set_user.go
+++ b/zen/set_user.go
@@ -28,7 +28,7 @@ func SetUser(ctx context.Context, id string, name string) (context.Context, erro
 	}
 
 	user := agent.OnUser(id, name, reqCtx.GetIP())
-	reqCtx.SetUser(user)
+	reqCtx.SetUser(&user)
 
 	return ctx, nil
 }

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -60,8 +60,8 @@ func TestSetUser(t *testing.T) {
 		reqCtx := request.GetContext(resultCtx)
 		require.NotNil(t, reqCtx, "Expected request context to exist")
 
-		userID := reqCtx.GetUser().ID
-		assert.Empty(t, userID, "Expected user ID to be empty")
+		user := reqCtx.GetUser()
+		assert.Nil(t, user, "Expected user to be nil")
 	})
 
 	t.Run("EmptyName", func(t *testing.T) {
@@ -84,8 +84,8 @@ func TestSetUser(t *testing.T) {
 		reqCtx := request.GetContext(resultCtx)
 		require.NotNil(t, reqCtx, "Expected request context to exist")
 
-		userID := reqCtx.GetUser().ID
-		assert.Empty(t, userID, "Expected user ID to be empty")
+		user := reqCtx.GetUser()
+		assert.Nil(t, user, "Expected user to be nil")
 	})
 
 	t.Run("NilRequestContext", func(t *testing.T) {
@@ -126,8 +126,8 @@ func TestSetUser(t *testing.T) {
 		require.NoError(t, err)
 
 		// User should not be set
-		userID := reqCtx.GetUser().ID
-		assert.Empty(t, userID, "Expected user ID to be empty when middleware already executed")
+		user := reqCtx.GetUser()
+		assert.Nil(t, user, "Expected user to be nil")
 	})
 
 	t.Run("UserAvailableImmediatelyForAttackDetection", func(t *testing.T) {

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -18,14 +18,14 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 
 	agent.OnMiddlewareInstalled() // Report middleware as installed, handy for dashboard.
 	// user-blocking :
-	user := reqCtx.GetUser()
-	if config.IsUserBlocked(user.ID) {
-		log.Info("User is blocked!", slog.String("user", user.ID))
+	userID := reqCtx.GetUserID()
+	if config.IsUserBlocked(userID) {
+		log.Info("User is blocked!", slog.String("user", userID))
 		return &BlockResponse{"blocked", "user", nil}
 	}
 
 	rateLimitingStatus := agent.GetRateLimitingStatus(
-		reqCtx.Method, reqCtx.Route, reqCtx.GetUser().ID, reqCtx.GetIP(), reqCtx.GetRateLimitGroup(),
+		reqCtx.Method, reqCtx.Route, userID, reqCtx.GetIP(), reqCtx.GetRateLimitGroup(),
 	)
 	if rateLimitingStatus != nil && rateLimitingStatus.Block {
 		log.Info("Request is rate-limited",


### PR DESCRIPTION
Storing user as a pointer in the context, makes more sense as this is an optional field, and prevents empty users being sent along with the attack details.

Added `GetUserID` just to remove the new for nil checks everywhere.