### PR TITLE
Add instance pool with max age for instances

### DIFF
--- a/internal/vulnerabilities/sqlinjection/detect_sql_injection_test.go
+++ b/internal/vulnerabilities/sqlinjection/detect_sql_injection_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal"
+	"github.com/AikidoSec/firewall-go/internal/vulnerabilities/zeninternals"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -245,7 +246,11 @@ func TestShouldReturnEarly(t *testing.T) {
 }
 
 func BenchmarkDetectSQLInjection(b *testing.B) {
+	require.NoError(b, zeninternals.Init())
+
 	tests := getBenchmarkTests()
+
+	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/internal/vulnerabilities/zeninternals/pool.go
+++ b/internal/vulnerabilities/zeninternals/pool.go
@@ -54,7 +54,10 @@ func (p *Pool) tryGetInstance() *wasmInstance {
 
 		// Check age of instance, if it's too old, we should discard it
 		if instance.createdAt.Before(time.Now().Add(-instanceMaxAge)) {
-			instance.mod.Close(context.Background())
+			if instance.mod != nil {
+				instance.mod.Close(context.Background())
+			}
+
 			return nil
 		}
 

--- a/internal/vulnerabilities/zeninternals/pool.go
+++ b/internal/vulnerabilities/zeninternals/pool.go
@@ -1,0 +1,67 @@
+package zeninternals
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+const (
+	instanceMaxAge   = 5 * time.Minute
+	maxIdleInstances = 10
+)
+
+type Pool struct {
+	newInstance   func() *wasmInstance
+	idleInstances []*wasmInstance
+
+	mu sync.Mutex
+}
+
+func NewPool(newInstance func() *wasmInstance) *Pool {
+	return &Pool{
+		newInstance:   newInstance,
+		idleInstances: make([]*wasmInstance, 0),
+	}
+}
+
+func (p *Pool) Get() (*wasmInstance, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Loop through max idle + 1 to ensure run through all available instances
+	for range maxIdleInstances + 1 {
+		instance := p.tryGetInstance()
+		if instance != nil {
+			return instance, nil
+		}
+	}
+
+	return nil, errors.New("could not acquire instance")
+}
+
+func (p *Pool) tryGetInstance() *wasmInstance {
+	if len(p.idleInstances) > 0 {
+		instance := p.idleInstances[len(p.idleInstances)-1]
+		p.idleInstances = p.idleInstances[:len(p.idleInstances)-1]
+
+		// Check health of instance
+		if instance.createdAt.Before(time.Now().Add(-instanceMaxAge)) {
+			return nil
+		}
+
+		return instance
+	}
+
+	instance := p.newInstance()
+	return instance
+}
+
+func (p *Pool) Put(instance *wasmInstance) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.idleInstances) < maxIdleInstances {
+		p.idleInstances = append(p.idleInstances, instance)
+	}
+}

--- a/internal/vulnerabilities/zeninternals/pool.go
+++ b/internal/vulnerabilities/zeninternals/pool.go
@@ -30,7 +30,8 @@ func (p *Pool) Get() (*wasmInstance, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Loop through max idle + 1 to ensure run through all available instances
+	// Loop through max idle + 1 to ensure we can loop through all potentially expired instances,
+	// and still get a new instance.
 	for range maxIdleInstances + 1 {
 		instance := p.tryGetInstance()
 		if instance != nil {

--- a/internal/vulnerabilities/zeninternals/pool_test.go
+++ b/internal/vulnerabilities/zeninternals/pool_test.go
@@ -1,0 +1,92 @@
+package zeninternals
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPool_Get_CreatesNewInstance(t *testing.T) {
+	callCount := 0
+	pool := NewPool(func() *wasmInstance {
+		callCount++
+		return &wasmInstance{createdAt: time.Now()}
+	})
+
+	instance, err := pool.Get()
+
+	require.NoError(t, err)
+	assert.NotNil(t, instance)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestPool_Get_ReusesIdleInstance(t *testing.T) {
+	callCount := 0
+	pool := NewPool(func() *wasmInstance {
+		callCount++
+		return &wasmInstance{createdAt: time.Now()}
+	})
+
+	instance1, _ := pool.Get()
+	pool.Put(instance1)
+	instance2, err := pool.Get()
+
+	require.NoError(t, err)
+	assert.Same(t, instance1, instance2)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestPool_Get_DiscardsExpiredInstance(t *testing.T) {
+	callCount := 0
+	pool := NewPool(func() *wasmInstance {
+		callCount++
+		return &wasmInstance{createdAt: time.Now()}
+	})
+
+	expiredInstance := &wasmInstance{createdAt: time.Now().Add(-instanceMaxAge - time.Second)}
+	pool.Put(expiredInstance)
+
+	instance, err := pool.Get()
+
+	require.NoError(t, err)
+	assert.NotSame(t, expiredInstance, instance)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestPool_Get_InstanceWhenAllInstancesExpired(t *testing.T) {
+	pool := NewPool(func() *wasmInstance {
+		return &wasmInstance{createdAt: time.Now()}
+	})
+
+	// Fill pool with expired instances
+	for range maxIdleInstances {
+		pool.Put(&wasmInstance{createdAt: time.Now().Add(-instanceMaxAge - time.Second)})
+	}
+
+	instance, err := pool.Get()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, instance)
+}
+
+func TestPool_Concurrency(t *testing.T) {
+	pool := NewPool(func() *wasmInstance {
+		return &wasmInstance{createdAt: time.Now()}
+	})
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			instance, err := pool.Get()
+			if err == nil {
+				pool.Put(instance)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/vulnerabilities/zeninternals/zen_internals_test.go
+++ b/internal/vulnerabilities/zeninternals/zen_internals_test.go
@@ -35,10 +35,6 @@ func TestNewWasmInstance(t *testing.T) {
 	// Test that newWasmInstance returns the correct type
 	instance := newWasmInstance()
 	require.NotNil(t, instance, "newWasmInstance should not return nil")
-
-	// Type assertion to verify it's a *wasmInstance
-	_, ok := instance.(*wasmInstance)
-	require.True(t, ok, "newWasmInstance should return *wasmInstance")
 }
 
 func TestDetectSQLInjection(t *testing.T) {
@@ -278,9 +274,7 @@ func TestCompilationAndPooling(t *testing.T) {
 	// After compilation, new instances should use compiled module
 	inst := newWasmInstance()
 	require.NotNil(t, inst)
-	wasmInst, ok := inst.(*wasmInstance)
-	require.True(t, ok)
-	require.True(t, wasmInst.isCompiled, "Should use compiled module after compilation")
+	require.True(t, inst.isCompiled, "Should use compiled module after compilation")
 
 	// Verify it works
 	result = DetectSQLInjection("SELECT * FROM users WHERE id = '1' OR 1=1", "1' OR 1=1", int(MySQL))


### PR DESCRIPTION
The WASM instances seem to suffer from memory fragmentation over time resulting in a very slow leak. Instances now stick around for 5 minutes before being dropped.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
**🚀 New Features**
* Introduced a custom Pool type managing WASM instances and lifecycle.

**⚡ Enhancements**
* Evicted WASM instances older than five minutes and capped idle.

**🐛 Bugfixes**
* Added nil checks and error handling when closing or acquiring instances.

**🔧 Refactors**
* Replaced sync.Pool with custom Pool and updated instance creation signatures.
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->