### PR TITLE
Log when unable to close wasm instance

### DIFF
--- a/internal/vulnerabilities/zeninternals/pool.go
+++ b/internal/vulnerabilities/zeninternals/pool.go
@@ -3,8 +3,11 @@ package zeninternals
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
 const (
@@ -59,7 +62,10 @@ func (p *Pool) tryGetInstance() *wasmInstance {
 	// Discard if too old
 	if time.Since(instance.createdAt) > instanceMaxAge {
 		if instance.mod != nil {
-			instance.mod.Close(context.Background())
+			err := instance.mod.Close(context.Background())
+			if err != nil {
+				log.Debug("instance could not be closed", slog.Any("error", err))
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Logged errors when failing to close expired wasm instances


<sup>[More info](https://app.aikido.dev/featurebranch/scan/70627963?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->