### PR TITLE
Use more idiomatic empty string check

### DIFF
--- a/internal/agent/apidiscovery/get_api_auth_type.go
+++ b/internal/agent/apidiscovery/get_api_auth_type.go
@@ -47,9 +47,10 @@ func GetApiAuthType(headers map[string][]string, cookies map[string]string) []*a
 
 // getAuthorizationHeaderType returns the authentication type from the Authorization header.
 func getAuthorizationHeaderType(authHeader string) *aikido_types.APIAuthType {
-	if len(authHeader) == 0 {
+	if authHeader == "" {
 		return nil
 	}
+
 	if strings.Contains(authHeader, " ") {
 		parts := strings.Split(authHeader, " ")
 		if len(parts) == 2 {

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -28,7 +28,7 @@ func SetContext(ctx context.Context, r *http.Request, data ContextData) context.
 	}
 
 	route := data.Route
-	if len(route) == 0 {
+	if route == "" {
 		route = r.URL.Path // Use path from URL as default.
 	}
 

--- a/internal/vulnerabilities/shellinjection/is_safely_encapsulated.go
+++ b/internal/vulnerabilities/shellinjection/is_safely_encapsulated.go
@@ -19,12 +19,12 @@ func isSafelyEncapsulated(command, userInput string) bool {
 
 		// Get the character before and after the user input
 		charBeforeUserInput := ""
-		if len(currentSegment) > 0 {
+		if currentSegment != "" {
 			charBeforeUserInput = currentSegment[len(currentSegment)-1:]
 		}
 
 		charAfterUserInput := ""
-		if len(nextSegment) > 0 {
+		if nextSegment != "" {
 			charAfterUserInput = nextSegment[:1]
 		}
 

--- a/zen/set_rate_limit_group.go
+++ b/zen/set_rate_limit_group.go
@@ -13,7 +13,7 @@ var ErrRateLimitGroupIDEmpty = errors.New("group id cannot be empty")
 // SetRateLimitGroup associates a group with the current request context which is used for rate limiting.
 // This function must be called before the Zen middleware is executed.
 func SetRateLimitGroup(ctx context.Context, id string) (context.Context, error) {
-	if len(id) == 0 {
+	if id == "" {
 		return ctx, ErrRateLimitGroupIDEmpty
 	}
 

--- a/zen/set_user.go
+++ b/zen/set_user.go
@@ -15,12 +15,10 @@ var ErrUserIDOrNameEmpty = errors.New("user id or name cannot be empty")
 // blocking and rate limiting. This function must be called before the Zen
 // middleware is executed.
 func SetUser(ctx context.Context, id string, name string) (context.Context, error) {
-	// Validate :
-	if len(id) == 0 || len(name) == 0 {
+	if id == "" || name == "" {
 		return ctx, ErrUserIDOrNameEmpty
 	}
 
-	// Get context :
 	reqCtx := request.GetContext(ctx)
 	if reqCtx == nil || reqCtx.HasMiddlewareExecuted() {
 		log.Info("zen.SetUser(...) must be called before the Zen middleware is executed.")


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Replaced len(...) == 0 checks with idiomatic == "" checks.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/70613191?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->