### PR TITLE
Support CIDR in allowed IPs

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -41,7 +41,7 @@ jobs:
           sed -i '/WORKDIR \/app/a COPY firewall-go-local ./firewall-go-local' Dockerfile
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@v1.0.1
+        uses: AikidoSec/firewall-tester-action@v1.0.3
         with:
           dockerfile_path: ./zen-demo-go/Dockerfile
           app_port: 3000

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -47,4 +47,4 @@ jobs:
           app_port: 3000
           sleep_before_test: 10
           test_timeout: 900
-          skip_tests: test_stored_ssrf,test_ssrf_diffrent_port,test_ssrf,test_stored_ssrf_no_context,test_wave_attack
+          skip_tests: test_stored_ssrf,test_ssrf_diffrent_port,test_ssrf,test_stored_ssrf_no_context,test_wave_attack,test_outbound_domain_blocking,test_bypassed_ip

--- a/end2end/scripts/start-app.sh
+++ b/end2end/scripts/start-app.sh
@@ -69,7 +69,7 @@ echo "✓ App process started with PID $APP_PID"
 echo "Waiting for health check on port $PORT..."
 
 # Wait for health check
-for i in {1..120}; do
+for i in {1..180}; do
 	if curl -sf "http://localhost:$PORT" >/dev/null 2>&1; then
 		# Write both PID and PORT files after successful health check
 		echo $APP_PID >"$PID_FILE"

--- a/internal/agent/config/service_config_test.go
+++ b/internal/agent/config/service_config_test.go
@@ -625,53 +625,6 @@ func TestGetCloudConfigUpdatedAt(t *testing.T) {
 	})
 }
 
-func TestBuildIPBlocklist(t *testing.T) {
-	t.Run("builds IPv4 blocklist", func(t *testing.T) {
-		ips := []string{"192.168.1.1", "10.0.0.0/8"}
-		blocklist := buildIPMatchList("test", "Test list", ips)
-
-		assert.Equal(t, "Test list", blocklist.Description)
-		assert.NotNil(t, blocklist.TrieV4)
-		assert.NotNil(t, blocklist.TrieV6)
-	})
-
-	t.Run("builds IPv6 blocklist", func(t *testing.T) {
-		ips := []string{"2001:db8::1", "2001:db8::/32"}
-		blocklist := buildIPMatchList("test", "IPv6 list", ips)
-
-		assert.Equal(t, "IPv6 list", blocklist.Description)
-		assert.NotNil(t, blocklist.TrieV4)
-		assert.NotNil(t, blocklist.TrieV6)
-	})
-
-	t.Run("handles mixed IPv4 and IPv6", func(t *testing.T) {
-		ips := []string{"192.168.1.1", "2001:db8::1"}
-		blocklist := buildIPMatchList("mixed", "Mixed list", ips)
-
-		assert.Equal(t, "Mixed list", blocklist.Description)
-		assert.NotNil(t, blocklist.TrieV4)
-		assert.NotNil(t, blocklist.TrieV6)
-	})
-
-	t.Run("skips invalid IP addresses", func(t *testing.T) {
-		ips := []string{"192.168.1.1", "not-an-ip", "10.0.0.1"}
-		blocklist := buildIPMatchList("test", "Test", ips)
-
-		// Should not panic and should create tries
-		assert.NotNil(t, blocklist.TrieV4)
-		assert.NotNil(t, blocklist.TrieV6)
-	})
-
-	t.Run("handles empty IP list", func(t *testing.T) {
-		ips := []string{}
-		blocklist := buildIPMatchList("empty", "Empty list", ips)
-
-		assert.Equal(t, "Empty list", blocklist.Description)
-		assert.NotNil(t, blocklist.TrieV4)
-		assert.NotNil(t, blocklist.TrieV6)
-	})
-}
-
 func TestConcurrency(t *testing.T) {
 	setupTestGlobals()
 	defer resetServiceConfig()

--- a/internal/agent/endpoints/match.go
+++ b/internal/agent/endpoints/match.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
 )
 
 // RouteMetadata represents a limited context with method, and route.
