### PR TITLE
Add version to zen-go hash

### DIFF
--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -31,7 +31,7 @@ func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string
 		return err
 	}
 
-	rulesHash := internal.ComputeInstrumentationHash(inst)
+	rulesHash := internal.ComputeInstrumentationHash(inst, version)
 
 	// Append our hash to the version string
 	versionStr := strings.TrimSpace(versionOutput.String())

--- a/cmd/zen-go/internal/hash.go
+++ b/cmd/zen-go/internal/hash.go
@@ -7,10 +7,13 @@ import (
 	"sort"
 )
 
-// ComputeInstrumentationHash computes a hash of all instrumentation rules.
-// This hash is used to modify the build ID so that when rules change, Go will rebuild packages.
-func ComputeInstrumentationHash(inst *Instrumentor) string {
+// ComputeInstrumentationHash computes a hash of all instrumentation rules and the zen-go version.
+// This hash is used to modify the build ID so that when rules or the version change, Go will rebuild packages.
+func ComputeInstrumentationHash(inst *Instrumentor, version string) string {
 	h := sha256.New()
+
+	// Hash the zen-go version
+	fmt.Fprintf(h, "version:%s\n", version)
 
 	// Hash wrap rules
 	for _, rule := range inst.WrapRules {

--- a/cmd/zen-go/internal/hash_test.go
+++ b/cmd/zen-go/internal/hash_test.go
@@ -11,13 +11,13 @@ func TestComputeInstrumentationHash(t *testing.T) {
 	inst, err := NewInstrumentor()
 	require.NoError(t, err)
 
-	hash := ComputeInstrumentationHash(inst)
+	hash := ComputeInstrumentationHash(inst, "test-version")
 
 	// Hash should be 16 characters (base64 encoded, truncated)
 	assert.Len(t, hash, 16)
 
 	// Hash should be consistent
-	hash2 := ComputeInstrumentationHash(inst)
+	hash2 := ComputeInstrumentationHash(inst, "test-version")
 	assert.Equal(t, hash, hash2)
 }
 
@@ -34,8 +34,8 @@ func TestComputeInstrumentationHash_DifferentRules(t *testing.T) {
 		},
 	}
 
-	hash1 := ComputeInstrumentationHash(inst1)
-	hash2 := ComputeInstrumentationHash(inst2)
+	hash1 := ComputeInstrumentationHash(inst1, "test-version")
+	hash2 := ComputeInstrumentationHash(inst2, "test-version")
 
 	assert.NotEqual(t, hash1, hash2)
 }
@@ -45,7 +45,7 @@ func TestComputeInstrumentationHash_EmptyRules(t *testing.T) {
 		WrapRules: []WrapRule{},
 	}
 
-	hash := ComputeInstrumentationHash(inst)
+	hash := ComputeInstrumentationHash(inst, "test-version")
 	assert.Len(t, hash, 16)
 }
 
@@ -62,8 +62,8 @@ func TestComputeInstrumentationHash_DifferentPrependRules(t *testing.T) {
 		},
 	}
 
-	hash1 := ComputeInstrumentationHash(inst1)
-	hash2 := ComputeInstrumentationHash(inst2)
+	hash1 := ComputeInstrumentationHash(inst1, "test-version")
+	hash2 := ComputeInstrumentationHash(inst2, "test-version")
 
 	assert.NotEqual(t, hash1, hash2)
 }
@@ -81,8 +81,8 @@ func TestComputeInstrumentationHash_DifferentInjectDeclRules(t *testing.T) {
 		},
 	}
 
-	hash1 := ComputeInstrumentationHash(inst1)
-	hash2 := ComputeInstrumentationHash(inst2)
+	hash1 := ComputeInstrumentationHash(inst1, "test-version")
+	hash2 := ComputeInstrumentationHash(inst2, "test-version")
 
 	assert.NotEqual(t, hash1, hash2)
 }
@@ -124,10 +124,23 @@ func TestComputeInstrumentationHash_AllRuleTypes(t *testing.T) {
 		},
 	}
 
-	hash1 := ComputeInstrumentationHash(inst1)
-	hash2 := ComputeInstrumentationHash(inst2)
-	hash3 := ComputeInstrumentationHash(inst3)
+	hash1 := ComputeInstrumentationHash(inst1, "test-version")
+	hash2 := ComputeInstrumentationHash(inst2, "test-version")
+	hash3 := ComputeInstrumentationHash(inst3, "test-version")
 
 	assert.NotEqual(t, hash1, hash2, "hash should change when prepend rule changes")
 	assert.NotEqual(t, hash2, hash3, "hash should change when inject-decl rule changes")
+}
+
+func TestComputeInstrumentationHash_DifferentVersions(t *testing.T) {
+	inst := &Instrumentor{
+		WrapRules: []WrapRule{
+			{ID: "test1", MatchCall: "pkg.Func"},
+		},
+	}
+
+	hash1 := ComputeInstrumentationHash(inst, "1.0.0")
+	hash2 := ComputeInstrumentationHash(inst, "1.0.1")
+
+	assert.NotEqual(t, hash1, hash2, "hash should change when version changes")
 }


### PR DESCRIPTION
Ensure Go rebuilds when zen-go is updated.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included zen-go version in instrumentation hash and updated callers.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/77139569?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->