### PR TITLE
Report outbound hostnames even if protocol unsupported

### DIFF
--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -15,11 +15,6 @@ func Examine(r *http.Request) {
 	hostname := r.URL.Hostname()
 	port := getPort(r)
 
-	// Unsupported protocol
-	if port == 0 {
-		return
-	}
-
 	go agent.OnDomain(hostname, uint32(port))
 }
 

--- a/internal/agent/state/hostnames.go
+++ b/internal/agent/state/hostnames.go
@@ -3,10 +3,6 @@ package state
 import "github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 
 func (c *Collector) StoreHostname(domain string, port uint32) {
-	if port == 0 {
-		return
-	}
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/internal/agent/state/hostnames_test.go
+++ b/internal/agent/state/hostnames_test.go
@@ -48,11 +48,11 @@ func TestStoreDomain(t *testing.T) {
 			calls: 2,
 		},
 		{
-			name:          "skips storage when port is 0",
+			name:          "stores when port is 0",
 			domain:        "example.com",
 			port:          0,
-			expectedCount: 0,
-			shouldStore:   false,
+			expectedCount: 1,
+			shouldStore:   true,
 			calls:         1,
 		},
 		{


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Reported outbound hostnames even when protocol port was unsupported


<sup>[More info](https://app.aikido.dev/featurebranch/scan/73086764?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->