@@ -16,15 +16,15 @@ type RouteMetadata struct {
 
 // FindMatches finds matching endpoints from a provided list based on the context.
 // This is the core matching logic that can be reused with any endpoint list.
-func FindMatches(endpoints []aikido_types.Endpoint, context RouteMetadata) []aikido_types.Endpoint {
-	var matches []aikido_types.Endpoint
+func FindMatches(endpoints []config.Endpoint, context RouteMetadata) []config.Endpoint {
+	var matches []config.Endpoint
 
 	if context.Method == "" {
 		return matches
 	}
 
 	// Filter possible endpoints based on method
-	var possible []aikido_types.Endpoint
+	var possible []config.Endpoint
 	for _, endpoint := range endpoints {
 		if endpoint.Method == "*" || endpoint.Method == context.Method {
 			possible = append(possible, endpoint)
@@ -46,7 +46,7 @@ func FindMatches(endpoints []aikido_types.Endpoint, context RouteMetadata) []aik
 		}
 	}
 
-	var wildcards []aikido_types.Endpoint
+	var wildcards []config.Endpoint
 
 	// Filter wildcards and sort by the number of '*' in the route
 	for _, endpoint := range possible {

--- a/internal/agent/endpoints/match_test.go
+++ b/internal/agent/endpoints/match_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,17 +19,17 @@ func sampleRouteMetadata(method, route string) RouteMetadata {
 
 func TestFindMatches(t *testing.T) {
 	t.Run("testInvalidUrlAndNoRoute", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", ""))
+		result := FindMatches([]config.Endpoint{}, sampleRouteMetadata("", ""))
 		assert.Nil(t, result)
 	})
 
 	t.Run("testNoUrlAndNoRoute", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("POST", ""))
+		result := FindMatches([]config.Endpoint{}, sampleRouteMetadata("POST", ""))
 		assert.Nil(t, result)
 	})
 
 	t.Run("testNoMethod", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "POST",
 				Route:  "/posts/:number",
@@ -36,7 +38,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -45,12 +47,12 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItReturnsUndefinedIfNothingFound", func(t *testing.T) {
-		result := FindMatches([]aikido_types.Endpoint{}, sampleRouteMetadata("", ""))
+		result := FindMatches([]config.Endpoint{}, sampleRouteMetadata("", ""))
 		assert.Nil(t, result)
 	})
 
 	t.Run("testItReturnsEndpointBasedOnRoute", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "POST",
 				Route:  "/posts/:number",
@@ -59,7 +61,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -69,7 +71,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItReturnsEndpointBasedOnRelativeUrl", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "POST",
 				Route:  "/posts/:number",
@@ -78,7 +80,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -87,7 +89,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItReturnsEndpointBasedOnWildcard", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "*",
 				Route:  "/posts/*",
@@ -96,7 +98,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -105,7 +107,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItReturnsEndpointBasedOnWildcardWithRelativeUrl", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "*",
 				Route:  "/posts/*",
@@ -114,7 +116,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -123,7 +125,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItFavorsMoreSpecificWildcard", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "*",
 				Route:  "/posts/*",
@@ -132,7 +134,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 			{
@@ -143,12 +145,12 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
 
-		expected := []aikido_types.Endpoint{
+		expected := []config.Endpoint{
 			endpoints[1],
 			endpoints[0],
 		}
@@ -157,7 +159,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItMatchesWildcardRouteWithSpecificMethod", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "POST",
 				Route:  "/posts/*/comments/*",
@@ -166,7 +168,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    10,
 					WindowSizeInMS: 1000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
@@ -175,7 +177,7 @@ func TestFindMatches(t *testing.T) {
 	})
 
 	t.Run("testItPrefersSpecificRouteOverWildcard", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "*",
 				Route:  "/api/*",
@@ -184,7 +186,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    20,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 			{
@@ -195,12 +197,12 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    100,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
 
-		expected := []aikido_types.Endpoint{
+		expected := []config.Endpoint{
 			endpoints[1],
 			endpoints[0],
 		}
@@ -212,7 +214,7 @@ func TestFindMatches(t *testing.T) {
 	t.Run("testItPrefersSpecificMethodOverWildcardFirstCase", func(t *testing.T) {
 		routeMetadata := sampleRouteMetadata("POST", "/api/test")
 
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "*",
 				Route:  "/api/test",
@@ -221,7 +223,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    20,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 			{
@@ -232,12 +234,12 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    100,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
 
-		expected := []aikido_types.Endpoint{
+		expected := []config.Endpoint{
 			endpoints[1],
 			endpoints[0],
 		}
@@ -248,7 +250,7 @@ func TestFindMatches(t *testing.T) {
 	t.Run("testItPrefersSpecificMethodOverWildcardSecondCase", func(t *testing.T) {
 		routeMetadata := sampleRouteMetadata("POST", "/api/test")
 
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			{
 				Method: "POST",
 				Route:  "/api/test",
@@ -257,7 +259,7 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    100,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 			{
@@ -268,12 +270,12 @@ func TestFindMatches(t *testing.T) {
 					MaxRequests:    20,
 					WindowSizeInMS: 60000,
 				},
-				AllowedIPAddresses: []string{},
+				AllowedIPAddresses: ipaddr.MatchList{},
 				ForceProtectionOff: false,
 			},
 		}
 
-		expected := []aikido_types.Endpoint{
+		expected := []config.Endpoint{
 			endpoints[0],
 			endpoints[1],
 		}

--- a/internal/agent/ipaddr/matchlist.go
+++ b/internal/agent/ipaddr/matchlist.go
@@ -1,0 +1,55 @@
+package ipaddr
+
+import (
+	"log/slog"
+
+	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/seancfoley/ipaddress-go/ipaddr"
+)
+
+type MatchList struct {
+	Description string
+	TrieV4      *ipaddr.IPv4AddressTrie
+	TrieV6      *ipaddr.IPv6AddressTrie
+}
+
+func (list *MatchList) Matches(ip *ipaddr.IPAddress) bool {
+	if list.TrieV4 == nil || list.TrieV6 == nil {
+		return false
+	}
+
+	if (ip.IsIPv4() && list.TrieV4.ElementContains(ip.ToIPv4())) ||
+		(ip.IsIPv6() && list.TrieV6.ElementContains(ip.ToIPv6())) {
+		return true
+	}
+
+	return false
+}
+
+func BuildMatchList(name, description string, ipsList []string) MatchList {
+	ipBlocklist := MatchList{
+		Description: description,
+		TrieV4:      &ipaddr.IPv4AddressTrie{},
+		TrieV6:      &ipaddr.IPv6AddressTrie{},
+	}
+
+	for _, ip := range ipsList {
+		ipAddress, err := ipaddr.NewIPAddressString(ip).ToAddress()
+		if err != nil {
+			log.Info("Invalid address", slog.String("name", name), slog.String("ip", ip))
+			continue
+		}
+
+		if ipAddress.IsIPv4() {
+			ipBlocklist.TrieV4.Add(ipAddress.ToIPv4())
+		} else if ipAddress.IsIPv6() {
+			ipBlocklist.TrieV6.Add(ipAddress.ToIPv6())
+		}
+	}
+
+	return ipBlocklist
+}
+
+func Parse(ip string) (*ipaddr.IPAddress, error) {
+	return ipaddr.NewIPAddressString(ip).ToAddress()
+}

--- a/internal/agent/ipaddr/matchlist.go
+++ b/internal/agent/ipaddr/matchlist.go
@@ -11,6 +11,7 @@ type MatchList struct {
 	Description string
 	TrieV4      *ipaddr.IPv4AddressTrie
 	TrieV6      *ipaddr.IPv6AddressTrie
+	Count       int
 }
 
 func (list *MatchList) Matches(ip *ipaddr.IPAddress) bool {
@@ -33,6 +34,8 @@ func BuildMatchList(name, description string, ipsList []string) MatchList {
 		TrieV6:      &ipaddr.IPv6AddressTrie{},
 	}
 
+	count := 0
+
 	for _, ip := range ipsList {
 		ipAddress, err := ipaddr.NewIPAddressString(ip).ToAddress()
 		if err != nil {
@@ -45,7 +48,10 @@ func BuildMatchList(name, description string, ipsList []string) MatchList {
 		} else if ipAddress.IsIPv6() {
 			ipBlocklist.TrieV6.Add(ipAddress.ToIPv6())
 		}
+		count++
 	}
+
+	ipBlocklist.Count = count
 
 	return ipBlocklist
 }

--- a/internal/agent/ipaddr/matchlist_test.go
+++ b/internal/agent/ipaddr/matchlist_test.go
@@ -1,0 +1,174 @@
+package ipaddr_test
+
+import (
+	"testing"
+
+	ipaddrPkg "github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
+	"github.com/seancfoley/ipaddress-go/ipaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMatchlist(t *testing.T) {
+	t.Run("builds IPv4 blocklist", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "10.0.0.0/8"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "Test list", ips)
+
+		assert.Equal(t, "Test list", blocklist.Description)
+		assert.NotNil(t, blocklist.TrieV4)
+		assert.NotNil(t, blocklist.TrieV6)
+	})
+
+	t.Run("builds IPv6 blocklist", func(t *testing.T) {
+		ips := []string{"2001:db8::1", "2001:db8::/32"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "IPv6 list", ips)
+
+		assert.Equal(t, "IPv6 list", blocklist.Description)
+		assert.NotNil(t, blocklist.TrieV4)
+		assert.NotNil(t, blocklist.TrieV6)
+	})
+
+	t.Run("handles mixed IPv4 and IPv6", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "2001:db8::1"}
+		blocklist := ipaddrPkg.BuildMatchList("mixed", "Mixed list", ips)
+
+		assert.Equal(t, "Mixed list", blocklist.Description)
+		assert.NotNil(t, blocklist.TrieV4)
+		assert.NotNil(t, blocklist.TrieV6)
+	})
+
+	t.Run("skips invalid IP addresses", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "not-an-ip", "10.0.0.1"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "Test", ips)
+
+		// Should not panic and should create tries
+		assert.NotNil(t, blocklist.TrieV4)
+		assert.NotNil(t, blocklist.TrieV6)
+	})
+
+	t.Run("handles empty IP list", func(t *testing.T) {
+		ips := []string{}
+		blocklist := ipaddrPkg.BuildMatchList("empty", "Empty list", ips)
+
+		assert.Equal(t, "Empty list", blocklist.Description)
+		assert.NotNil(t, blocklist.TrieV4)
+		assert.NotNil(t, blocklist.TrieV6)
+	})
+}
+
+func TestMatchList_Matches(t *testing.T) {
+	t.Run("matches IPv4 address in blocklist", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "10.0.0.0/8"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "Test list", ips)
+
+		// Test exact match
+		ip, err := ipaddr.NewIPAddressString("192.168.1.1").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ip))
+
+		// Test CIDR match
+		ip, err = ipaddr.NewIPAddressString("10.5.5.5").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ip))
+	})
+
+	t.Run("matches IPv6 address in blocklist", func(t *testing.T) {
+		ips := []string{"2001:db8::1", "2001:db8::/32"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "IPv6 list", ips)
+
+		// Test exact match
+		ip, err := ipaddr.NewIPAddressString("2001:db8::1").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ip))
+
+		// Test CIDR match
+		ip, err = ipaddr.NewIPAddressString("2001:db8:1::1").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ip))
+	})
+
+	t.Run("returns false for non-matching IP", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "10.0.0.0/8"}
+		blocklist := ipaddrPkg.BuildMatchList("test", "Test list", ips)
+
+		ip, err := ipaddr.NewIPAddressString("172.16.0.1").ToAddress()
+		require.NoError(t, err)
+		assert.False(t, blocklist.Matches(ip))
+	})
+
+	t.Run("returns false when tries are nil", func(t *testing.T) {
+		blocklist := ipaddrPkg.MatchList{
+			Description: "Empty list",
+			TrieV4:      nil,
+			TrieV6:      nil,
+		}
+
+		ip, err := ipaddr.NewIPAddressString("192.168.1.1").ToAddress()
+		require.NoError(t, err)
+		assert.False(t, blocklist.Matches(ip))
+	})
+
+	t.Run("handles mixed IPv4 and IPv6 blocklist", func(t *testing.T) {
+		ips := []string{"192.168.1.1", "2001:db8::1"}
+		blocklist := ipaddrPkg.BuildMatchList("mixed", "Mixed list", ips)
+
+		// Test IPv4 match
+		ipv4, err := ipaddr.NewIPAddressString("192.168.1.1").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ipv4))
+
+		// Test IPv6 match
+		ipv6, err := ipaddr.NewIPAddressString("2001:db8::1").ToAddress()
+		require.NoError(t, err)
+		assert.True(t, blocklist.Matches(ipv6))
+
+		// Test non-match
+		ipNoMatch, err := ipaddr.NewIPAddressString("10.0.0.1").ToAddress()
+		require.NoError(t, err)
+		assert.False(t, blocklist.Matches(ipNoMatch))
+	})
+}
+
+func TestParse(t *testing.T) {
+	t.Run("parses valid IPv4 address", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("192.168.1.1")
+		assert.NoError(t, err)
+		assert.NotNil(t, ip)
+		assert.True(t, ip.IsIPv4())
+		assert.Equal(t, "192.168.1.1", ip.String())
+	})
+
+	t.Run("parses valid IPv6 address", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("2001:db8::1")
+		assert.NoError(t, err)
+		assert.NotNil(t, ip)
+		assert.True(t, ip.IsIPv6())
+		assert.Equal(t, "2001:db8::1", ip.String())
+	})
+
+	t.Run("parses IPv4 CIDR notation", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("192.168.1.0/24")
+		assert.NoError(t, err)
+		assert.NotNil(t, ip)
+		assert.True(t, ip.IsIPv4())
+	})
+
+	t.Run("parses IPv6 CIDR notation", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("2001:db8::/32")
+		assert.NoError(t, err)
+		assert.NotNil(t, ip)
+		assert.True(t, ip.IsIPv6())
+	})
+
+	t.Run("returns error for invalid IP address", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("not-an-ip")
+		assert.Error(t, err)
+		assert.Nil(t, ip)
+	})
+
+	t.Run("returns error for malformed IP", func(t *testing.T) {
+		ip, err := ipaddrPkg.Parse("192.168.1.256")
+		assert.Error(t, err)
+		assert.Nil(t, ip)
+	})
+}

