### PR TITLE
Add rules and paths packages to zen-go

### DIFF
--- a/cmd/zen-go/internal/hash_test.go
+++ b/cmd/zen-go/internal/hash_test.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"testing"
 
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,13 +24,13 @@ func TestComputeInstrumentationHash(t *testing.T) {
 
 func TestComputeInstrumentationHash_DifferentRules(t *testing.T) {
 	inst1 := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "test1", MatchCall: "pkg.Func1"},
 		},
 	}
 
 	inst2 := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "test2", MatchCall: "pkg.Func2"},
 		},
 	}
@@ -42,7 +43,7 @@ func TestComputeInstrumentationHash_DifferentRules(t *testing.T) {
 
 func TestComputeInstrumentationHash_EmptyRules(t *testing.T) {
 	inst := &Instrumentor{
-		WrapRules: []WrapRule{},
+		WrapRules: []rules.WrapRule{},
 	}
 
 	hash := ComputeInstrumentationHash(inst, "test-version")
@@ -51,13 +52,13 @@ func TestComputeInstrumentationHash_EmptyRules(t *testing.T) {
 
 func TestComputeInstrumentationHash_DifferentPrependRules(t *testing.T) {
 	inst1 := &Instrumentor{
-		PrependRules: []PrependRule{
+		PrependRules: []rules.PrependRule{
 			{ID: "test1", Package: "os", FuncNames: []string{"Open"}},
 		},
 	}
 
 	inst2 := &Instrumentor{
-		PrependRules: []PrependRule{
+		PrependRules: []rules.PrependRule{
 			{ID: "test2", Package: "os", FuncNames: []string{"Create"}},
 		},
 	}
@@ -70,13 +71,13 @@ func TestComputeInstrumentationHash_DifferentPrependRules(t *testing.T) {
 
 func TestComputeInstrumentationHash_DifferentInjectDeclRules(t *testing.T) {
 	inst1 := &Instrumentor{
-		InjectDeclRules: []InjectDeclRule{
+		InjectDeclRules: []rules.InjectDeclRule{
 			{ID: "test1", Package: "os", AnchorFunc: "Getpid"},
 		},
 	}
 
 	inst2 := &Instrumentor{
-		InjectDeclRules: []InjectDeclRule{
+		InjectDeclRules: []rules.InjectDeclRule{
 			{ID: "test2", Package: "os", AnchorFunc: "Getuid"},
 		},
 	}
@@ -89,37 +90,37 @@ func TestComputeInstrumentationHash_DifferentInjectDeclRules(t *testing.T) {
 
 func TestComputeInstrumentationHash_AllRuleTypes(t *testing.T) {
 	inst1 := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "wrap1", MatchCall: "pkg.Func"},
 		},
-		PrependRules: []PrependRule{
+		PrependRules: []rules.PrependRule{
 			{ID: "prepend1", Package: "os", FuncNames: []string{"Open"}},
 		},
-		InjectDeclRules: []InjectDeclRule{
+		InjectDeclRules: []rules.InjectDeclRule{
 			{ID: "inject1", Package: "os", AnchorFunc: "Getpid"},
 		},
 	}
 
 	inst2 := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "wrap1", MatchCall: "pkg.Func"},
 		},
-		PrependRules: []PrependRule{
+		PrependRules: []rules.PrependRule{
 			{ID: "prepend2", Package: "os", FuncNames: []string{"Open"}}, // Different ID
 		},
-		InjectDeclRules: []InjectDeclRule{
+		InjectDeclRules: []rules.InjectDeclRule{
 			{ID: "inject1", Package: "os", AnchorFunc: "Getpid"},
 		},
 	}
 
 	inst3 := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "wrap1", MatchCall: "pkg.Func"},
 		},
-		PrependRules: []PrependRule{
+		PrependRules: []rules.PrependRule{
 			{ID: "prepend2", Package: "os", FuncNames: []string{"Open"}},
 		},
-		InjectDeclRules: []InjectDeclRule{
+		InjectDeclRules: []rules.InjectDeclRule{
 			{ID: "inject1", Package: "os", AnchorFunc: "Getuid"}, // Different anchor
 		},
 	}
@@ -134,7 +135,7 @@ func TestComputeInstrumentationHash_AllRuleTypes(t *testing.T) {
 
 func TestComputeInstrumentationHash_DifferentVersions(t *testing.T) {
 	inst := &Instrumentor{
-		WrapRules: []WrapRule{
+		WrapRules: []rules.WrapRule{
 			{ID: "test1", MatchCall: "pkg.Func"},
 		},
 	}

--- a/cmd/zen-go/internal/importcfg.go
+++ b/cmd/zen-go/internal/importcfg.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/paths"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -101,7 +102,7 @@ func createTempFile(objdir string) (*os.File, error) {
 // GetPackageExport returns the file path to the compiled export data for the given import path.
 // It runs 'go list -export' from the module root.
 func GetPackageExport(importPath string) (string, error) {
-	dir := findModuleRoot()
+	dir := paths.FindModuleRoot()
 
 	// Pass original build flags to packages.Load to prevent cache misses and fingerprint errors.
 	buildFlags, err := parentBuildFlags()
@@ -130,22 +131,4 @@ func GetPackageExport(importPath string) (string, error) {
 	}
 
 	return pkgs[0].ExportFile, err
-}
-
-func findModuleRoot() string {
-	dir, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return ""
-		}
-		dir = parent
-	}
 }

--- a/cmd/zen-go/internal/importcfg_test.go
+++ b/cmd/zen-go/internal/importcfg_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/paths"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +89,7 @@ func TestFindModuleRoot(t *testing.T) {
 	require.NoError(t, os.MkdirAll(subDir, 0755))
 	require.NoError(t, os.Chdir(subDir))
 
-	root := findModuleRoot()
+	root := paths.FindModuleRoot()
 
 	expectedRoot, _ := filepath.EvalSymlinks(tmpDir)
 	actualRoot, _ := filepath.EvalSymlinks(root)
@@ -103,7 +104,7 @@ func TestFindModuleRoot_NoGoMod(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, os.Chdir(tmpDir))
 
-	root := findModuleRoot()
+	root := paths.FindModuleRoot()
 	assert.Empty(t, root)
 }
 

--- a/cmd/zen-go/internal/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor.go
@@ -8,24 +8,27 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/paths"
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
 type Instrumentor struct {
-	WrapRules       []WrapRule
-	PrependRules    []PrependRule
-	InjectDeclRules []InjectDeclRule
+	WrapRules       []rules.WrapRule
+	PrependRules    []rules.PrependRule
+	InjectDeclRules []rules.InjectDeclRule
 }
 
 // NewInstrumentor creates a new Instrumentor, loading rules from YAML files
 func NewInstrumentor() (*Instrumentor, error) {
 	// Try to load rules from the instrumentation directory
-	if instDir := findInstrumentationDir(); instDir != "" {
-		rules, err := loadRulesFromDir(instDir)
+	if instDir := paths.FindInstrumentationDir(); instDir != "" {
+		rulesData, err := rules.LoadRulesFromDir(instDir)
 		if err != nil {
 			return nil, err
 		}
 
-		return NewInstrumentorWithRules(rules), nil
+		return NewInstrumentorWithRules(rulesData), nil
 	}
 
 	// No rules found
@@ -33,7 +36,7 @@ func NewInstrumentor() (*Instrumentor, error) {
 }
 
 // NewInstrumentorWithRules creates an Instrumentor with the given rules
-func NewInstrumentorWithRules(rules *InstrumentationRules) *Instrumentor {
+func NewInstrumentorWithRules(rules *rules.InstrumentationRules) *Instrumentor {
 	return &Instrumentor{
 		WrapRules:       rules.WrapRules,
 		PrependRules:    rules.PrependRules,

--- a/cmd/zen-go/internal/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor_test.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // testChiRules returns rules for testing chi instrumentation (with /v5 version in path)
-func testChiRules() []WrapRule {
-	return []WrapRule{
+func testChiRules() []rules.WrapRule {
+	return []rules.WrapRule{
 		{
 			ID:        "chi.NewMux",
 			MatchCall: "github.com/go-chi/chi/v5.NewMux",
@@ -33,8 +34,8 @@ func testChiRules() []WrapRule {
 }
 
 // testGinRules returns rules for testing gin instrumentation
-func testGinRules() []WrapRule {
-	return []WrapRule{
+func testGinRules() []rules.WrapRule {
+	return []rules.WrapRule{
 		{
 			ID:        "gin.Default",
 			MatchCall: "github.com/gin-gonic/gin.Default",
@@ -68,7 +69,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testChiRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -95,7 +96,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testChiRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -119,7 +120,7 @@ func WithRouter() *chi.Mux {
 	tmpFile := filepath.Join(tmpDir, "middleware.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	rules := []WrapRule{
+	wrapRules := []rules.WrapRule{
 		{
 			ID:          "chi.NewRouter",
 			MatchCall:   "github.com/go-chi/chi/v5.NewRouter",
@@ -128,7 +129,7 @@ func WithRouter() *chi.Mux {
 			WrapTmpl:    `func() *chi.Mux { r := {{.}}; r.Use(zenchi.GetMiddleware()); return r }()`,
 		},
 	}
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: rules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: wrapRules})
 	result, err := inst.InstrumentFile(tmpFile, "github.com/go-chi/chi/v5/middleware")
 
 	require.NoError(t, err)
@@ -149,7 +150,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -176,7 +177,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -200,7 +201,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -222,7 +223,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -249,7 +250,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -276,7 +277,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -302,7 +303,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -314,7 +315,7 @@ func TestInstrumentFile_InvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "nonexistent.go")
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -333,7 +334,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{WrapRules: testGinRules()})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -358,7 +359,7 @@ func main() {
 	inst, err := NewInstrumentor()
 	require.NoError(t, err)
 
-	inst.WrapRules = []WrapRule{
+	inst.WrapRules = []rules.WrapRule{
 		{
 			ID:        "gin.Default",
 			MatchCall: "github.com/gin-gonic/gin.Default",
@@ -392,7 +393,7 @@ type Rows struct{}
 	tmpFile := filepath.Join(tmpDir, "db.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:           "sql.DB.QueryContext",
 			ReceiverType: "*database/sql.DB",
@@ -406,7 +407,7 @@ type Rows struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "database/sql")
 
 	require.NoError(t, err)
@@ -431,7 +432,7 @@ func DoSomething() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:           "sql.DB.QueryContext",
 			ReceiverType: "*database/sql.DB",
@@ -441,7 +442,7 @@ func DoSomething() {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -475,7 +476,7 @@ func (c *Cmd) Wait() error {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
 	// Single rule that matches both Run and Start, but not Wait
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:           "exec.Cmd.RunOrStart",
 			ReceiverType: "*os/exec.Cmd",
@@ -485,7 +486,7 @@ func (c *Cmd) Wait() error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os/exec")
 
 	require.NoError(t, err)
@@ -509,7 +510,7 @@ type File struct{}
 	tmpFile := filepath.Join(tmpDir, "file.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:        "os.OpenFile",
 			Package:   "os",
@@ -521,7 +522,7 @@ type File struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -544,7 +545,7 @@ func OpenFile(name string) error {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:          "os.OpenFile",
 			Package:     "os", // Rule targets "os" package
@@ -554,7 +555,7 @@ func OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "main") // Compiling "main" package
 
 	require.NoError(t, err)
@@ -574,7 +575,7 @@ func (f *File) OpenFile(name string) error {
 	tmpFile := filepath.Join(tmpDir, "file.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	prependRules := []PrependRule{
+	prependRules := []rules.PrependRule{
 		{
 			ID:          "os.OpenFile",
 			Package:     "os", // Standalone function rule
@@ -584,7 +585,7 @@ func (f *File) OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{PrependRules: prependRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -607,7 +608,7 @@ func OpenFile(name string) error {
 	tmpFile := filepath.Join(tmpDir, "proc.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	injectDeclRules := []InjectDeclRule{
+	injectDeclRules := []rules.InjectDeclRule{
 		{
 			ID:         "os.linkname",
 			Package:    "os",
@@ -618,7 +619,7 @@ func __example_check(string) error`,
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{InjectDeclRules: injectDeclRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -643,7 +644,7 @@ func SomeOtherFunc() {
 	tmpFile := filepath.Join(tmpDir, "other.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	injectDeclRules := []InjectDeclRule{
+	injectDeclRules := []rules.InjectDeclRule{
 		{
 			ID:           "os.linkname",
 			Package:      "os",
@@ -653,7 +654,7 @@ func SomeOtherFunc() {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&InstrumentationRules{InjectDeclRules: injectDeclRules})
+	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules})
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)

--- a/cmd/zen-go/internal/paths/paths.go
+++ b/cmd/zen-go/internal/paths/paths.go
@@ -1,0 +1,55 @@
+package paths
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// FindModuleRoot finds the root directory of the current Go module
+func FindModuleRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// FindInstrumentationDir finds the instrumentation directory from the firewall-go module
+func FindInstrumentationDir() string {
+	// Use go list to find where the firewall-go module is located
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/AikidoSec/firewall-go")
+
+	// Run from the module root if we can find it
+	if modRoot := FindModuleRoot(); modRoot != "" {
+		cmd.Dir = modRoot
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	modDir := strings.TrimSpace(string(output))
+	if modDir == "" {
+		return ""
+	}
+
+	instDir := filepath.Join(modDir, "instrumentation")
+	if info, err := os.Stat(instDir); err == nil && info.IsDir() {
+		return instDir
+	}
+
+	return ""
+}

--- a/cmd/zen-go/internal/rules/rules.go
+++ b/cmd/zen-go/internal/rules/rules.go
@@ -1,10 +1,9 @@
-package internal
+package rules
 
 import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -76,8 +75,8 @@ type InjectDeclRule struct {
 	DeclTemplate string   // The declaration to inject
 }
 
-// loadRulesFromDir loads all zen.instrument.yml files from a directory tree
-func loadRulesFromDir(dir string) (*InstrumentationRules, error) {
+// LoadRulesFromDir loads all zen.instrument.yml files from a directory tree
+func LoadRulesFromDir(dir string) (*InstrumentationRules, error) {
 	result := &InstrumentationRules{}
 
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
@@ -157,32 +156,4 @@ func loadRulesFromFile(path string) (*InstrumentationRules, error) {
 	}
 
 	return result, nil
-}
-
-// findInstrumentationDir finds the instrumentation directory from the firewall-go module
-func findInstrumentationDir() string {
-	// Use go list to find where the firewall-go module is located
-	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/AikidoSec/firewall-go")
-
-	// Run from the module root if we can find it
-	if modRoot := findModuleRoot(); modRoot != "" {
-		cmd.Dir = modRoot
-	}
-
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	modDir := strings.TrimSpace(string(output))
-	if modDir == "" {
-		return ""
-	}
-
-	instDir := filepath.Join(modDir, "instrumentation")
-	if info, err := os.Stat(instDir); err == nil && info.IsDir() {
-		return instDir
-	}
-
-	return ""
 }

--- a/cmd/zen-go/internal/rules/rules_test.go
+++ b/cmd/zen-go/internal/rules/rules_test.go
@@ -1,4 +1,4 @@
-package internal
+package rules
 
 import (
 	"os"
@@ -137,7 +137,7 @@ rules:
 	err = os.WriteFile(yamlPath, []byte(yamlContent), 0o600)
 	require.NoError(t, err)
 
-	rules, err := loadRulesFromDir(tmpDir)
+	rules, err := LoadRulesFromDir(tmpDir)
 	require.NoError(t, err)
 	require.Len(t, rules.WrapRules, 1)
 
@@ -170,7 +170,7 @@ rules:
 		require.NoError(t, err)
 	}
 
-	rules, err := loadRulesFromDir(tmpDir)
+	rules, err := LoadRulesFromDir(tmpDir)
 	require.NoError(t, err)
 	require.Len(t, rules.WrapRules, 2)
 }
@@ -220,7 +220,7 @@ func TestLoadRulesFromFile_InvalidYAML(t *testing.T) {
 func TestLoadRulesFromDir_EmptyDir(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	rules, err := loadRulesFromDir(tmpDir)
+	rules, err := LoadRulesFromDir(tmpDir)
 	require.NoError(t, err)
 	assert.Empty(t, rules.WrapRules)
 	assert.Empty(t, rules.PrependRules)

--- a/cmd/zen-go/internal/transform_inject_decl.go
+++ b/cmd/zen-go/internal/transform_inject_decl.go
@@ -6,11 +6,13 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
 // transformDeclsInjectDecl injects declarations (like go:linkname) into a file.
 // The declaration is inserted immediately before the anchor function.
-func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule InjectDeclRule, modified *bool, linksToAdd *[]string) error {
+func transformDeclsInjectDecl(f *ast.File, fset *token.FileSet, rule rules.InjectDeclRule, modified *bool, linksToAdd *[]string) error {
 	anchorIndex := findAnchorFunction(f, rule.AnchorFunc)
 	if anchorIndex == -1 {
 		return nil // Anchor function not found, skip

--- a/cmd/zen-go/internal/transform_prepend.go
+++ b/cmd/zen-go/internal/transform_prepend.go
@@ -8,12 +8,14 @@ import (
 	"go/token"
 	"slices"
 	"text/template"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
 // transformDeclsPrepend finds function declarations matching the prepend rule
 // and prepends statements to the function body.
 // Supports both methods (with receiver) and standalone functions (without receiver).
-func transformDeclsPrepend(decls []ast.Decl, compilingPkg string, rule PrependRule, modified *bool, importsToAdd map[string]string) error {
+func transformDeclsPrepend(decls []ast.Decl, compilingPkg string, rule rules.PrependRule, modified *bool, importsToAdd map[string]string) error {
 	for _, decl := range decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {

--- a/cmd/zen-go/internal/transform_wrap.go
+++ b/cmd/zen-go/internal/transform_wrap.go
@@ -7,11 +7,13 @@ import (
 	"go/printer"
 	"go/token"
 	"strings"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
 // transformDeclsWrap walks through all declarations in a file looking for function
 // declarations, then recursively transforms any matching function calls within them.
-func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) error {
+func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
 	for _, decl := range decls {
 		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
 			err := transformStmtsWrap(fn.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
@@ -32,7 +34,7 @@ func transformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName
 // - Expression statements (pkg.Func())
 // - Return statements (return pkg.Func())
 // - Control flow blocks (if/for/switch/select bodies)
-func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) error {
+func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
 		case *ast.AssignStmt:
@@ -144,7 +146,7 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 // 5. If all match, wrap the call using the rule's template
 //
 // Returns the wrapped expression if transformation occurred, nil otherwise.
-func tryTransformCall(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule WrapRule, modified *bool, importsToAdd map[string]string) (ast.Expr, error) {
+func tryTransformCall(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) (ast.Expr, error) {
 	// Step 1: Check if this is a function call at all
 	call, ok := expr.(*ast.CallExpr)
 	if !ok {


### PR DESCRIPTION
Cleaning up the internal package, and starting to split into smaller pkgs.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added paths package providing module and instrumentation directory discovery
* Added rules package to parse YAML and load instrumentation rules

**⚡ Enhancements**
* Updated Instrumentor to discover and load rules using packages

**🔧 Refactors**
* Refactored internal functions to use new rules package types


<sup>[More info](https://app.aikido.dev/featurebranch/scan/79144521?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->