### PR TITLE
Add rate limited stats to heartbeat

### DIFF
--- a/internal/agent/aikido_types/events.go
+++ b/internal/agent/aikido_types/events.go
@@ -44,6 +44,7 @@ type Requests struct {
 	Total           int             `json:"total"`
 	Aborted         int             `json:"aborted"`
 	AttacksDetected AttacksDetected `json:"attacksDetected"`
+	RateLimited     int             `json:"rateLimited"`
 }
 
 type Stats struct {

--- a/internal/agent/state/stats/stats.go
+++ b/internal/agent/state/stats/stats.go
@@ -15,6 +15,7 @@ type Stats struct {
 	startedAt            int64
 	requests             int
 	requestsAborted      int
+	requestsRateLimited  int
 	attacks              int
 	attacksBlocked       int
 	monitoredSinkTimings map[string]aikido_types.MonitoredSinkTimings
@@ -42,6 +43,7 @@ func (s *Stats) GetAndClear() aikido_types.Stats {
 				Total:   s.attacks,
 				Blocked: s.attacksBlocked,
 			},
+			RateLimited: s.requestsRateLimited,
 		},
 		Sinks: s.getAndClearSinks(),
 	}
@@ -49,6 +51,7 @@ func (s *Stats) GetAndClear() aikido_types.Stats {
 	s.startedAt = utils.GetTime()
 	s.requests = 0
 	s.requestsAborted = 0
+	s.requestsRateLimited = 0
 	s.attacks = 0
 	s.attacksBlocked = 0
 
@@ -122,4 +125,11 @@ func (s *Stats) OnSinkStats(sink string, stats *aikido_types.MonitoredSinkTiming
 	monitoredSinkTimings.Timings = append(monitoredSinkTimings.Timings, stats.Timings...)
 
 	s.monitoredSinkTimings[sink] = monitoredSinkTimings
+}
+
+func (s *Stats) OnRateLimit() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.requestsRateLimited++
 }

--- a/internal/agent/state/stats/stats_test.go
+++ b/internal/agent/state/stats/stats_test.go
@@ -266,3 +266,27 @@ func TestOnSinkStats(t *testing.T) {
 		assert.Equal(t, 3.0, sinkStats.CompressedTimings[0].AverageInMS, "Average should be calculated from all timings")
 	})
 }
+
+func TestOnRateLimited(t *testing.T) {
+	t.Run("increments rate limited count", func(t *testing.T) {
+		stats := New()
+
+		stats.OnRateLimit()
+
+		data := stats.GetAndClear()
+
+		assert.Equal(t, 1, data.Requests.RateLimited, "rate limited should be incremented to 1")
+	})
+
+	t.Run("increments rate limited count multiple times", func(t *testing.T) {
+		stats := New()
+
+		stats.OnRateLimit()
+		stats.OnRateLimit()
+		stats.OnRateLimit()
+
+		data := stats.GetAndClear()
+
+		assert.Equal(t, 3, data.Requests.RateLimited, "rate limited should be incremented to 3")
+	})
+}

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -28,6 +28,8 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 		reqCtx.Method, reqCtx.Route, userID, reqCtx.GetIP(), reqCtx.GetRateLimitGroup(),
 	)
 	if rateLimitingStatus != nil && rateLimitingStatus.Block {
+		go agent.Stats().OnRateLimit()
+
 		log.Info("Request is rate-limited",
 			slog.String("ip", reqCtx.GetIP()), slog.String("trigger", rateLimitingStatus.Trigger))
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido Security
**🚀 New Features**
* Added rate-limited counter to stats and types.

**⚡ Enhancements**
* Emitted rate-limited metric in heartbeat and incremented on block.
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->