--- a/internal/agent/ratelimiting/rate_limiting.go
+++ b/internal/agent/ratelimiting/rate_limiting.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 	"github.com/AikidoSec/firewall-go/internal/log"
@@ -159,9 +159,9 @@ func (rl *RateLimiter) checkEntity(method string, route string, kind entityKind,
 // 1. Checks for exact route match first
 // 2. If no exact match, selects the most restrictive rate (lowest maxRequests / windowSizeInMS)
 func (rl *RateLimiter) findMatchingRateLimitEndpoint(method string, route string) *endpointData {
-	var endpointList []aikido_types.Endpoint
+	var endpointList []config.Endpoint
 	for key := range rl.rateLimitingMap {
-		endpointList = append(endpointList, aikido_types.Endpoint{
+		endpointList = append(endpointList, config.Endpoint{
 			Method: key.Method,
 			Route:  key.Route,
 		})

--- a/internal/http/ip_allowed_to_access_route.go
+++ b/internal/http/ip_allowed_to_access_route.go
@@ -36,6 +36,8 @@ func ipAllowed(remoteAddress string, endpoint config.Endpoint) bool {
 		return false
 	}
 
+	// If there are no allowed IPs configured (or they are all invalid)
+	// then, all IPs are allowed to access this endpoint.
 	if endpoint.AllowedIPAddresses.Count == 0 {
 		return true
 	}

--- a/internal/http/ip_allowed_to_access_route_test.go
+++ b/internal/http/ip_allowed_to_access_route_test.go
@@ -3,16 +3,17 @@ package http
 import (
 	"testing"
 
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
 	"github.com/stretchr/testify/assert"
 )
 
 // genEndpoint creates a new Endpoint for testing.
-func genEndpoint(allowedIPAddresses []string) aikido_types.Endpoint {
-	return aikido_types.Endpoint{
+func genEndpoint(allowedIPAddresses []string) config.Endpoint {
+	return config.Endpoint{
 		Method:             "POST",
 		Route:              "/posts/:id",
-		AllowedIPAddresses: allowedIPAddresses,
+		AllowedIPAddresses: ipaddr.BuildMatchList("", "", allowedIPAddresses),
 		ForceProtectionOff: true,
 	}
 }
@@ -20,51 +21,51 @@ func genEndpoint(allowedIPAddresses []string) aikido_types.Endpoint {
 func TestIPAccessController(t *testing.T) {
 	t.Run("testEmptyEndpoints", func(t *testing.T) {
 		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", nil))
-		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", []aikido_types.Endpoint{}))
+		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", []config.Endpoint{}))
 	})
 
 	t.Run("testAlwaysAllowsRequestIfNotProduction", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.True(t, ipAllowedToAccessRoute("::1", endpoints))
 	})
 
 	t.Run("testAlwaysAllowsRequestIfNoMatch", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", endpoints))
 	})
 
 	t.Run("testAlwaysAllowsRequestIfAllowedIpAddress", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", endpoints))
 	})
 
 	t.Run("testAlwaysAllowsRequestIfLocalhost", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.True(t, ipAllowedToAccessRoute("::1", endpoints))
 	})
 
 	t.Run("testBlocksRequestIfNoIpAddress", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.False(t, ipAllowedToAccessRoute("", endpoints))
 	})
 
 	t.Run("testAllowsRequestIfConfigurationIsBroken", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{})} // Broken configuration
+		endpoints := []config.Endpoint{genEndpoint([]string{})} // Broken configuration
 		assert.True(t, ipAllowedToAccessRoute("3.4.5.6", endpoints))
 	})
 
 	t.Run("testAllowsRequestIfAllowedIpAddressesIsEmpty", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{})}
