### PR TITLE
Add zen.ShouldProtect to return early when Protect isn't called

### DIFF
--- a/instrumentation/sinks/database/sql/disabled_test.go
+++ b/instrumentation/sinks/database/sql/disabled_test.go
@@ -58,3 +58,48 @@ func TestExamineContext_Disabled(t *testing.T) {
 		// Expected: no attack detected
 	}
 }
+
+func TestExamineContext_NotLoaded(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	originalLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(originalDisabled)
+		config.SetZenLoaded(originalLoaded)
+	}()
+
+	// Set state: not disabled, but not loaded
+	zen.SetDisabled(false)
+	config.SetZenLoaded(false)
+
+	originalClient := agent.GetCloudClient()
+	originalBlocking := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+	defer func() {
+		config.SetBlocking(originalBlocking)
+		agent.SetCloudClient(originalClient)
+	}()
+
+	mockClient := testutil.NewMockCloudClient()
+	agent.SetCloudClient(mockClient)
+
+	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
+
+	err := sql.ExamineContext(ctx, maliciousQuery, "database/sql.DB.QueryContext")
+
+	require.NoError(t, err, "ExamineContext should return early with no error when zen is not loaded")
+
+	select {
+	case <-mockClient.AttackDetectedEventSent:
+		t.Fatal("No attack should be detected when zen is not loaded")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no attack detected
+	}
+}

