### PR TITLE
Remove unnecessary goroutines from post request

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -322,6 +322,8 @@ func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 }
 
 func TestMiddlewareCallsOnPostRequestOnPanic(t *testing.T) {
+	agent.Stats().GetAndClear()
+
 	router := gin.Default()
 	router.ContextWithFallback = true
 	router.Use(zengin.GetMiddleware())

--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -337,8 +337,8 @@ func TestMiddlewareCallsOnPostRequestOnPanic(t *testing.T) {
 
 	router.ServeHTTP(w, r)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := agent.Stats().GetAndClear()
-		return stats.Requests.Total == 1
+		require.Equal(c, 1, stats.Requests.Total)
 	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/instrumentation/sources/go-chi/chi/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi/middleware_test.go
@@ -12,8 +12,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	zenchi "github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi"
+	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -299,4 +301,23 @@ func TestMiddlewarePreservesBodyForRawReadAfterFormParsing(t *testing.T) {
 
 	assert.Equal(t, originalBody, bodyReadInHandler)
 	assert.Equal(t, 200, w.Code)
+}
+
+func TestMiddlewareCallsOnPostRequest(t *testing.T) {
+	router := chi.NewRouter()
+	router.Use(zenchi.GetMiddleware())
+
+	router.Get("/route", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	r := httptest.NewRequest("GET", "/route?query=value", http.NoBody)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		stats := agent.Stats().GetAndClear()
+		require.Equal(c, 1, stats.Requests.Total)
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/instrumentation/sources/go-chi/chi/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi/middleware_test.go
@@ -304,6 +304,8 @@ func TestMiddlewarePreservesBodyForRawReadAfterFormParsing(t *testing.T) {
 }
 
 func TestMiddlewareCallsOnPostRequest(t *testing.T) {
+	agent.Stats().GetAndClear()
+
 	router := chi.NewRouter()
 	router.Use(zenchi.GetMiddleware())
 

--- a/instrumentation/sources/labstack/echo/middleware_test.go
+++ b/instrumentation/sources/labstack/echo/middleware_test.go
@@ -315,8 +315,8 @@ func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 
 	router.ServeHTTP(w, r)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := agent.Stats().GetAndClear()
-		return stats.Requests.Total == 1
+		require.Equal(c, 1, stats.Requests.Total)
 	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/instrumentation/sources/labstack/echo/middleware_test.go
+++ b/instrumentation/sources/labstack/echo/middleware_test.go
@@ -301,6 +301,8 @@ func TestMiddlewarePreservesBodyForRawReadAfterFormParsing(t *testing.T) {
 }
 
 func TestMiddlewareCallsOnPostRequest(t *testing.T) {
+	agent.Stats().GetAndClear()
+
 	router := echo.New()
 	router.Use(zenecho.GetMiddleware())
 

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -250,6 +250,8 @@ func TestExtractRouteParams(t *testing.T) {
 }
 
 func TestMiddlewareCallsOnPostRequest(t *testing.T) {
+	agent.Stats().GetAndClear()
+
 	handler := Middleware(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -261,8 +261,8 @@ func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 
 	handler(w, r)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		stats := agent.Stats().GetAndClear()
-		return stats.Requests.Total == 1
+		require.Equal(c, 1, stats.Requests.Total)
 	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -102,7 +102,7 @@ func OnRequestShutdown(method string, route string, statusCode int, user string,
 		slog.String("user", user),
 		slog.String("ip", ip))
 
-	go stateCollector.Stats().OnRequest()
+	stateCollector.Stats().OnRequest()
 	go stateCollector.StoreRoute(method, route, apiSpec)
 }
 

--- a/internal/http/on_post_request.go
+++ b/internal/http/on_post_request.go
@@ -5,25 +5,10 @@ import (
 	"log/slog"
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
-	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/apidiscovery"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
-
-func OnRequestShutdownReporting(method string, route string, statusCode int, user string, ip string, apiSpec *aikido_types.APISpec) {
-	if method == "" || route == "" || statusCode == 0 {
-		return
-	}
-
-	log.Debug("[RSHUTDOWN] Got request metadata", slog.String("method", method), slog.String("route", route), slog.Int("statusCode", statusCode))
-
-	if !shouldDiscoverRoute(statusCode, route, method) {
-		return // Route is not to be discovered, e.g. status code might be 500.
-	}
-
-	agent.OnRequestShutdown(method, route, statusCode, user, ip, apiSpec)
-}
 
 // OnPostRequest gets called after a response is ready to be sent out.
 func OnPostRequest(ctx context.Context, statusCode int) {
@@ -34,7 +19,21 @@ func OnPostRequest(ctx context.Context, statusCode int) {
 
 	apiSpec := apidiscovery.GetAPIInfo(reqCtx)
 
-	go OnRequestShutdownReporting(
-		reqCtx.Method, reqCtx.Route, statusCode, reqCtx.GetUserID(), reqCtx.GetIP(), apiSpec,
-	)
+	method := reqCtx.Method
+	route := reqCtx.Route
+
+	if method == "" || route == "" || statusCode == 0 {
+		return
+	}
+
+	log.Debug("[RSHUTDOWN] Got request metadata", slog.String("method", method), slog.String("route", route), slog.Int("statusCode", statusCode))
+
+	if !shouldDiscoverRoute(statusCode, route, method) {
+		return // Route is not to be discovered, e.g. status code might be 500.
+	}
+
+	user := reqCtx.GetUserID()
+	ip := reqCtx.GetIP()
+
+	agent.OnRequestShutdown(method, route, statusCode, user, ip, apiSpec)
 }


### PR DESCRIPTION
These goroutines were causing some test flakiness, but also spawning these goroutines are more expensive than the work they were doing.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed unnecessary goroutine wrapping Stats().OnRequest, invoking it synchronously.
* Refactored OnPostRequest to remove goroutine and validate request context.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/73312639?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->