### PR TITLE
Refactor start/stop polling to reduce state in callers and wait on stop

### DIFF
--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -11,31 +11,23 @@ import (
 )
 
 var (
-	heartbeatRoutineChannel     = make(chan struct{})
-	heartbeatTicker             *time.Ticker
-	configPollingRoutineChannel = make(chan struct{})
-	configPollingTicker         *time.Ticker
+	heartbeatRoutine     *utils.PollingRoutine
+	configPollingRoutine *utils.PollingRoutine
 
 	minHeartbeatIntervalInMS = 120000
 )
 
 func startPolling() {
-	heartbeatTicker = time.NewTicker(10 * time.Minute)
-	configPollingTicker = time.NewTicker(1 * time.Minute)
-
-	utils.StartPollingRoutine(heartbeatRoutineChannel, heartbeatTicker, sendHeartbeatEvent)
-	utils.StartPollingRoutine(configPollingRoutineChannel, configPollingTicker, refreshCloudConfig)
+	heartbeatRoutine = utils.StartPollingRoutine(10*time.Minute, sendHeartbeatEvent)
+	configPollingRoutine = utils.StartPollingRoutine(1*time.Minute, refreshCloudConfig)
 }
 
 func stopPolling() {
-	utils.StopPollingRoutine(heartbeatRoutineChannel)
-	utils.StopPollingRoutine(configPollingRoutineChannel)
-
-	if heartbeatTicker != nil {
-		heartbeatTicker.Stop()
+	if heartbeatRoutine != nil {
+		heartbeatRoutine.Stop()
 	}
-	if configPollingTicker != nil {
-		configPollingTicker.Stop()
+	if configPollingRoutine != nil {
+		configPollingRoutine.Stop()
 	}
 }
 
@@ -99,8 +91,8 @@ func calculateHeartbeatInterval(heartbeatIntervalInMS int, receivedAnyStats bool
 }
 
 func resetHeartbeatTicker(newInterval time.Duration) {
-	if heartbeatTicker != nil && newInterval > 0 {
+	if heartbeatRoutine != nil && newInterval > 0 {
 		log.Debug("Resetting HeartbeatTicker", slog.String("interval", newInterval.String()))
-		heartbeatTicker.Reset(newInterval)
+		heartbeatRoutine.Reset(newInterval)
 	}
 }

--- a/internal/agent/polling.go
+++ b/internal/agent/polling.go
@@ -6,20 +6,20 @@ import (
 
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
-	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/AikidoSec/firewall-go/internal/polling"
 )
 
 var (
-	heartbeatRoutine     *utils.PollingRoutine
-	configPollingRoutine *utils.PollingRoutine
+	heartbeatRoutine     *polling.Routine
+	configPollingRoutine *polling.Routine
 
 	minHeartbeatIntervalInMS = 120000
 )
 
 func startPolling() {
-	heartbeatRoutine = utils.StartPollingRoutine(10*time.Minute, sendHeartbeatEvent)
-	configPollingRoutine = utils.StartPollingRoutine(1*time.Minute, refreshCloudConfig)
+	heartbeatRoutine = polling.Start(10*time.Minute, sendHeartbeatEvent)
+	configPollingRoutine = polling.Start(1*time.Minute, refreshCloudConfig)
 }
 
 func stopPolling() {

--- a/internal/agent/ratelimiting/rate_limiting.go
+++ b/internal/agent/ratelimiting/rate_limiting.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
-	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/AikidoSec/firewall-go/internal/polling"
 	"github.com/AikidoSec/firewall-go/internal/slidingwindow"
 )
 
@@ -74,7 +74,7 @@ type RateLimiter struct {
 	mu sync.RWMutex
 
 	// Polling routine for periodic cleanup
-	cleanupRoutine *utils.PollingRoutine
+	cleanupRoutine *polling.Routine
 }
 
 func New() *RateLimiter {
@@ -85,7 +85,7 @@ func New() *RateLimiter {
 
 // Init initializes the rate limiting subsystem with periodic cleanup
 func (rl *RateLimiter) Init() {
-	rl.cleanupRoutine = utils.StartPollingRoutine(inactiveCleanupInterval, rl.cleanupInactive)
+	rl.cleanupRoutine = polling.Start(inactiveCleanupInterval, rl.cleanupInactive)
 }
 
 // Uninit shuts down the rate limiting subsystem

--- a/internal/agent/utils/utils.go
+++ b/internal/agent/utils/utils.go
@@ -1,25 +1,52 @@
 package utils
 
 import (
+	"sync"
 	"time"
 )
 
-func StartPollingRoutine(stopChan chan struct{}, ticker *time.Ticker, pollingFunction func()) {
+type PollingRoutine struct {
+	ticker   *time.Ticker
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+}
+
+// StartPollingRoutine starts a new polling routine with the given interval and function
+func StartPollingRoutine(interval time.Duration, fn func()) *PollingRoutine {
+	pr := &PollingRoutine{
+		ticker:   time.NewTicker(interval),
+		stopChan: make(chan struct{}),
+	}
+
+	pr.wg.Add(1)
 	go func() {
+		defer pr.wg.Done()
+		defer pr.ticker.Stop()
 		for {
 			select {
-			case <-ticker.C:
-				pollingFunction()
-			case <-stopChan:
-				ticker.Stop()
+			case <-pr.ticker.C:
+				fn()
+			case <-pr.stopChan:
 				return
 			}
 		}
 	}()
+
+	return pr
 }
 
-func StopPollingRoutine(stopChan chan struct{}) {
-	close(stopChan)
+// Stop stops the polling routine and waits for the goroutine to complete
+func (pr *PollingRoutine) Stop() {
+	close(pr.stopChan)
+	pr.wg.Wait()
+}
+
+// Reset resets the interval of the polling routine
+func (pr *PollingRoutine) Reset(interval time.Duration) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	pr.ticker.Reset(interval)
 }
 
 func GetTime() int64 {

--- a/internal/agent/utils/utils.go
+++ b/internal/agent/utils/utils.go
@@ -1,53 +1,8 @@
 package utils
 
 import (
-	"sync"
 	"time"
 )
-
-type PollingRoutine struct {
-	ticker   *time.Ticker
-	stopChan chan struct{}
-	wg       sync.WaitGroup
-	mu       sync.Mutex
-}
-
-// StartPollingRoutine starts a new polling routine with the given interval and function
-func StartPollingRoutine(interval time.Duration, fn func()) *PollingRoutine {
-	pr := &PollingRoutine{
-		ticker:   time.NewTicker(interval),
-		stopChan: make(chan struct{}),
-	}
-
-	pr.wg.Add(1)
-	go func() {
-		defer pr.wg.Done()
-		defer pr.ticker.Stop()
-		for {
-			select {
-			case <-pr.ticker.C:
-				fn()
-			case <-pr.stopChan:
-				return
-			}
-		}
-	}()
-
-	return pr
-}
-
-// Stop stops the polling routine and waits for the goroutine to complete
-func (pr *PollingRoutine) Stop() {
-	close(pr.stopChan)
-	pr.wg.Wait()
-}
-
-// Reset resets the interval of the polling routine
-func (pr *PollingRoutine) Reset(interval time.Duration) {
-	pr.mu.Lock()
-	defer pr.mu.Unlock()
-	pr.ticker.Reset(interval)
-}
 
 func GetTime() int64 {
 	return time.Now().UnixMilli()

--- a/internal/agent/utils/utils_test.go
+++ b/internal/agent/utils/utils_test.go
@@ -1,62 +1,11 @@
 package utils
 
 import (
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestStartPollingRoutine(t *testing.T) {
-	var callCount int64
-
-	pr := StartPollingRoutine(10*time.Millisecond, func() {
-		atomic.AddInt64(&callCount, 1)
-	})
-
-	time.Sleep(35 * time.Millisecond)
-	pr.Stop()
-
-	assert.Greater(t, atomic.LoadInt64(&callCount), int64(1))
-}
-
-func TestStopPollingRoutine(t *testing.T) {
-	var callCount int64
-
-	pr := StartPollingRoutine(10*time.Millisecond, func() {
-		atomic.AddInt64(&callCount, 1)
-	})
-
-	time.Sleep(25 * time.Millisecond)
-	pr.Stop() // Waits for goroutine to complete
-
-	finalCount := atomic.LoadInt64(&callCount)
-	time.Sleep(30 * time.Millisecond)
-
-	assert.Equal(t, finalCount, atomic.LoadInt64(&callCount))
-}
-
-func TestPollingRoutineReset(t *testing.T) {
-	var callCount int64
-
-	pr := StartPollingRoutine(50*time.Millisecond, func() {
-		atomic.AddInt64(&callCount, 1)
-	})
-
-	time.Sleep(30 * time.Millisecond)
-	firstCount := atomic.LoadInt64(&callCount)
-	assert.Equal(t, int64(0), firstCount, "Should not have fired yet")
-
-	// Reset to a faster interval
-	pr.Reset(10 * time.Millisecond)
-
-	time.Sleep(35 * time.Millisecond)
-	pr.Stop()
-
-	finalCount := atomic.LoadInt64(&callCount)
-	assert.Greater(t, finalCount, int64(1), "Should have fired multiple times after reset")
-}
 
 func TestGetTime(t *testing.T) {
 	before := time.Now().UnixMilli()

--- a/internal/agent/utils/utils_test.go
+++ b/internal/agent/utils/utils_test.go
@@ -10,35 +10,52 @@ import (
 
 func TestStartPollingRoutine(t *testing.T) {
 	var callCount int64
-	stopChan := make(chan struct{})
-	ticker := time.NewTicker(10 * time.Millisecond)
 
-	StartPollingRoutine(stopChan, ticker, func() {
+	pr := StartPollingRoutine(10*time.Millisecond, func() {
 		atomic.AddInt64(&callCount, 1)
 	})
 
 	time.Sleep(35 * time.Millisecond)
-	StopPollingRoutine(stopChan)
-	time.Sleep(10 * time.Millisecond)
+	pr.Stop()
 
 	assert.Greater(t, atomic.LoadInt64(&callCount), int64(1))
 }
 
 func TestStopPollingRoutine(t *testing.T) {
 	var callCount int64
-	stopChan := make(chan struct{})
-	ticker := time.NewTicker(10 * time.Millisecond)
 
-	StartPollingRoutine(stopChan, ticker, func() {
+	pr := StartPollingRoutine(10*time.Millisecond, func() {
 		atomic.AddInt64(&callCount, 1)
 	})
 
 	time.Sleep(25 * time.Millisecond)
-	StopPollingRoutine(stopChan)
+	pr.Stop() // Waits for goroutine to complete
+
 	finalCount := atomic.LoadInt64(&callCount)
 	time.Sleep(30 * time.Millisecond)
 
 	assert.Equal(t, finalCount, atomic.LoadInt64(&callCount))
+}
+
+func TestPollingRoutineReset(t *testing.T) {
+	var callCount int64
+
+	pr := StartPollingRoutine(50*time.Millisecond, func() {
+		atomic.AddInt64(&callCount, 1)
+	})
+
+	time.Sleep(30 * time.Millisecond)
+	firstCount := atomic.LoadInt64(&callCount)
+	assert.Equal(t, int64(0), firstCount, "Should not have fired yet")
+
+	// Reset to a faster interval
+	pr.Reset(10 * time.Millisecond)
+
+	time.Sleep(35 * time.Millisecond)
+	pr.Stop()
+
+	finalCount := atomic.LoadInt64(&callCount)
+	assert.Greater(t, finalCount, int64(1), "Should have fired multiple times after reset")
 }
 
 func TestGetTime(t *testing.T) {

--- a/internal/polling/routine.go
+++ b/internal/polling/routine.go
@@ -1,0 +1,47 @@
+package polling
+
+import (
+	"sync"
+	"time"
+)
+
+type Routine struct {
+	ticker   *time.Ticker
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+}
+
+func Start(interval time.Duration, fn func()) *Routine {
+	r := &Routine{
+		ticker:   time.NewTicker(interval),
+		stopChan: make(chan struct{}),
+	}
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		defer r.ticker.Stop()
+		for {
+			select {
+			case <-r.ticker.C:
+				fn()
+			case <-r.stopChan:
+				return
+			}
+		}
+	}()
+
+	return r
+}
+
+func (r *Routine) Stop() {
+	close(r.stopChan)
+	r.wg.Wait()
+}
+
+func (r *Routine) Reset(interval time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ticker.Reset(interval)
+}

--- a/internal/polling/routine.go
+++ b/internal/polling/routine.go
@@ -35,11 +35,13 @@ func Start(interval time.Duration, fn func()) *Routine {
 	return r
 }
 
+// Stop stops the polling routine and waits for the goroutine to complete
 func (r *Routine) Stop() {
 	close(r.stopChan)
 	r.wg.Wait()
 }
 
+// Reset resets the interval of the polling routine
 func (r *Routine) Reset(interval time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/polling/routine_test.go
+++ b/internal/polling/routine_test.go
@@ -1,0 +1,59 @@
+package polling
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStart(t *testing.T) {
+	var callCount int64
+
+	r := Start(10*time.Millisecond, func() {
+		atomic.AddInt64(&callCount, 1)
+	})
+
+	time.Sleep(35 * time.Millisecond)
+	r.Stop()
+
+	assert.Greater(t, atomic.LoadInt64(&callCount), int64(1))
+}
+
+func TestStop(t *testing.T) {
+	var callCount int64
+
+	r := Start(10*time.Millisecond, func() {
+		atomic.AddInt64(&callCount, 1)
+	})
+
+	time.Sleep(25 * time.Millisecond)
+	r.Stop() // Waits for goroutine to complete
+
+	finalCount := atomic.LoadInt64(&callCount)
+	time.Sleep(30 * time.Millisecond)
+
+	assert.Equal(t, finalCount, atomic.LoadInt64(&callCount))
+}
+
+func TestReset(t *testing.T) {
+	var callCount int64
+
+	r := Start(50*time.Millisecond, func() {
+		atomic.AddInt64(&callCount, 1)
+	})
+
+	time.Sleep(30 * time.Millisecond)
+	firstCount := atomic.LoadInt64(&callCount)
+	assert.Equal(t, int64(0), firstCount, "Should not have fired yet")
+
+	// Reset to a faster interval
+	r.Reset(10 * time.Millisecond)
+
+	time.Sleep(35 * time.Millisecond)
+	r.Stop()
+
+	finalCount := atomic.LoadInt64(&callCount)
+	assert.Greater(t, finalCount, int64(1), "Should have fired multiple times after reset")
+}


### PR DESCRIPTION
This was causing another flaky test, stop wasn't waiting for the goroutine to stop.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added polling.Routine type and implementation for managed tickers

**🐛 Bugfixes**
* Stopped blocking on stop; Stop now waited for goroutine completion

**🔧 Refactors**
* Replaced ad-hoc ticker channels with polling.Routine in agent and ratelimiting
* Removed Start/StopPollingRoutine helpers from utils package to simplify


<sup>[More info](https://app.aikido.dev/featurebranch/scan/73321865?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->