### PR TITLE
Add flags for providing sinks/sources

### DIFF
--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -130,6 +130,9 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 		if err != nil {
 			return err
 		}
+		if len(selectedSources) == 0 && sourcesFlag == "" {
+			fmt.Fprintln(stdout, "No sources selected (empty argument provided)")
+		}
 	} else {
 		selectedSources, err = promptForSources()
 		if err != nil {
@@ -142,6 +145,9 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 		selectedSinks, err = parseAndValidateList(sinksFlag, availableSinks, "sink")
 		if err != nil {
 			return err
+		}
+		if len(selectedSinks) == 0 && sinksFlag == "" {
+			fmt.Fprintln(stdout, "No sinks selected (empty argument provided)")
 		}
 	} else {
 		selectedSinks, err = promptForSinks()

--- a/cmd/zen-go/cmd_init_test.go
+++ b/cmd/zen-go/cmd_init_test.go
@@ -24,7 +24,7 @@ func TestInitCommand_DoesNotOverwriteExistingFile(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false)
+	err = initCommand(&buf, false, "", false, "", false)
 	require.NoError(t, err)
 
 	// Verify file content was not overwritten
@@ -99,4 +99,145 @@ func TestGenerateToolsFile_OnlySinksSelected(t *testing.T) {
 	assert.NotContains(t, content, "// Aikido Zen: Sources")
 	assert.Contains(t, content, "// Aikido Zen: Sinks")
 	assert.Contains(t, content, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx")
+}
+
+func TestParseAndValidateList_ValidSources(t *testing.T) {
+	result, err := parseAndValidateList("gin,chi", availableSources, "source")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gin", "chi"}, result)
+}
+
+func TestParseAndValidateList_ValidSourcesWithWhitespace(t *testing.T) {
+	result, err := parseAndValidateList("gin, chi , echo/v4", availableSources, "source")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gin", "chi", "echo/v4"}, result)
+}
+
+func TestParseAndValidateList_InvalidSource(t *testing.T) {
+	result, err := parseAndValidateList("gin,invalid", availableSources, "source")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "invalid source(s): invalid")
+	assert.Contains(t, err.Error(), "Available sources:")
+}
+
+func TestParseAndValidateList_EmptyString(t *testing.T) {
+	result, err := parseAndValidateList("", availableSources, "source")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, result)
+}
+
+func TestParseAndValidateList_ValidSinks(t *testing.T) {
+	result, err := parseAndValidateList("pgx", availableSinks, "sink")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pgx"}, result)
+}
+
+func TestInitCommand_WithSourcesAndSinksFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, "gin", true, "pgx", true)
+	require.NoError(t, err)
+
+	// Verify file was created
+	filename := "zen.tool.go"
+	content, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	// Verify both sources and sinks are included
+	contentStr := string(content)
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin")
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx")
+
+	// Verify output message
+	output := buf.String()
+	assert.Contains(t, output, "Created zen.tool.go")
+	assert.Contains(t, output, "Sources: gin")
+	assert.Contains(t, output, "Sinks: pgx")
+}
+
+func TestInitCommand_WithInvalidSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, "invalid", true, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source(s): invalid")
+}
+
+func TestInitCommand_WithEmptySourcesFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, "", true, "pgx", true)
+	require.NoError(t, err)
+
+	// Verify file was created
+	filename := "zen.tool.go"
+	content, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	// Verify no sources section
+	contentStr := string(content)
+	assert.NotContains(t, contentStr, "// Aikido Zen: Sources")
+
+	// Verify sinks are included
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx")
+
+	// Verify output message
+	output := buf.String()
+	assert.Contains(t, output, "Created zen.tool.go")
+	assert.NotContains(t, output, "Sources:")
+	assert.Contains(t, output, "Sinks: pgx")
+}
+
+func TestInitCommand_WithEmptySinksFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, "gin", true, "", true)
+	require.NoError(t, err)
+
+	// Verify file was created
+	filename := "zen.tool.go"
+	content, err := os.ReadFile(filename)
+	require.NoError(t, err)
+
+	// Verify sources are included
+	contentStr := string(content)
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin")
+
+	// Verify no sinks section
+	assert.NotContains(t, contentStr, "// Aikido Zen: Sinks")
+
+	// Verify output message
+	output := buf.String()
+	assert.Contains(t, output, "Created zen.tool.go")
+	assert.Contains(t, output, "Sources: gin")
+	assert.NotContains(t, output, "Sinks:")
 }

--- a/cmd/zen-go/cmd_init_test.go
+++ b/cmd/zen-go/cmd_init_test.go
@@ -205,6 +205,7 @@ func TestInitCommand_WithEmptySourcesFlag(t *testing.T) {
 
 	// Verify output message
 	output := buf.String()
+	assert.Contains(t, output, "No sources selected (empty argument provided)")
 	assert.Contains(t, output, "Created zen.tool.go")
 	assert.NotContains(t, output, "Sources:")
 	assert.Contains(t, output, "Sinks: pgx")
@@ -237,6 +238,7 @@ func TestInitCommand_WithEmptySinksFlag(t *testing.T) {
 
 	// Verify output message
 	output := buf.String()
+	assert.Contains(t, output, "No sinks selected (empty argument provided)")
 	assert.Contains(t, output, "Created zen.tool.go")
 	assert.Contains(t, output, "Sources: gin")
 	assert.NotContains(t, output, "Sinks:")

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -31,9 +31,24 @@ func newCommand() *cli.Command {
 						Aliases: []string{"f"},
 						Usage:   "Force overwrite existing zen.tool.go file",
 					},
+					&cli.StringFlag{
+						Name:  "sources",
+						Usage: "Comma-separated list of sources to instrument (e.g., 'gin,chi,echo/v4'). Skips interactive prompt.",
+					},
+					&cli.StringFlag{
+						Name:  "sinks",
+						Usage: "Comma-separated list of sinks to instrument (e.g., 'pgx'). Skips interactive prompt.",
+					},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
-					return initCommand(cmd.Root().Writer, cmd.Bool("force"))
+					return initCommand(
+						cmd.Root().Writer,
+						cmd.Bool("force"),
+						cmd.String("sources"),
+						cmd.IsSet("sources"),
+						cmd.String("sinks"),
+						cmd.IsSet("sinks"),
+					)
 				},
 			},
 			{


### PR DESCRIPTION
Allow calling `init` programmatically with flags for sinks/sources. It will be used as part of testing the compiler.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added CLI flags for specifying sources and sinks non-interactively
* Updated init command to accept flags and skip interactive prompts
* Added parseAndValidateList to parse and validate comma-separated inputs
* Logged notice when empty sources or sinks flag was explicitly provided

**🔧 Refactors**
* Split combined prompt into promptForSources and promptForSinks functions


<sup>[More info](https://app.aikido.dev/featurebranch/scan/80545373?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->