### PR TITLE
Add support for inject declarations

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -54,9 +54,7 @@ func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, too
 
 	// After successful compile, if we have link-time dependencies, record them
 	// in a sidecar file next to the archive. The linker will read these later.
-	if len(allLinkDeps) > 0 {
-		writeLinkDepsForArchive(stderr, outputPath, allLinkDeps)
-	}
+	writeLinkDepsForArchive(stderr, outputPath, allLinkDeps)
 
 	return nil
 }

--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -114,7 +114,7 @@ func getObjDir(outputPath string) string {
 func instrumentFiles(stderr io.Writer, toolArgs []string, pkgPath, objdir string) ([]string, map[string]string, []string, error) {
 	newArgs := make([]string, 0, len(toolArgs))
 	allAddedImports := make(map[string]string) // alias -> import path
-	var allLinkDeps []string
+	var allAddedLinkDeps []string
 	instrumentor, err := internal.NewInstrumentor()
 	if err != nil {
 		return nil, nil, nil, err
@@ -144,8 +144,8 @@ func instrumentFiles(stderr io.Writer, toolArgs []string, pkgPath, objdir string
 		// zengin -> github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
 		maps.Copy(allAddedImports, result.Imports)
 
-		// Collect link dependencies
-		allLinkDeps = append(allLinkDeps, result.LinkDeps...)
+		// Collect link dependencies from each file to pass to the linker later
+		allAddedLinkDeps = append(allAddedLinkDeps, result.LinkDeps...)
 
 		tempFile, err := writeTempFile(arg, result.Code, objdir)
 		if err != nil {
@@ -166,7 +166,7 @@ func instrumentFiles(stderr io.Writer, toolArgs []string, pkgPath, objdir string
 		}
 	}
 
-	return newArgs, allAddedImports, allLinkDeps, nil
+	return newArgs, allAddedImports, allAddedLinkDeps, nil
 }
 
 func updateImportcfgInArgs(stderr io.Writer, args []string, importcfgPath string, addedImports map[string]string, objdir string) ([]string, error) {

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -77,6 +77,7 @@ func collectLinkDeps(importcfgContent []byte, stderr io.Writer) map[string]bool 
 		archivePath := parts[1]
 		deps, err := internal.ReadLinkDeps(archivePath)
 		if err != nil {
+			fmt.Fprintf(stderr, "zen-go: warning: could not read linkdeps: %v\n", err)
 			continue
 		}
 

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -9,6 +9,11 @@ import (
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal"
 )
 
+// toolexecLinkCommand is invoked by Go's -toolexec flag when linking.
+// Example args:
+//
+//	tool: "/usr/local/go/pkg/tool/darwin_arm64/link"
+//	toolArgs: ["-o", "/path/to/output", "-importcfg", "/tmp/importcfg", "-buildmode=exe", "main.a"]
 func toolexecLinkCommand(_ io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
 	importcfgPath := extractLinkerImportcfg(toolArgs)
 	if importcfgPath == "" {

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal"
+)
+
+func toolexecLinkCommand(_ io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
+	importcfgPath := extractLinkerImportcfg(toolArgs)
+	if importcfgPath == "" {
+		return passthrough(tool, toolArgs)
+	}
+
+	if isDebug() {
+		fmt.Fprintf(stderr, "zen-go: intercepting linker\n")
+	}
+
+	// Read the importcfg to find all archives
+	content, err := os.ReadFile(importcfgPath)
+	if err != nil {
+		return passthrough(tool, toolArgs)
+	}
+
+	// Collect all link deps from all archives
+	allLinkDeps := collectLinkDeps(content, stderr)
+	if len(allLinkDeps) == 0 {
+		return passthrough(tool, toolArgs)
+	}
+
+	// Check which deps are missing from importcfg and get their export paths
+	newLines := resolveMissingDeps(content, allLinkDeps, stderr)
+	if len(newLines) == 0 {
+		return passthrough(tool, toolArgs)
+	}
+
+	// Write new importcfg with additional dependencies
+	newImportcfgPath, err := writeExtendedLinkerImportcfg(content, newLines)
+	if err != nil {
+		fmt.Fprintf(stderr, "zen-go: warning: failed to write extended importcfg: %v\n", err)
+		return passthrough(tool, toolArgs)
+	}
+	defer os.Remove(newImportcfgPath)
+
+	// Update args with new importcfg
+	newArgs := replaceLinkerImportcfgArg(toolArgs, newImportcfgPath)
+
+	return passthrough(tool, newArgs)
+}
+
+func extractLinkerImportcfg(args []string) string {
+	for i := range len(args) {
+		if val, ok := extractFlag(args, i, "-importcfg"); ok {
+			return val
+		}
+	}
+	return ""
+}
+
+func collectLinkDeps(importcfgContent []byte, stderr io.Writer) map[string]bool {
+	allLinkDeps := make(map[string]bool)
+	lines := strings.Split(string(importcfgContent), "\n")
+
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "packagefile ") {
+			continue
+		}
+
+		parts := strings.SplitN(strings.TrimPrefix(line, "packagefile "), "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		archivePath := parts[1]
+		deps, err := internal.ReadLinkDeps(archivePath)
+		if err != nil {
+			continue
+		}
+
+		if len(deps) > 0 {
+			for _, dep := range deps {
+				allLinkDeps[dep] = true
+			}
+			if isDebug() {
+				fmt.Fprintf(stderr, "zen-go: found link deps in %s: %v\n", parts[0], deps)
+			}
+		}
+	}
+
+	return allLinkDeps
+}
+
+func resolveMissingDeps(importcfgContent []byte, allLinkDeps map[string]bool, stderr io.Writer) []string {
+	// Parse existing packages in importcfg
+	existing := make(map[string]bool)
+	lines := strings.Split(string(importcfgContent), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "packagefile ") {
+			parts := strings.SplitN(strings.TrimPrefix(line, "packagefile "), "=", 2)
+			if len(parts) == 2 {
+				existing[parts[0]] = true
+			}
+		}
+	}
+
+	// Find missing deps and resolve their export paths
+	var newLines []string
+	for dep := range allLinkDeps {
+		if existing[dep] {
+			if isDebug() {
+				fmt.Fprintf(stderr, "zen-go: link dep %s already in importcfg\n", dep)
+			}
+			continue
+		}
+
+		exportPath, err := internal.GetPackageExport(dep)
+		if err != nil {
+			fmt.Fprintf(stderr, "zen-go: warning: could not find export for link dep %s: %v\n", dep, err)
+			continue
+		}
+
+		newLines = append(newLines, fmt.Sprintf("packagefile %s=%s", dep, exportPath))
+		if isDebug() {
+			fmt.Fprintf(stderr, "zen-go: adding link dep to importcfg: %s=%s\n", dep, exportPath)
+		}
+	}
+
+	return newLines
+}
+
+func writeExtendedLinkerImportcfg(originalContent []byte, newLines []string) (string, error) {
+	newContent := string(originalContent)
+	if !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+	newContent += strings.Join(newLines, "\n") + "\n"
+
+	tmpFile, err := os.CreateTemp("", "importcfg_link_*.txt")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := tmpFile.WriteString(newContent); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		return "", err
+	}
+	tmpFile.Close()
+
+	if isDebug() {
+		fmt.Fprintf(os.Stderr, "zen-go: wrote extended linker importcfg to %s\n", tmpFile.Name())
+	}
+
+	return tmpFile.Name(), nil
+}
+
+func replaceLinkerImportcfgArg(args []string, newPath string) []string {
+	result := make([]string, len(args))
+	copy(result, args)
+
+	for i := range len(result) {
+		if result[i] == "-importcfg" && i+1 < len(result) {
+			result[i+1] = newPath
+			return result
+		}
+		if strings.HasPrefix(result[i], "-importcfg=") {
+			result[i] = "-importcfg=" + newPath
+			return result
+		}
+	}
+	return result
+}
+
+// writeLinkDepsForArchive writes link dependencies for the compiled archive if any exist.
+func writeLinkDepsForArchive(stderr io.Writer, outputPath string, linkDeps []string) {
+	if len(linkDeps) == 0 {
+		return
+	}
+
+	if outputPath == "" {
+		return
+	}
+
+	// Only write if the output file exists (it should after successful compilation)
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		return
+	}
+
+	if err := internal.WriteLinkDeps(outputPath, linkDeps, stderr, isDebug()); err != nil {
+		fmt.Fprintf(stderr, "zen-go: warning: failed to write link deps: %v\n", err)
+	}
+}

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -36,7 +36,10 @@ func toolexecLinkCommand(_ io.Writer, stderr io.Writer, tool string, toolArgs []
 		return passthrough(tool, toolArgs)
 	}
 
-	// Check which deps are missing from importcfg and get their export paths
+	// Find deps we introduced that aren't in the original importcfg.
+	// Example: if we injected a go:linkname pointing to
+	// github.com/AikidoSec/firewall-go/instrumentation/sinks/os,
+	// that package won't be in the importcfg unless the app already used it.
 	newLines := resolveMissingDeps(content, allLinkDeps, stderr)
 	if len(newLines) == 0 {
 		return passthrough(tool, toolArgs)

--- a/cmd/zen-go/cmd_toolexec_link_test.go
+++ b/cmd/zen-go/cmd_toolexec_link_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractLinkerImportcfg(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "flag with space separator",
+			args:     []string{"-o", "output", "-importcfg", "/path/to/importcfg"},
+			expected: "/path/to/importcfg",
+		},
+		{
+			name:     "flag with equals separator",
+			args:     []string{"-o=output", "-importcfg=/path/to/importcfg"},
+			expected: "/path/to/importcfg",
+		},
+		{
+			name:     "no importcfg flag",
+			args:     []string{"-o", "output", "-L", "/lib"},
+			expected: "",
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractLinkerImportcfg(tt.args)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCollectLinkDeps(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create mock archive files with link deps
+	archive1 := filepath.Join(tmpDir, "pkg1.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive1, []byte{}, 0o644))
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive1+".linkdeps", []byte("github.com/example/dep1\ngithub.com/example/dep2"), 0o644))
+
+	archive2 := filepath.Join(tmpDir, "pkg2.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive2, []byte{}, 0o644))
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive2+".linkdeps", []byte("github.com/example/dep2\ngithub.com/example/dep3"), 0o644))
+
+	// Archive without link deps
+	archive3 := filepath.Join(tmpDir, "pkg3.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive3, []byte{}, 0o644))
+
+	importcfgContent := []byte("# import config\n" +
+		"packagefile pkg1=" + archive1 + "\n" +
+		"packagefile pkg2=" + archive2 + "\n" +
+		"packagefile pkg3=" + archive3 + "\n")
+
+	deps := collectLinkDeps(importcfgContent, os.Stderr)
+
+	assert.Len(t, deps, 3)
+	assert.True(t, deps["github.com/example/dep1"])
+	assert.True(t, deps["github.com/example/dep2"])
+	assert.True(t, deps["github.com/example/dep3"])
+}
+
+func TestCollectLinkDeps_NoDeps(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	archive := filepath.Join(tmpDir, "pkg.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(archive, []byte{}, 0o644))
+
+	importcfgContent := []byte("# import config\npackagefile pkg=" + archive + "\n")
+
+	deps := collectLinkDeps(importcfgContent, os.Stderr)
+
+	assert.Empty(t, deps)
+}
+
+func TestResolveMissingDeps(t *testing.T) {
+	importcfgContent := []byte("# import config\n" +
+		"packagefile github.com/existing/pkg=/path/to/existing.a\n")
+
+	allLinkDeps := map[string]bool{
+		"github.com/existing/pkg": true, // Should be skipped
+		"github.com/missing/pkg":  true, // Would need resolution, but will fail
+	}
+
+	// This will try to resolve the missing package which will fail,
+	// so we just verify it doesn't crash and handles the error gracefully
+	newLines := resolveMissingDeps(importcfgContent, allLinkDeps, os.Stderr)
+
+	// The existing package should be skipped, and the missing one will fail to resolve
+	// so we expect either 0 or 1 entries (depending on if go list can find it)
+	assert.GreaterOrEqual(t, 1, len(newLines))
+}
+
+func TestReplaceLinkerImportcfgArg(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		newPath  string
+		expected []string
+	}{
+		{
+			name:     "space separator",
+			args:     []string{"-o", "out", "-importcfg", "/old/path", "file.a"},
+			newPath:  "/new/path",
+			expected: []string{"-o", "out", "-importcfg", "/new/path", "file.a"},
+		},
+		{
+			name:     "equals separator",
+			args:     []string{"-o=out", "-importcfg=/old/path", "file.a"},
+			newPath:  "/new/path",
+			expected: []string{"-o=out", "-importcfg=/new/path", "file.a"},
+		},
+		{
+			name:     "no importcfg",
+			args:     []string{"-o", "out", "file.a"},
+			newPath:  "/new/path",
+			expected: []string{"-o", "out", "file.a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := replaceLinkerImportcfgArg(tt.args, tt.newPath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWriteExtendedLinkerImportcfg(t *testing.T) {
+	originalContent := []byte("# import config\npackagefile fmt=/path/to/fmt.a")
+	newLines := []string{
+		"packagefile os=/path/to/os.a",
+		"packagefile io=/path/to/io.a",
+	}
+
+	tmpPath, err := writeExtendedLinkerImportcfg(originalContent, newLines)
+	require.NoError(t, err)
+	defer os.Remove(tmpPath)
+
+	content, err := os.ReadFile(tmpPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "packagefile fmt=/path/to/fmt.a")
+	assert.Contains(t, string(content), "packagefile os=/path/to/os.a")
+	assert.Contains(t, string(content), "packagefile io=/path/to/io.a")
+}
+
+func TestWriteLinkDepsForArchive_NoLinkDeps(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(outputPath, []byte{}, 0o644))
+
+	linkDeps := []string{}
+
+	// Should not create a linkdeps file
+	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
+
+	_, err := os.Stat(outputPath + ".linkdeps")
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestWriteLinkDepsForArchive_EmptyOutputPath(t *testing.T) {
+	linkDeps := []string{"github.com/example/pkg"}
+
+	// Should not panic with empty output path
+	writeLinkDepsForArchive(os.Stderr, "", linkDeps)
+}
+
+func TestWriteLinkDepsForArchive_NonExistentOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "nonexistent.a")
+
+	linkDeps := []string{"github.com/example/pkg"}
+
+	// Should not create linkdeps file if output doesn't exist
+	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
+
+	_, err := os.Stat(outputPath + ".linkdeps")
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestWriteLinkDepsForArchive_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	outputPath := filepath.Join(tmpDir, "test.a")
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(outputPath, []byte{}, 0o644))
+
+	linkDeps := []string{
+		"github.com/example/pkg1",
+		"github.com/example/pkg2",
+	}
+
+	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
+
+	content, err := os.ReadFile(outputPath + ".linkdeps")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "github.com/example/pkg1")
+	assert.Contains(t, string(content), "github.com/example/pkg2")
+}

--- a/cmd/zen-go/cmd_toolexec_link_test.go
+++ b/cmd/zen-go/cmd_toolexec_link_test.go
@@ -53,13 +53,13 @@ func TestCollectLinkDeps(t *testing.T) {
 	// #nosec G306 -- test file
 	require.NoError(t, os.WriteFile(archive1, []byte{}, 0o644))
 	// #nosec G306 -- test file
-	require.NoError(t, os.WriteFile(archive1+".linkdeps", []byte("github.com/example/dep1\ngithub.com/example/dep2"), 0o644))
+	require.NoError(t, os.WriteFile(archive1+".zenlinkdeps", []byte("github.com/example/dep1\ngithub.com/example/dep2"), 0o644))
 
 	archive2 := filepath.Join(tmpDir, "pkg2.a")
 	// #nosec G306 -- test file
 	require.NoError(t, os.WriteFile(archive2, []byte{}, 0o644))
 	// #nosec G306 -- test file
-	require.NoError(t, os.WriteFile(archive2+".linkdeps", []byte("github.com/example/dep2\ngithub.com/example/dep3"), 0o644))
+	require.NoError(t, os.WriteFile(archive2+".zenlinkdeps", []byte("github.com/example/dep2\ngithub.com/example/dep3"), 0o644))
 
 	// Archive without link deps
 	archive3 := filepath.Join(tmpDir, "pkg3.a")
@@ -176,7 +176,7 @@ func TestWriteLinkDepsForArchive_NoLinkDeps(t *testing.T) {
 	// Should not create a linkdeps file
 	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
 
-	_, err := os.Stat(outputPath + ".linkdeps")
+	_, err := os.Stat(outputPath + ".zenlinkdeps")
 	assert.True(t, os.IsNotExist(err))
 }
 
@@ -196,7 +196,7 @@ func TestWriteLinkDepsForArchive_NonExistentOutput(t *testing.T) {
 	// Should not create linkdeps file if output doesn't exist
 	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
 
-	_, err := os.Stat(outputPath + ".linkdeps")
+	_, err := os.Stat(outputPath + ".zenlinkdeps")
 	assert.True(t, os.IsNotExist(err))
 }
 
@@ -213,7 +213,7 @@ func TestWriteLinkDepsForArchive_Success(t *testing.T) {
 
 	writeLinkDepsForArchive(os.Stderr, outputPath, linkDeps)
 
-	content, err := os.ReadFile(outputPath + ".linkdeps")
+	content, err := os.ReadFile(outputPath + ".zenlinkdeps")
 	require.NoError(t, err)
 
 	assert.Contains(t, string(content), "github.com/example/pkg1")

--- a/cmd/zen-go/internal/hash.go
+++ b/cmd/zen-go/internal/hash.go
@@ -49,6 +49,19 @@ func ComputeInstrumentationHash(inst *Instrumentor) string {
 		fmt.Fprintf(h, "%s\n", rule.PrependTmpl)
 	}
 
+	// Hash inject decl rules
+	for _, rule := range inst.InjectDeclRules {
+		fmt.Fprintf(h, "inject-decl:%s:%s:%s:", rule.ID, rule.Package, rule.AnchorFunc)
+		// Sort links for consistent hashing
+		links := make([]string, len(rule.Links))
+		copy(links, rule.Links)
+		sort.Strings(links)
+		for _, link := range links {
+			fmt.Fprintf(h, "%s:", link)
+		}
+		fmt.Fprintf(h, "%s\n", rule.DeclTemplate)
+	}
+
 	// Return base64-encoded hash (first 16 chars for brevity)
 	hash := h.Sum(nil)
 	return base64.URLEncoding.EncodeToString(hash)[:16]

--- a/cmd/zen-go/internal/importcfg.go
+++ b/cmd/zen-go/internal/importcfg.go
@@ -41,7 +41,7 @@ func ExtendImportcfg(origPath string, addedImports map[string]string, objdir str
 		}
 
 		var exportPath string
-		exportPath, err = getPackageExport(importPath)
+		exportPath, err = GetPackageExport(importPath)
 		if err != nil {
 			fmt.Fprintf(stderr, "zen-go: warning: could not find export for %s: %v\n", importPath, err)
 			continue
@@ -98,7 +98,7 @@ func createTempFile(objdir string) (*os.File, error) {
 	return os.CreateTemp("", "importcfg_*.txt")
 }
 
-func getPackageExport(importPath string) (string, error) {
+func GetPackageExport(importPath string) (string, error) {
 	dir := findModuleRoot()
 
 	// Pass original build flags to packages.Load to prevent cache misses and fingerprint errors.

--- a/cmd/zen-go/internal/importcfg.go
+++ b/cmd/zen-go/internal/importcfg.go
@@ -98,6 +98,8 @@ func createTempFile(objdir string) (*os.File, error) {
 	return os.CreateTemp("", "importcfg_*.txt")
 }
 
+// GetPackageExport returns the file path to the compiled export data for the given import path.
+// It runs 'go list -export' from the module root.
 func GetPackageExport(importPath string) (string, error) {
 	dir := findModuleRoot()
 

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -119,7 +119,7 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 			continue
 		}
 
-		err := transformDeclsInjectDecl(file, fset, rule, &modified, &linksToAdd)
+		err = transformDeclsInjectDecl(file, fset, rule, &modified, &linksToAdd)
 		if err != nil {
 			return InstrumentFileResult{}, err
 		}

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -24,11 +24,7 @@ func NewInstrumentor() (*Instrumentor, error) {
 			return nil, err
 		}
 
-		return &Instrumentor{
-			WrapRules:       rules.WrapRules,
-			PrependRules:    rules.PrependRules,
-			InjectDeclRules: rules.InjectDeclRules,
-		}, nil
+		return NewInstrumentorWithRules(rules), nil
 	}
 
 	// No rules found

--- a/cmd/zen-go/internal/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor_test.go
@@ -46,7 +46,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -146,7 +146,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -199,7 +199,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestInstrumentFile_InvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "nonexistent.go")
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -230,7 +230,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(testGinRules(), nil)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -303,7 +303,7 @@ type Rows struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "database/sql")
 
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func DoSomething() {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -382,7 +382,7 @@ func (c *Cmd) Wait() error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os/exec")
 
 	require.NoError(t, err)
@@ -418,7 +418,7 @@ type File struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "main") // Compiling "main" package
 
 	require.NoError(t, err)
@@ -481,10 +481,78 @@ func (f *File) OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(nil, prependRules)
+	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
 	// Should NOT match because OpenFile is a method, not a standalone function
+	assert.False(t, result.Modified)
+}
+
+func TestInstrumentFile_InjectDeclRule(t *testing.T) {
+	src := `package os
+
+func Getpid() int {
+	return 0
+}
+
+func OpenFile(name string) error {
+	return nil
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "proc.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	injectDeclRules := []InjectDeclRule{
+		{
+			ID:         "os.linkname",
+			Package:    "os",
+			AnchorFunc: "Getpid",
+			Links:      []string{"github.com/example/sink"},
+			DeclTemplate: `//go:linkname __example_check github.com/example/sink.Check
+func __example_check(string) error`,
+		},
+	}
+
+	inst := NewInstrumentorWithRules(&InstrumentationRules{InjectDeclRules: injectDeclRules})
+	result, err := inst.InstrumentFile(tmpFile, "os")
+
+	require.NoError(t, err)
+	assert.True(t, result.Modified)
+
+	// Check that link dependency is added
+	assert.Contains(t, result.LinkDeps, "github.com/example/sink")
+
+	resultStr := string(result.Code)
+	assert.Contains(t, resultStr, "go:linkname")
+	assert.Contains(t, resultStr, "__example_check")
+	assert.Contains(t, resultStr, `"unsafe"`)
+}
+
+func TestInstrumentFile_InjectDeclRule_NoAnchor(t *testing.T) {
+	src := `package os
+
+func SomeOtherFunc() {
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "other.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	injectDeclRules := []InjectDeclRule{
+		{
+			ID:           "os.linkname",
+			Package:      "os",
+			AnchorFunc:   "Getpid", // Not in this file
+			Links:        []string{},
+			DeclTemplate: `func __test() {}`,
+		},
+	}
+
+	inst := NewInstrumentorWithRules(&InstrumentationRules{InjectDeclRules: injectDeclRules})
+	result, err := inst.InstrumentFile(tmpFile, "os")
+
+	require.NoError(t, err)
 	assert.False(t, result.Modified)
 }

--- a/cmd/zen-go/internal/linkdeps.go
+++ b/cmd/zen-go/internal/linkdeps.go
@@ -1,0 +1,49 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// WriteLinkDeps writes link-time dependencies to a sidecar file next to the archive.
+// These dependencies are packages that need to be linked into the final binary
+// but are not direct imports of the package being compiled.
+func WriteLinkDeps(archivePath string, deps []string, stderr io.Writer, debug bool) error {
+	depsFile := archivePath + ".linkdeps"
+	content := strings.Join(deps, "\n")
+	// #nosec G306 -- link deps file needs to be readable by the linker
+	if err := os.WriteFile(depsFile, []byte(content), 0o644); err != nil {
+		return err
+	}
+
+	if debug {
+		fmt.Fprintf(stderr, "zen-go: wrote link deps to %s: %v\n", depsFile, deps)
+	}
+
+	return nil
+}
+
+// ReadLinkDeps reads link-time dependencies from a sidecar file next to the archive.
+// Returns nil if the file doesn't exist (which is not an error - it means no link deps).
+func ReadLinkDeps(archivePath string) ([]string, error) {
+	depsFile := archivePath + ".linkdeps"
+	content, err := os.ReadFile(depsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var deps []string
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			deps = append(deps, line)
+		}
+	}
+	return deps, nil
+}
+

--- a/cmd/zen-go/internal/linkdeps.go
+++ b/cmd/zen-go/internal/linkdeps.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 )
 
