### PR TITLE
Add envvar for output log files from zen-go

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -47,7 +47,7 @@ func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, too
 	}
 
 	// Run the compiler
-	err = passthrough(tool, newArgs)
+	err = passthrough(stdout, stderr, tool, newArgs)
 	if err != nil {
 		return err
 	}
@@ -71,11 +71,11 @@ func extractFlag(args []string, i int, flag string) (string, bool) {
 
 // passthrough runs the given Golang tool
 // For example, it will run the compiler with the arguments originally passed our toolexec command
-func passthrough(tool string, args []string) error {
+func passthrough(stdout io.Writer, stderr io.Writer, tool string, args []string) error {
 	cmd := exec.Command(tool, args...)
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	return cmd.Run()
 }

--- a/cmd/zen-go/cmd_toolexec_test.go
+++ b/cmd/zen-go/cmd_toolexec_test.go
@@ -132,7 +132,7 @@ func TestPassthrough(t *testing.T) {
 	os.Stdout = w
 
 	toolArgs := []string{"arg1", "arg2", "arg3"}
-	err = passthrough(mockTool, toolArgs)
+	err = passthrough(os.Stdout, os.Stderr, mockTool, toolArgs)
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -159,7 +159,7 @@ func TestPassthrough_Error(t *testing.T) {
 	os.Stderr = w
 
 	toolArgs := []string{}
-	err = passthrough(mockTool, toolArgs)
+	err = passthrough(os.Stdout, os.Stderr, mockTool, toolArgs)
 
 	w.Close()
 	os.Stderr = oldStderr
@@ -231,7 +231,7 @@ func TestPassthrough_PreservesExitCode(t *testing.T) {
 			os.Stderr = w
 
 			toolArgs := []string{}
-			err = passthrough(mockTool, toolArgs)
+			err = passthrough(os.Stdout, os.Stderr, mockTool, toolArgs)
 
 			w.Close()
 			os.Stderr = oldStderr
@@ -265,7 +265,7 @@ func TestPassthrough_WithComplexArgs(t *testing.T) {
 		"-trimpath", "/tmp",
 		"input.go",
 	}
-	err = passthrough(mockTool, toolArgs)
+	err = passthrough(os.Stdout, os.Stderr, mockTool, toolArgs)
 
 	w.Close()
 	os.Stdout = oldStdout

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -74,7 +74,7 @@ func newCommand() *cli.Command {
 					case "link":
 						return toolexecLinkCommand(out, outErr, tool, toolArgs)
 					default:
-						return passthrough(tool, toolArgs)
+						return passthrough(out, outErr, tool, toolArgs)
 					}
 				},
 			},


### PR DESCRIPTION
Adding option to output to a logfile to help with debugging. With some invocations of `zen-go`, we don't see all of its output to the console, such as with `go test`. Outputting everything to a log file should make it easier to debug what's happening.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added ZENGO_LOG environment variable to write combined logs

**🔧 Refactors**
* Changed passthrough to accept stdout and stderr io.Writers
* Propagated custom writers through compile and link toolexec commands


<sup>[More info](https://app.aikido.dev/featurebranch/scan/76551677?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->