### PR TITLE
Use commit versions for firewall-go for QA action

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -29,17 +29,10 @@ jobs:
 
       - name: Use local firewall-go
         run: |
-          cp -r firewall-go zen-demo-go/firewall-go-local
           cd zen-demo-go
-          go mod edit -replace github.com/AikidoSec/firewall-go=./firewall-go-local
-          go mod edit -replace github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin=./firewall-go-local/instrumentation/sources/gin-gonic/gin
+          go get github.com/AikidoSec/firewall-go@$GITHUB_SHA
+          go get github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin@$GITHUB_SHA
           go mod tidy
-
-      - name: Patch Dockerfile for local build
-        run: |
-          cd zen-demo-go
-          # Insert the COPY command after WORKDIR and before go.mod COPY
-          sed -i '/WORKDIR \/app/a COPY firewall-go-local ./firewall-go-local' Dockerfile
 
       - name: Run Firewall QA Tests
         uses: AikidoSec/firewall-tester-action@v1.0.7

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout firewall-go
-        uses: actions/checkout@v5
-        with:
-          path: firewall-go
-
       - name: Checkout zen-demo-go
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -33,6 +33,7 @@ jobs:
           go get github.com/AikidoSec/firewall-go@$GITHUB_SHA
           go get github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin@$GITHUB_SHA
           go mod tidy
+          sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@latest|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
 
       - name: Run Firewall QA Tests
         uses: AikidoSec/firewall-tester-action@v1.0.7


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced local firewall-go checkout with commit-pinned go get calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82033886?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->