+const linkdepsExtension = ".zenlinkdeps"
+
 // WriteLinkDeps writes link-time dependencies to a sidecar file next to the archive.
 // These dependencies are packages that need to be linked into the final binary
 // but are not direct imports of the package being compiled.
 func WriteLinkDeps(archivePath string, deps []string, stderr io.Writer, debug bool) error {
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + linkdepsExtension
 	content := strings.Join(deps, "\n")
 	// #nosec G306 -- link deps file needs to be readable by the linker
 	if err := os.WriteFile(depsFile, []byte(content), 0o644); err != nil {
@@ -28,7 +30,7 @@ func WriteLinkDeps(archivePath string, deps []string, stderr io.Writer, debug bo
 // ReadLinkDeps reads link-time dependencies from a sidecar file next to the archive.
 // Returns nil if the file doesn't exist (which is not an error - it means no link deps).
 func ReadLinkDeps(archivePath string) ([]string, error) {
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + linkdepsExtension
 	content, err := os.ReadFile(depsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -46,4 +48,3 @@ func ReadLinkDeps(archivePath string) ([]string, error) {
 	}
 	return deps, nil
 }
-

--- a/cmd/zen-go/internal/linkdeps.go
+++ b/cmd/zen-go/internal/linkdeps.go
@@ -31,6 +31,7 @@ func WriteLinkDeps(archivePath string, deps []string, stderr io.Writer, debug bo
 // Returns nil if the file doesn't exist (which is not an error - it means no link deps).
 func ReadLinkDeps(archivePath string) ([]string, error) {
 	depsFile := archivePath + linkdepsExtension
+	// #nosec G304 - depsFile is derived from archivePath which comes from Go toolchain
 	content, err := os.ReadFile(depsFile)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/zen-go/internal/linkdeps_test.go
+++ b/cmd/zen-go/internal/linkdeps_test.go
@@ -1,0 +1,117 @@
+package internal
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteLinkDeps_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+
+	deps := []string{
+		"github.com/example/pkg1",
+		"github.com/example/pkg2",
+	}
+
+	var stderr bytes.Buffer
+	err := WriteLinkDeps(archivePath, deps, &stderr, false)
+	require.NoError(t, err)
+
+	depsFile := archivePath + ".linkdeps"
+	content, err := os.ReadFile(depsFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, "github.com/example/pkg1\ngithub.com/example/pkg2", string(content))
+}
+
+func TestWriteLinkDeps_DebugOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+
+	deps := []string{"github.com/example/pkg"}
+
+	var stderr bytes.Buffer
+	err := WriteLinkDeps(archivePath, deps, &stderr, true)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "zen-go: wrote link deps to")
+	assert.Contains(t, stderr.String(), "github.com/example/pkg")
+}
+
+func TestReadLinkDeps_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+	depsFile := archivePath + ".linkdeps"
+
+	content := "github.com/example/pkg1\ngithub.com/example/pkg2\n"
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(depsFile, []byte(content), 0o644))
+
+	deps, err := ReadLinkDeps(archivePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"github.com/example/pkg1", "github.com/example/pkg2"}, deps)
+}
+
+func TestReadLinkDeps_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "nonexistent.a")
+
+	deps, err := ReadLinkDeps(archivePath)
+	require.NoError(t, err)
+	assert.Nil(t, deps)
+}
+
+func TestReadLinkDeps_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+	depsFile := archivePath + ".linkdeps"
+
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(depsFile, []byte(""), 0o644))
+
+	deps, err := ReadLinkDeps(archivePath)
+	require.NoError(t, err)
+	assert.Nil(t, deps)
+}
+
+func TestReadLinkDeps_SkipsEmptyLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+	depsFile := archivePath + ".linkdeps"
+
+	content := "github.com/example/pkg1\n\n  \ngithub.com/example/pkg2\n"
+	// #nosec G306 -- test file
+	require.NoError(t, os.WriteFile(depsFile, []byte(content), 0o644))
+
+	deps, err := ReadLinkDeps(archivePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"github.com/example/pkg1", "github.com/example/pkg2"}, deps)
+}
+
+func TestWriteAndReadLinkDeps_Roundtrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "test.a")
+
+	original := []string{
+		"github.com/AikidoSec/firewall-go/internal/agent",
+		"github.com/AikidoSec/firewall-go/internal/request",
+	}
+
+	var stderr bytes.Buffer
+	err := WriteLinkDeps(archivePath, original, &stderr, false)
+	require.NoError(t, err)
+
+	read, err := ReadLinkDeps(archivePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, original, read)
+}
+

