### PR TITLE
Add defer to handle some Gin panics

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -42,11 +42,15 @@ func GetMiddleware() gin.HandlerFunc {
 			return
 		}
 
+		// Run post request in defer to still trigger it on panics
+		// It may not run depending where the recovery middleware sits in the middleware chain
+		defer func() {
+			statusCode := c.Writer.Status()
+			http.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
+		}()
+
 		request.WrapWithGLS(reqCtx, func() {
 			c.Next()
 		})
-
-		statusCode := c.Writer.Status()
-		http.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
 	}
 }


### PR DESCRIPTION
This doesn't fix post request not triggering in _all_ panics as it depends on the order of the middleware. If `gin.Default()` is used, then it will work as expected as the recover middleware is inserted before ours, so we see the panics and then can recover correctly. If the recovery middleware is setup later, then we won't trigger post request.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido Security
**⚡ Enhancements**
* Added tests to verify post-request triggers for Echo and net/http

**🐛 Bugfixes**
* Ensured Gin middleware executed post-request on panics using defer
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->