--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -19,7 +19,7 @@ func Examine(query string, op string) error {
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.
 func ExamineContext(ctx context.Context, query string, op string) error {
-	if zen.IsDisabled() {
+	if !zen.ShouldProtect() {
 		return nil
 	}
 

--- a/instrumentation/sinks/jackc/pgx/disabled_test.go
+++ b/instrumentation/sinks/jackc/pgx/disabled_test.go
@@ -58,3 +58,48 @@ func TestExamineContext_Disabled(t *testing.T) {
 		// Expected: no attack detected
 	}
 }
+
+func TestExamineContext_NotLoaded(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	originalLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(originalDisabled)
+		config.SetZenLoaded(originalLoaded)
+	}()
+
+	// Set state: not disabled, but not loaded
+	zen.SetDisabled(false)
+	config.SetZenLoaded(false)
+
+	originalClient := agent.GetCloudClient()
+	originalBlocking := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+	defer func() {
+		config.SetBlocking(originalBlocking)
+		agent.SetCloudClient(originalClient)
+	}()
+
+	mockClient := testutil.NewMockCloudClient()
+	agent.SetCloudClient(mockClient)
+
+	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
+
+	err := pgx.ExamineContext(ctx, maliciousQuery, "github.com/jackc/pgx/v5.Query")
+
+	require.NoError(t, err, "ExamineContext should return early with no error when zen is not loaded")
+
+	select {
+	case <-mockClient.AttackDetectedEventSent:
+		t.Fatal("No attack should be detected when zen is not loaded")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: no attack detected
+	}
+}

--- a/instrumentation/sinks/jackc/pgx/examine.go
+++ b/instrumentation/sinks/jackc/pgx/examine.go
@@ -13,7 +13,7 @@ import (
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.
 func ExamineContext(ctx context.Context, query string, op string) error {
-	if zen.IsDisabled() {
+	if !zen.ShouldProtect() {
 		return nil
 	}
 

--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -10,6 +10,10 @@ import (
 )
 
 func Examine(r *http.Request) error {
+	if !zen.ShouldProtect() {
+		return nil
+	}
+
 	if r.URL == nil {
 		return nil
 	}

--- a/instrumentation/sinks/net/http/instrumention_test.go
+++ b/instrumentation/sinks/net/http/instrumention_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestHTTPClientInstrumentation(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -15,7 +15,7 @@ func GetMiddleware() gin.HandlerFunc {
 			return // Don't investigate empty requests.
 		}
 
-		if zen.IsDisabled() {
+		if !zen.ShouldProtect() {
 			c.Next()
 			return
 		}

--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	original := config.IsZenLoaded()
+	config.SetZenLoaded(true)
+
+	code := m.Run()
+
+	config.SetZenLoaded(original)
+	os.Exit(code)
+}
 
 func TestMiddlewareAddsContext(t *testing.T) {
 	router := gin.New()

--- a/instrumentation/sources/go-chi/chi/middleware.go
+++ b/instrumentation/sources/go-chi/chi/middleware.go
@@ -9,6 +9,7 @@ import (
 	zenhttp "github.com/AikidoSec/firewall-go/internal/http"
 	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -17,6 +18,11 @@ import (
 func GetMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !zen.ShouldProtect() {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			if r == nil {
 				next.ServeHTTP(w, r)
 				return

--- a/instrumentation/sources/go-chi/chi/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -23,6 +24,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	original := config.IsZenLoaded()
+	config.SetZenLoaded(true)
+
+	code := m.Run()
+
+	config.SetZenLoaded(original)
+	os.Exit(code)
+}
 
 func TestMiddlewareAddsContext(t *testing.T) {
 	router := chi.NewRouter()

--- a/instrumentation/sources/labstack/echo/disabled_test.go
+++ b/instrumentation/sources/labstack/echo/disabled_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	zenecho "github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v4"
@@ -31,6 +32,43 @@ func TestMiddleware_Disabled(t *testing.T) {
 
 		reqCtx := request.GetContext(c.Request().Context())
 		require.Nil(t, reqCtx, "Request context should not be created when zen is disabled")
+
+		return c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	e.ServeHTTP(w, req)
+
+	require.True(t, handlerCalled)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ok", w.Body.String())
+}
+
+func TestMiddleware_NotLoaded(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	originalLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(originalDisabled)
+		config.SetZenLoaded(originalLoaded)
+	}()
+
+	zen.SetDisabled(false)
+	config.SetZenLoaded(false)
+
+	require.False(t, zen.IsDisabled())
+	require.False(t, zen.ShouldProtect())
+
+	e := echo.New()
+	e.Use(zenecho.GetMiddleware())
+
+	handlerCalled := false
+	e.GET("/test", func(c echo.Context) error {
+		handlerCalled = true
+
+		reqCtx := request.GetContext(c.Request().Context())
+		require.Nil(t, reqCtx, "Request context should not be created when zen is not loaded")
 
 		return c.String(http.StatusOK, "ok")
 	})

--- a/instrumentation/sources/labstack/echo/middleware.go
+++ b/instrumentation/sources/labstack/echo/middleware.go
@@ -14,7 +14,7 @@ import (
 func GetMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			if zen.IsDisabled() {
+			if !zen.ShouldProtect() {
 				return next(c)
 			}
 

--- a/instrumentation/sources/labstack/echo/middleware_test.go
+++ b/instrumentation/sources/labstack/echo/middleware_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	original := config.IsZenLoaded()
+	config.SetZenLoaded(true)
+
+	code := m.Run()
+
+	config.SetZenLoaded(original)
+	os.Exit(code)
+}
 
 func TestMiddlewareAddsContext(t *testing.T) {
 	router := echo.New()

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -16,7 +16,7 @@ import (
 // It is part of the automatic instrumentation and will be run before any other middleware.
 func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if zen.IsDisabled() {
+		if !zen.ShouldProtect() {
 			orig(w, r)
 			return
 		}

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -10,15 +10,28 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	// Set zen as loaded for all tests in this package
+	original := config.IsZenLoaded()
+	config.SetZenLoaded(true)
+
+	code := m.Run()
+
+	config.SetZenLoaded(original)
+	os.Exit(code)
+}
 
 func TestStatusRecorder(t *testing.T) {
 	t.Run("captures status code", func(t *testing.T) {

--- a/internal/agent/config/disabled.go
+++ b/internal/agent/config/disabled.go
@@ -3,6 +3,7 @@ package config
 import "sync/atomic"
 
 var isZenDisabled atomic.Bool
+var isZenLoaded atomic.Bool
 
 func SetZenDisabled(disabled bool) {
 	isZenDisabled.Store(disabled)
@@ -10,4 +11,18 @@ func SetZenDisabled(disabled bool) {
 
 func IsZenDisabled() bool {
 	return isZenDisabled.Load()
+}
+
+func SetZenLoaded(loaded bool) {
+	isZenLoaded.Store(loaded)
+}
+
+func IsZenLoaded() bool {
+	return isZenLoaded.Load()
+}
+
+// ShouldProtect returns true if protection should run.
+// Protection runs when zen is not disabled AND has been loaded successfully.
+func ShouldProtect() bool {
+	return !IsZenDisabled() && IsZenLoaded()
 }

--- a/internal/agent/config/disabled_test.go
+++ b/internal/agent/config/disabled_test.go
@@ -14,3 +14,56 @@ func TestZenDisabled(t *testing.T) {
 	config.SetZenDisabled(false)
 	assert.False(t, config.IsZenDisabled())
 }
+
+func TestShouldProtect(t *testing.T) {
+	tests := []struct {
+		name     string
+		disabled bool
+		loaded   bool
+		want     bool
+	}{
+		{
+			name:     "not loaded and not disabled returns false",
+			disabled: false,
+			loaded:   false,
+			want:     false,
+		},
+		{
+			name:     "loaded and not disabled returns true",
+			disabled: false,
+			loaded:   true,
+			want:     true,
+		},
+		{
+			name:     "not loaded and disabled returns false",
+			disabled: true,
+			loaded:   false,
+			want:     false,
+		},
+		{
+			name:     "loaded but disabled returns false",
+			disabled: true,
+			loaded:   true,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original state
+			origDisabled := config.IsZenDisabled()
+			origLoaded := config.IsZenLoaded()
+			defer func() {
+				config.SetZenDisabled(origDisabled)
+				config.SetZenLoaded(origLoaded)
+			}()
+
+			// Set test state
+			config.SetZenDisabled(tt.disabled)
+			config.SetZenLoaded(tt.loaded)
+
+			got := config.ShouldProtect()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/vulnerabilities/scan.go
+++ b/internal/vulnerabilities/scan.go
@@ -34,7 +34,7 @@ func Scan[T any](ctx context.Context, operation string, vulnerability Vulnerabil
 }
 
 func ScanWithOptions[T any](ctx context.Context, operation string, vulnerability Vulnerability[T], args T, opts ScanOptions) error {
-	if config.IsZenDisabled() {
+	if !config.ShouldProtect() {
 		return nil
 	}
 

--- a/zen/not_loaded_test.go
+++ b/zen/not_loaded_test.go
@@ -1,0 +1,69 @@
+//go:build !integration
+
+package zen_test
+
+import (
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/zen"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShouldProtect_NotLoaded verifies that ShouldProtect returns false
+// when zen.Protect() has not been called, preventing panics from
+// uninitialized resources like the WASM module.
+func TestShouldProtect_NotLoaded(t *testing.T) {
+	// Save and restore original state
+	origDisabled := zen.IsDisabled()
+	origLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(origDisabled)
+		config.SetZenLoaded(origLoaded)
+	}()
+
+	// Set up test state: not disabled, but not loaded
+	zen.SetDisabled(false)
+	config.SetZenLoaded(false)
+
+	// ShouldProtect must return false when not loaded
+	require.False(t, zen.ShouldProtect(), "ShouldProtect should return false when zen.Protect() was never called")
+}
+
+// TestShouldProtect_Loaded verifies that ShouldProtect returns true
+// when zen.Protect() has been successfully called.
+func TestShouldProtect_Loaded(t *testing.T) {
+	// Save and restore original state
+	origDisabled := zen.IsDisabled()
+	origLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(origDisabled)
+		config.SetZenLoaded(origLoaded)
+	}()
+
+	// Set up test state: not disabled, and loaded
+	zen.SetDisabled(false)
+	config.SetZenLoaded(true)
+
+	// ShouldProtect must return true when loaded and not disabled
+	require.True(t, zen.ShouldProtect(), "ShouldProtect should return true when zen.Protect() was called successfully")
+}
+
+// TestShouldProtect_DisabledOverridesLoaded verifies that being disabled
+// takes precedence over being loaded.
+func TestShouldProtect_DisabledOverridesLoaded(t *testing.T) {
+	// Save and restore original state
+	origDisabled := zen.IsDisabled()
+	origLoaded := config.IsZenLoaded()
+	defer func() {
+		zen.SetDisabled(origDisabled)
+		config.SetZenLoaded(origLoaded)
+	}()
+
+	// Set up test state: disabled AND loaded
+	zen.SetDisabled(true)
+	config.SetZenLoaded(true)
+
+	// ShouldProtect must return false when disabled, even if loaded
+	require.False(t, zen.ShouldProtect(), "ShouldProtect should return false when disabled, even if loaded")
+}

--- a/zen/protect.go
+++ b/zen/protect.go
@@ -181,6 +181,8 @@ func doProtect(cfg *Config) {
 		return
 	}
 
+	config.SetZenLoaded(true)
+
 	log.Info("Aikido Zen loaded!",
 		slog.String("version", globals.EnvironmentConfig.Version))
 }
@@ -247,4 +249,10 @@ func getEnvBool(name string) bool {
 // The disabled state is determined by the AIKIDO_DISABLE environment variable at startup.
 func IsDisabled() bool {
 	return config.IsZenDisabled()
+}
+
+// ShouldProtect returns true if protection should run.
+// Protection runs when zen is not disabled AND has been loaded successfully via Protect().
+func ShouldProtect() bool {
+	return config.ShouldProtect()
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added ShouldProtect API and zen loaded flag in config
* Set Zen loaded state when Protect completed initialization

**🔧 Refactors**
* Replaced zen.IsDisabled checks with ShouldProtect in middlewares
* Replaced zen.IsDisabled checks with ShouldProtect in examine sinks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/76862140?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->