--- a/cmd/zen-go/internal/linkdeps_test.go
+++ b/cmd/zen-go/internal/linkdeps_test.go
@@ -23,7 +23,7 @@ func TestWriteLinkDeps_Success(t *testing.T) {
 	err := WriteLinkDeps(archivePath, deps, &stderr, false)
 	require.NoError(t, err)
 
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + ".zenlinkdeps"
 	content, err := os.ReadFile(depsFile)
 	require.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestWriteLinkDeps_DebugOutput(t *testing.T) {
 func TestReadLinkDeps_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "test.a")
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + ".zenlinkdeps"
 
 	content := "github.com/example/pkg1\ngithub.com/example/pkg2\n"
 	// #nosec G306 -- test file
@@ -71,7 +71,7 @@ func TestReadLinkDeps_NoFile(t *testing.T) {
 func TestReadLinkDeps_EmptyFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "test.a")
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + ".zenlinkdeps"
 
 	// #nosec G306 -- test file
 	require.NoError(t, os.WriteFile(depsFile, []byte(""), 0o644))
@@ -84,7 +84,7 @@ func TestReadLinkDeps_EmptyFile(t *testing.T) {
 func TestReadLinkDeps_SkipsEmptyLines(t *testing.T) {
 	tmpDir := t.TempDir()
 	archivePath := filepath.Join(tmpDir, "test.a")
-	depsFile := archivePath + ".linkdeps"
+	depsFile := archivePath + ".zenlinkdeps"
 
 	content := "github.com/example/pkg1\n\n  \ngithub.com/example/pkg2\n"
 	// #nosec G306 -- test file
@@ -114,4 +114,3 @@ func TestWriteAndReadLinkDeps_Roundtrip(t *testing.T) {
 
 	assert.Equal(t, original, read)
 }
-

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -10,19 +10,7 @@ import (
 // transformDeclsInjectDecl injects declarations (like go:linkname) into a file.
 // The declaration is inserted immediately before the anchor function.
 func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclRule, modified *bool, linksToAdd *[]string) error {
-	// Find the anchor function
-	anchorIndex := -1
-	for i, decl := range f.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		if fn.Name.Name == rule.AnchorFunc {
-			anchorIndex = i
-			break
-		}
-	}
-
+	anchorIndex := findAnchorFunction(f, rule.AnchorFunc)
 	if anchorIndex == -1 {
 		return nil // Anchor function not found, skip
 	}
@@ -76,6 +64,22 @@ func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclR
 	return nil
 }
 
+func findAnchorFunction(f *ast.File, anchor string) int {
+	anchorIndex := -1
+	for i, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name.Name == anchor {
+			anchorIndex = i
+			break
+		}
+	}
+
+	return anchorIndex
+}
+
 // addUnsafeImport adds an import for "unsafe" package if not already present.
 // This is required for go:linkname directives.
 func addUnsafeImport(f *ast.File) {
@@ -114,4 +118,3 @@ func addUnsafeImport(f *ast.File) {
 		f.Decls = append([]ast.Decl{newImport}, f.Decls...)
 	}
 }
-

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -37,7 +38,7 @@ func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclR
 	}
 
 	if len(declsToInject) == 0 {
-		return nil
+		return errors.New("no declarations found in template")
 	}
 
 	// Find and associate comments with declarations

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -17,7 +17,10 @@ func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclR
 
 	// Parse the declaration template with comments
 	// We need to add "unsafe" import for go:linkname to work
