### PR TITLE
Pass toolexec to go list to ensure using correct cache

### DIFF
--- a/cmd/zen-go/internal/importcfg.go
+++ b/cmd/zen-go/internal/importcfg.go
@@ -91,7 +91,15 @@ func createTempFile(objdir string) (*os.File, error) {
 }
 
 func getPackageExport(importPath string) (string, error) {
-	cmd := exec.Command("go", "list", "-export", "-f", "{{.Export}}", importPath)
+	// Get the path to ourselves so we can use -toolexec
+	// This ensures we get the export path from the same cache as the current build
+	selfPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	toolexecArg := selfPath + " toolexec"
+	cmd := exec.Command("go", "list", "-toolexec", toolexecArg, "-export", "-f", "{{.Export}}", importPath)
 	if modDir := findModuleRoot(); modDir != "" {
 		cmd.Dir = modDir
 	}

--- a/instrumentation/sinks/os/zen.instrument.yml
+++ b/instrumentation/sinks/os/zen.instrument.yml
@@ -1,0 +1,20 @@
+meta:
+  name: os
+  description: Protection from Local File Inclusion (LFI) Attacks.
+
+rules:
+  # Prepend security check to os.OpenFile
+  - id: os.OpenFile
+    type: prepend
+    package: os
+    imports:
+      zentransits: github.com/AikidoSec/firewall-go/instrumentation/transits
+    function: OpenFile
+    template: |
+      if examinePath := zentransits.ExaminePath(); examinePath != nil {
+        const _aikido_deferReporting = false
+        _aikido_block := examinePath("os.OpenFile", []string{ {{ .Function.Argument 0 }} }, _aikido_deferReporting)
+        if _aikido_block != nil {
+          return nil, _aikido_block
+        }
+      }


### PR DESCRIPTION
Adding the os instrumentation caused an issue with the cache due to our instrumentation code depending on `os` and then `go list` sending us to the wrong cached version of a build.

**Before 😞** 
<img width="1610" height="75" alt="image" src="https://github.com/user-attachments/assets/a1fb5a32-a5c7-4477-99ef-0e2fafb61bca" />

**After 😄** 
<img width="1610" height="47" alt="image" src="https://github.com/user-attachments/assets/cd9fdd71-2cbe-4841-b3f6-1a0ac476879f" />


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added zen instrumentation YAML defining os.OpenFile security prepend rule

**⚡ Enhancements**
* Passed toolexec to 'go list' to ensure using correct cache


<sup>[More info](https://app.aikido.dev/featurebranch/scan/74635570?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->