### PR TITLE
Remove URL from RouteMetadata

### DIFF
--- a/internal/agent/endpoints/match.go
+++ b/internal/agent/endpoints/match.go
@@ -8,9 +8,8 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 )
 
-// RouteMetadata represents a limited context with URL, method, and route.
+// RouteMetadata represents a limited context with method, and route.
 type RouteMetadata struct {
-	URL    string
 	Method string
 	Route  string
 }

--- a/internal/agent/endpoints/match_test.go
+++ b/internal/agent/endpoints/match_test.go
@@ -8,22 +8,21 @@ import (
 )
 
 // sampleRouteMetadata creates a new RouteMetadata for testing.
-func sampleRouteMetadata(url, method, route string) RouteMetadata {
+func sampleRouteMetadata(method, route string) RouteMetadata {
 	return RouteMetadata{
 		Route:  route,
-		URL:    url,
 		Method: method,
 	}
 }
 
 func TestFindMatches(t *testing.T) {
 	t.Run("testInvalidUrlAndNoRoute", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("abc", "", ""))
+		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", ""))
 		assert.Nil(t, result)
 	})
 
 	t.Run("testNoUrlAndNoRoute", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", "POST", ""))
+		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("POST", ""))
 		assert.Nil(t, result)
 	})
 
@@ -41,12 +40,12 @@ func TestFindMatches(t *testing.T) {
 				ForceProtectionOff: false,
 			},
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/posts/3", "", "/posts/:id"))
+		result := FindMatches(endpoints, sampleRouteMetadata("", "/posts/:id"))
 		assert.Nil(t, result)
 	})
 
 	t.Run("testItReturnsUndefinedIfNothingFound", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", "", ""))
+		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", ""))
 		assert.Nil(t, result)
 	})
 
@@ -65,7 +64,7 @@ func TestFindMatches(t *testing.T) {
 			},
 		}
 
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/posts/3", "POST", "/posts/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number"))
 		assert.Equal(t, endpoints, result)
 	})
 
@@ -83,7 +82,7 @@ func TestFindMatches(t *testing.T) {
 				ForceProtectionOff: false,
 			},
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("/posts/3", "POST", "/posts/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number"))
 		assert.Equal(t, endpoints, result)
 	})
 
@@ -101,7 +100,7 @@ func TestFindMatches(t *testing.T) {
 				ForceProtectionOff: false,
 			},
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/posts/3", "POST", "/posts/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number"))
 		assert.Equal(t, endpoints, result)
 	})
 
@@ -119,7 +118,7 @@ func TestFindMatches(t *testing.T) {
 				ForceProtectionOff: false,
 			},
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("/posts/3", "POST", "/posts/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number"))
 		assert.Equal(t, endpoints, result)
 	})
 
@@ -153,7 +152,7 @@ func TestFindMatches(t *testing.T) {
 			endpoints[1],
 			endpoints[0],
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/posts/3/comments/10", "POST", "/posts/:number/comments/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number/comments/:number"))
 		assert.Equal(t, expected, result)
 	})
 
@@ -171,7 +170,7 @@ func TestFindMatches(t *testing.T) {
 				ForceProtectionOff: false,
 			},
 		}
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/posts/3/comments/10", "POST", "/posts/:number/comments/:number"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/posts/:number/comments/:number"))
 		assert.Equal(t, endpoints, result)
 	})
 
@@ -206,14 +205,12 @@ func TestFindMatches(t *testing.T) {
 			endpoints[0],
 		}
 
-		result := FindMatches(endpoints, sampleRouteMetadata("http://localhost:4000/api/coach", "POST", "/api/coach"))
+		result := FindMatches(endpoints, sampleRouteMetadata("POST", "/api/coach"))
 		assert.Equal(t, expected, result)
 	})
 
 	t.Run("testItPrefersSpecificMethodOverWildcardFirstCase", func(t *testing.T) {
-		routeMetadata := sampleRouteMetadata(
-			"http://localhost:4000/api/test", "POST", "/api/test",
-		)
+		routeMetadata := sampleRouteMetadata("POST", "/api/test")
 
 		endpoints := []aikido_types.Endpoint{
 			{
@@ -249,9 +246,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItPrefersSpecificMethodOverWildcardSecondCase", func(t *testing.T) {
-		routeMetadata := sampleRouteMetadata(
-			"http://localhost:4000/api/test", "POST", "/api/test",
-		)
+		routeMetadata := sampleRouteMetadata("POST", "/api/test")
 
 		endpoints := []aikido_types.Endpoint{
 			{

--- a/internal/http/on_init_request.go
+++ b/internal/http/on_init_request.go
@@ -40,7 +40,7 @@ func OnInitRequest(ctx context.Context) *Response {
 
 	matches := endpoints.FindMatches(
 		config.GetEndpoints(),
-		endpoints.RouteMetadata{URL: reqCtx.URL, Method: reqCtx.Method, Route: reqCtx.Route},
+		endpoints.RouteMetadata{Method: reqCtx.Method, Route: reqCtx.Route},
 	)
 	// IP Allowlists per route
 	if !ipAllowedToAccessRoute(ip, matches) {

--- a/internal/vulnerabilities/scan.go
+++ b/internal/vulnerabilities/scan.go
@@ -43,7 +43,6 @@ func ScanWithOptions[T any](ctx context.Context, operation string, vulnerability
 	matches := endpoints.FindMatches(
 		config.GetEndpoints(),
 		endpoints.RouteMetadata{
-			URL:    reqCtx.URL,
 			Method: reqCtx.Method,
 			Route:  reqCtx.Route,
 		},


### PR DESCRIPTION
The full URL isn't used as part of the route matching, so removed it. 