-	declCode := "package p\nimport _ \"unsafe\"\n" + rule.DeclTemplate
+	declCode := `package p
+		import _ "unsafe"
+	` + rule.DeclTemplate
+
 	declFile, err := parser.ParseFile(fset, "", declCode, parser.ParseComments)
 	if err != nil {
 		return fmt.Errorf("failed to parse inject decl template for %s: %w", rule.ID, err)

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -41,8 +41,9 @@ func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclR
 		return errors.New("no declarations found in template")
 	}
 
-	// Find and associate comments with declarations
-	// Comments that appear immediately before a declaration should be preserved
+	// Copy go:linkname directive comments to the target file.
+	// Go's AST stores comments separately from declarations, so we must
+	// explicitly add them to f.Comments or they'll be lost in the output.
 	for _, decl := range declsToInject {
 		for _, cg := range declFile.Comments {
 			// Check if comment is immediately before this declaration

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -1,0 +1,117 @@
+package internal
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+)
+
+// transformDeclsInjectDecl injects declarations (like go:linkname) into a file.
+// The declaration is inserted immediately before the anchor function.
+func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclRule, modified *bool, linksToAdd *[]string) error {
+	// Find the anchor function
+	anchorIndex := -1
+	for i, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name.Name == rule.AnchorFunc {
+			anchorIndex = i
+			break
+		}
+	}
+
+	if anchorIndex == -1 {
+		return nil // Anchor function not found, skip
+	}
+
+	// Parse the declaration template with comments
+	// We need to add "unsafe" import for go:linkname to work
+	declCode := "package p\nimport _ \"unsafe\"\n" + rule.DeclTemplate
+	declFile, err := parser.ParseFile(fset, "", declCode, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("failed to parse inject decl template for %s: %w", rule.ID, err)
+	}
+
+	// Extract declarations to inject (skip import)
+	var declsToInject []ast.Decl
+	for _, decl := range declFile.Decls {
+		// Skip the import declaration, we'll handle that separately
+		if genDecl, ok := decl.(*ast.GenDecl); ok && genDecl.Tok == token.IMPORT {
+			continue
+		}
+		declsToInject = append(declsToInject, decl)
+	}
+
+	if len(declsToInject) == 0 {
+		return nil
+	}
+
+	// Find and associate comments with declarations
+	// Comments that appear immediately before a declaration should be preserved
+	for _, decl := range declsToInject {
+		for _, cg := range declFile.Comments {
+			// Check if comment is immediately before this declaration
+			if decl.Pos() > cg.Pos() && decl.Pos()-cg.End() < 100 {
+				f.Comments = append(f.Comments, cg)
+			}
+		}
+	}
+
+	// Insert declarations right before the anchor function
+	newDecls := make([]ast.Decl, 0, len(f.Decls)+len(declsToInject))
+	newDecls = append(newDecls, f.Decls[:anchorIndex]...)
+	newDecls = append(newDecls, declsToInject...)
+	newDecls = append(newDecls, f.Decls[anchorIndex:]...)
+	f.Decls = newDecls
+
+	// Add unsafe import (required for go:linkname)
+	addUnsafeImport(f)
+
+	*modified = true
+	*linksToAdd = append(*linksToAdd, rule.Links...)
+
+	return nil
+}
+
+// addUnsafeImport adds an import for "unsafe" package if not already present.
+// This is required for go:linkname directives.
+func addUnsafeImport(f *ast.File) {
+	// Check if unsafe is already imported
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"unsafe"` {
+			return
+		}
+	}
+
+	// Find or create an import declaration
+	var importDecl *ast.GenDecl
+	for _, decl := range f.Decls {
+		if genDecl, ok := decl.(*ast.GenDecl); ok && genDecl.Tok == token.IMPORT {
+			importDecl = genDecl
+			break
+		}
+	}
+
+	unsafeSpec := &ast.ImportSpec{
+		Name: ast.NewIdent("_"),
+		Path: &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: `"unsafe"`,
+		},
+	}
+
+	if importDecl != nil {
+		importDecl.Specs = append(importDecl.Specs, unsafeSpec)
+	} else {
+		// Create new import declaration
+		newImport := &ast.GenDecl{
+			Tok:   token.IMPORT,
+			Specs: []ast.Spec{unsafeSpec},
+		}
+		f.Decls = append([]ast.Decl{newImport}, f.Decls...)
+	}
+}
+

--- a/cmd/zen-go/internal/transform_prepend.go
+++ b/cmd/zen-go/internal/transform_prepend.go
@@ -11,7 +11,7 @@ import (
 )
 
 // transformDeclsPrepend finds function declarations matching the prepend rule
-// and prepends statements to the function body
+// and prepends statements to the function body.
 // Supports both methods (with receiver) and standalone functions (without receiver).
 func transformDeclsPrepend(decls []ast.Decl, compilingPkg string, rule PrependRule, modified *bool, importsToAdd map[string]string) error {
 	for _, decl := range decls {
@@ -20,7 +20,7 @@ func transformDeclsPrepend(decls []ast.Decl, compilingPkg string, rule PrependRu
 			continue
 		}
 
-		// Check if function name matches any in the list
+		// Check if function name matches any of the rule's function names
 		if !matchesFuncName(fn.Name.Name, rule.FuncNames) {
 			continue
 		}

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -51,6 +51,8 @@ func newCommand() *cli.Command {
 					switch toolName {
 					case "compile":
 						return toolexecCompileCommand(os.Stdout, os.Stderr, tool, toolArgs)
+					case "link":
+						return toolexecLinkCommand(os.Stdout, os.Stderr, tool, toolArgs)
 					default:
 						return passthrough(tool, toolArgs)
 					}

--- a/instrumentation/sinks/net/http/zen.instrument.yml
+++ b/instrumentation/sinks/net/http/zen.instrument.yml
@@ -1,0 +1,26 @@
+meta:
+  name: net/http
+  description: net/http.Client is the stdlib http client
+
+rules:
+  # Inject go:linkname declaration for Examine
+  - id: net/http.Client.linkname.Examine
+    type: inject-decl
+    package: net/http
+    anchor: Do
+    links:
+      - github.com/AikidoSec/firewall-go/instrumentation/sinks/net/http
+    template: |
+      //go:linkname __aikido_http_do github.com/AikidoSec/firewall-go/instrumentation/sinks/net/http.Examine
+      func __aikido_http_do(*Request) error
+
+  # Prepend to Client.Do
+  - id: net/http.Client.Do
+    type: prepend
+    receiver: "*net/http.Client"
+    function: Do
+    template: |
+      _aikido_err := __aikido_http_do({{ .Function.Argument 0 }})
+      if _aikido_err != nil {
+        return nil, _aikido_err
+      }

--- a/instrumentation/sources/net/http/zen.instrument.yml
+++ b/instrumentation/sources/net/http/zen.instrument.yml
@@ -1,0 +1,42 @@
+meta:
+  name: net/http
+  description: net/http.ServeMux is the stdlib request multiplexer
+
+rules:
+  # Inject go:linkname declaration for WrapHandler
+  - id: net/http.ServeMux.linkname.WrapHandler
+    type: inject-decl
+    package: net/http
+    anchor: Handle
+    links:
+      - github.com/AikidoSec/firewall-go/instrumentation/sources/net/http
+    template: |
+      //go:linkname __aikido_http_wrapHandler github.com/AikidoSec/firewall-go/instrumentation/sources/net/http.WrapHandler
+      func __aikido_http_wrapHandler(Handler) Handler
+
+  # Inject go:linkname declaration for Middleware
+  - id: net/http.ServeMux.linkname.Middleware
+    type: inject-decl
+    package: net/http
+    anchor: HandleFunc
+    links:
+      - github.com/AikidoSec/firewall-go/instrumentation/sources/net/http
+    template: |
+      //go:linkname __aikido_http_middleware github.com/AikidoSec/firewall-go/instrumentation/sources/net/http.Middleware
+      func __aikido_http_middleware(func(ResponseWriter, *Request)) func(ResponseWriter, *Request)
+
+  # Prepend to ServeMux.Handle
+  - id: net/http.ServeMux.Handle
+    type: prepend
+    receiver: "*net/http.ServeMux"
+    function: Handle
+    template: |
+      {{ .Function.Argument 1 }} = __aikido_http_wrapHandler({{ .Function.Argument 1 }})
+
+  # Prepend to ServeMux.HandleFunc
+  - id: net/http.ServeMux.HandleFunc
+    type: prepend
+    receiver: "*net/http.ServeMux"
+    function: HandleFunc
+    template: |
+      {{ .Function.Argument 1 }} = __aikido_http_middleware({{ .Function.Argument 1 }})


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 2 | 🔍 Quality Issues: 5 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added InjectDeclRule and AST transform to inject declarations before anchors.
* Introduced link-deps sidecar files and read/write helpers for archives.

**⚡ Enhancements**
* Integrated compile and link to record and resolve link-time dependencies.

**🔧 Refactors**
* Refactored Instrumentor to accept InstrumentationRules and return link metadata.

**📚 Documentation**
* Added net/http instrumentation YAML and comments explaining linkname usage.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/75261604?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->