### PR TITLE
Pass only buildflags to packages.Load

### DIFF
--- a/cmd/zen-go/internal/buildflags.go
+++ b/cmd/zen-go/internal/buildflags.go
@@ -102,6 +102,8 @@ func matchesGoBinary(candidate, goBinary string) bool {
 // extractBuildFlags parses the parent go command's arguments and returns
 // the build flags. Skips -a (would force unnecessary rebuilds).
 func extractBuildFlags(args []string) []string {
+	// We use an allowlist to ensure only build flags are passed through.
+	// For example, we don't want to pass flags from `go test`.
 	standalone := map[string]bool{
 		"-asan":       true,
 		"-cover":      true,

--- a/cmd/zen-go/internal/buildflags.go
+++ b/cmd/zen-go/internal/buildflags.go
@@ -102,6 +102,35 @@ func matchesGoBinary(candidate, goBinary string) bool {
 // extractBuildFlags parses the parent go command's arguments and returns
 // the build flags. Skips -a (would force unnecessary rebuilds).
 func extractBuildFlags(args []string) []string {
+	standalone := map[string]bool{
+		"-asan":       true,
+		"-cover":      true,
+		"-linkshared": true,
+		"-modcacherw": true,
+		"-msan":       true,
+		"-race":       true,
+		"-trimpath":   true,
+		"-work":       true,
+	}
+	withValue := map[string]bool{
+		"-asmflags":   true,
+		"-buildmode":  true,
+		"-buildvcs":   true,
+		"-compiler":   true,
+		"-covermode":  true,
+		"-coverpkg":   true,
+		"-gccgoflags": true,
+		"-gcflags":    true,
+		"-ldflags":    true,
+		"-mod":        true,
+		"-modfile":    true,
+		"-overlay":    true,
+		"-pgo":        true,
+		"-pkgdir":     true,
+		"-tags":       true,
+		"-toolexec":   true,
+	}
+
 	var result []string
 
 	// Skip go binary and subcommand
@@ -117,11 +146,26 @@ func extractBuildFlags(args []string) []string {
 			break
 		}
 
-		if arg == "-a" || arg == "--a" {
+		if !strings.HasPrefix(arg, "-") {
 			continue
 		}
 
-		result = append(result, arg)
+		// Normalize --flag to -flag
+		normalized := arg
+		if strings.HasPrefix(arg, "--") {
+			normalized = arg[1:]
+		}
+
+		if key, val, ok := strings.Cut(normalized, "="); ok {
+			if withValue[key] {
+				result = append(result, key+"="+val)
+			}
+		} else if withValue[normalized] {
+			result = append(result, normalized+"="+args[i+1])
+			i++
+		} else if standalone[normalized] {
+			result = append(result, normalized)
+		}
 	}
 
 	return result


### PR DESCRIPTION
This is required as using `go test` will provide flags which `go list` does not support, for example you will see an error like this:

```
zen-go: warning: could not find export for github.com/AikidoSec/firewall-go/instrumentation/transits: unsupported version of go: exit status 2: flag provided but not defined: -coverprofile

usage: go list [-f format] [-json] [-m] [list flags] [build flags] [packages]

Run 'go help list' for details.
```

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Restricted forwarded flags to an allowlist and parsed them properly

**📚 Documentation**
* Added comment explaining why an allowlist was used for flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/76264265?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->