### PR TITLE
Add multi-segment params support to net/http

### DIFF
--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -122,7 +122,7 @@ func extractRouteParams(r *http.Request, pattern string) map[string]string {
 	remaining := pattern
 
 	// Find all wildcard parameters in the pattern
-	// Pattern examples: "/users/{id}", "/posts/{id}/comments/{commentId}"
+	// Pattern examples: "/users/{id}", "/posts/{id}/comments/{commentId}", "/files/{path...}"
 	for {
 		start := strings.Index(remaining, "{")
 		if start == -1 {
@@ -134,6 +134,8 @@ func extractRouteParams(r *http.Request, pattern string) map[string]string {
 		}
 
 		paramName := remaining[start+1 : start+end]
+		// Strip "..." suffix for multi-segment wildcards
+		paramName = strings.TrimSuffix(paramName, "...")
 		// Use PathValue to get the actual value from the request
 		params[paramName] = r.PathValue(paramName)
 

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -244,6 +244,18 @@ func TestExtractRouteParams(t *testing.T) {
 			path:     "/api/v1/users",
 			expected: map[string]string{"version": "v1"},
 		},
+		{
+			name:     "multi segment wildcard",
+			pattern:  "/files/{path...}",
+			path:     "/files/a/b/c",
+			expected: map[string]string{"path": "a/b/c"},
+		},
+		{
+			name:     "empty multi segment wildcard",
+			pattern:  "/files/{path...}",
+			path:     "/files/",
+			expected: map[string]string{"path": ""},
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,7 +263,7 @@ func TestExtractRouteParams(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc(tt.pattern, func(w http.ResponseWriter, r *http.Request) {})
 
-			req := httptest.NewRequest("GET", tt.path, http.NoBody)
+			req := httptest.NewRequest(http.MethodGet, tt.path, http.NoBody)
 			w := httptest.NewRecorder()
 
 			mux.ServeHTTP(w, req)


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added support for multi-segment route parameters in extraction


<sup>[More info](https://app.aikido.dev/featurebranch/scan/78864040?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->