### PR TITLE
Get directories of sub modules for loading rules

### DIFF
--- a/cmd/zen-go/internal/paths/paths_test.go
+++ b/cmd/zen-go/internal/paths/paths_test.go
@@ -1,0 +1,88 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectInstrumentationDirs_RootAndSeparateSubmodules(t *testing.T) {
+	// Simulate module cache layout where submodules are in separate directories
+	// (this is the case when packages are installed via go get)
+	rootDir := t.TempDir()
+	instDir := filepath.Join(rootDir, "instrumentation")
+	require.NoError(t, os.MkdirAll(filepath.Join(instDir, "sinks", "os"), 0o755))
+
+	ginDir := t.TempDir() // Separate dir for gin submodule
+	pgxDir := t.TempDir() // Separate dir for pgx submodule
+
+	dirs := collectInstrumentationDirs(rootDir, []string{ginDir, pgxDir})
+
+	assert.Equal(t, []string{instDir, ginDir, pgxDir}, dirs)
+}
+
+func TestCollectInstrumentationDirs_ReplaceDirective(t *testing.T) {
+	// Simulate local development with replace directives:
+	// submodule dirs are subdirectories of the root instrumentation dir.
+	// Both are included because LoadRulesFromDir handles dedup by skipping
+	// subdirectories that have their own go.mod.
+	rootDir := t.TempDir()
+	instDir := filepath.Join(rootDir, "instrumentation")
+	ginDir := filepath.Join(instDir, "sources", "gin-gonic", "gin")
+	pgxDir := filepath.Join(instDir, "sinks", "jackc", "pgx.v5")
+
+	require.NoError(t, os.MkdirAll(ginDir, 0o755))
+	require.NoError(t, os.MkdirAll(pgxDir, 0o755))
+
+	dirs := collectInstrumentationDirs(rootDir, []string{ginDir, pgxDir})
+
+	// All dirs are returned; LoadRulesFromDir skips submodule subdirs during walk
+	assert.Equal(t, []string{instDir, ginDir, pgxDir}, dirs)
+}
+
+func TestCollectInstrumentationDirs_NoRootModule(t *testing.T) {
+	// Only submodules, no root module (e.g., user only imports a specific instrumentation package)
+	ginDir := t.TempDir()
+
+	dirs := collectInstrumentationDirs("", []string{ginDir})
+
+	assert.Equal(t, []string{ginDir}, dirs)
+}
+
+func TestCollectInstrumentationDirs_NoSubmodules(t *testing.T) {
+	// Only root module, no submodules
+	rootDir := t.TempDir()
+	instDir := filepath.Join(rootDir, "instrumentation")
+	require.NoError(t, os.MkdirAll(instDir, 0o755))
+
+	dirs := collectInstrumentationDirs(rootDir, nil)
+
+	assert.Equal(t, []string{instDir}, dirs)
+}
+
+func TestCollectInstrumentationDirs_Empty(t *testing.T) {
+	dirs := collectInstrumentationDirs("", nil)
+
+	assert.Empty(t, dirs)
+}
+
+func TestCollectInstrumentationDirs_RootWithoutInstrumentationDir(t *testing.T) {
+	// Root module exists but has no instrumentation/ subdirectory
+	rootDir := t.TempDir()
+	ginDir := t.TempDir()
+
+	dirs := collectInstrumentationDirs(rootDir, []string{ginDir})
+
+	// Only submodule dir should be returned since root has no instrumentation/
+	assert.Equal(t, []string{ginDir}, dirs)
+}
+
+func TestCollectInstrumentationDirs_NonexistentRootModule(t *testing.T) {
+	// Root module path doesn't exist on disk
+	dirs := collectInstrumentationDirs("/nonexistent/path", nil)
+
+	assert.Empty(t, dirs)
+}

--- a/instrumentation/sinks/jackc/pgx.v5/go.mod
+++ b/instrumentation/sinks/jackc/pgx.v5/go.mod
@@ -2,7 +2,7 @@ module github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5
 
 go 1.24.2
 
-replace github.com/aikidoSec/firewall-go => ../../../../
+replace github.com/AikidoSec/firewall-go => ../../../../
 
 require (
 	github.com/AikidoSec/firewall-go v0.0.0-20260205155144-7e398694c761


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added functions to discover instrumentation directories across module and submodules
* Updated rules loader to skip subdirectories that are separate Go modules
* Aggregated and loaded instrumentation rules from multiple discovered instrumentation directories


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82007139?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->