### PR TITLE
Add prepend rules to version hash

### DIFF
--- a/cmd/zen-go/internal/hash.go
+++ b/cmd/zen-go/internal/hash.go
@@ -27,6 +27,28 @@ func ComputeInstrumentationHash(inst *Instrumentor) string {
 		fmt.Fprintf(h, "%s\n", rule.WrapTmpl)
 	}
 
+	// Hash prepend rules
+	for _, rule := range inst.PrependRules {
+		fmt.Fprintf(h, "prepend:%s:%s:%s:", rule.ID, rule.ReceiverType, rule.Package)
+		// Sort function names for consistent hashing
+		funcNames := make([]string, len(rule.FuncNames))
+		copy(funcNames, rule.FuncNames)
+		sort.Strings(funcNames)
+		for _, fn := range funcNames {
+			fmt.Fprintf(h, "%s:", fn)
+		}
+		// Sort imports for consistent hashing
+		importKeys := make([]string, 0, len(rule.Imports))
+		for k := range rule.Imports {
+			importKeys = append(importKeys, k)
+		}
+		sort.Strings(importKeys)
+		for _, k := range importKeys {
+			fmt.Fprintf(h, "%s=%s:", k, rule.Imports[k])
+		}
+		fmt.Fprintf(h, "%s\n", rule.PrependTmpl)
+	}
+
 	// Return base64-encoded hash (first 16 chars for brevity)
 	hash := h.Sum(nil)
 	return base64.URLEncoding.EncodeToString(hash)[:16]

--- a/cmd/zen-go/internal/hash_test.go
+++ b/cmd/zen-go/internal/hash_test.go
@@ -48,3 +48,28 @@ func TestComputeInstrumentationHash_EmptyRules(t *testing.T) {
 	hash := ComputeInstrumentationHash(inst)
 	assert.Len(t, hash, 16)
 }
+
+func TestComputeInstrumentationHash_AllRuleTypes(t *testing.T) {
+	inst1 := &Instrumentor{
+		WrapRules: []WrapRule{
+			{ID: "wrap1", MatchCall: "pkg.Func"},
+		},
+		PrependRules: []PrependRule{
+			{ID: "prepend1", Package: "os", FuncNames: []string{"Open"}},
+		},
+	}
+
+	inst2 := &Instrumentor{
+		WrapRules: []WrapRule{
+			{ID: "wrap1", MatchCall: "pkg.Func"},
+		},
+		PrependRules: []PrependRule{
+			{ID: "prepend2", Package: "os", FuncNames: []string{"Open"}},
+		},
+	}
+
+	hash1 := ComputeInstrumentationHash(inst1)
+	hash2 := ComputeInstrumentationHash(inst2)
+
+	assert.NotEqual(t, hash1, hash2, "hash should change when prepend rule changes")
+}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included prepend rules in instrumentation version hash computation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/72483544?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->