+		endpoints := []config.Endpoint{genEndpoint([]string{})}
 		assert.True(t, ipAllowedToAccessRoute("3.4.5.6", endpoints))
 	})
 
 	t.Run("testBlocksRequestIfNotAllowedIpAddress", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{genEndpoint([]string{"1.2.3.4"})}
+		endpoints := []config.Endpoint{genEndpoint([]string{"1.2.3.4"})}
 		assert.False(t, ipAllowedToAccessRoute("3.4.5.6", endpoints))
 	})
 
 	t.Run("testChecksEveryMatchingEndpoint", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			genEndpoint([]string{"3.4.5.6"}),
 			genEndpoint([]string{"1.2.3.4"}),
 		}
@@ -72,7 +73,7 @@ func TestIPAccessController(t *testing.T) {
 	})
 
 	t.Run("testIfAllowedIpsIsEmptyOrBroken", func(t *testing.T) {
-		endpoints := []aikido_types.Endpoint{
+		endpoints := []config.Endpoint{
 			genEndpoint([]string{}),
 			genEndpoint([]string{}), // Broken configuration
 			genEndpoint(nil),        // Broken configuration
@@ -81,5 +82,53 @@ func TestIPAccessController(t *testing.T) {
 
 		assert.True(t, ipAllowedToAccessRoute("1.2.3.4", endpoints))
 		assert.False(t, ipAllowedToAccessRoute("3.4.5.6", endpoints))
+	})
+
+	t.Run("testCIDRIPv4Ranges", func(t *testing.T) {
+		endpoints := []config.Endpoint{genEndpoint([]string{"192.168.1.0/24"})}
+
+		// IPs within the CIDR range should be allowed
+		assert.True(t, ipAllowedToAccessRoute("192.168.1.1", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("192.168.1.100", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("192.168.1.254", endpoints))
+
+		// IPs outside the CIDR range should be blocked
+		assert.False(t, ipAllowedToAccessRoute("192.168.2.1", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("10.0.0.1", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("172.16.0.1", endpoints))
+	})
+
+	t.Run("testCIDRIPv6Ranges", func(t *testing.T) {
+		endpoints := []config.Endpoint{genEndpoint([]string{"2001:db8::/32"})}
+
+		// IPs within the CIDR range should be allowed
+		assert.True(t, ipAllowedToAccessRoute("2001:db8::1", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("2001:db8:1::1", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("2001:db8:ffff::ffff", endpoints))
+
+		// IPs outside the CIDR range should be blocked
+		assert.False(t, ipAllowedToAccessRoute("2001:db9::1", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("2001:0db7::1", endpoints))
+	})
+
+	t.Run("testMixedCIDRAndIndividualIPs", func(t *testing.T) {
+		endpoints := []config.Endpoint{genEndpoint([]string{
+			"192.168.1.0/24", // CIDR range
+			"10.0.0.1",       // Individual IP
+			"2001:db8::/32",  // IPv6 CIDR range
+			"::1",            // IPv6 individual IP (localhost)
+		})}
+
+		// Should allow IPs within CIDR ranges
+		assert.True(t, ipAllowedToAccessRoute("192.168.1.50", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("10.0.0.1", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("2001:db8:1234::5678", endpoints))
+		assert.True(t, ipAllowedToAccessRoute("::1", endpoints))
+
+		// Should block IPs not in any range
+		assert.False(t, ipAllowedToAccessRoute("192.168.2.1", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("10.0.0.2", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("2001:db9::1", endpoints))
+		assert.False(t, ipAllowedToAccessRoute("::2", endpoints))
 	})
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido Security
* **🚀 New Features**
  * Added IP matchlist utility supporting CIDR and ranges

* **⚡ Enhancements**
  * Allowed-IP checking now parses addresses and matches CIDRs
  * Updated CI QA workflow to newer tester and skip tests

* **🔧 Refactors**
  * Reworked endpoint/config types to embed structured MatchList objects
  * Adjusted rate limiting and endpoint matching to use new types
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->