### PR TITLE
Check for any version of zen-go in QA step instead of @latest

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -28,7 +28,7 @@ jobs:
           go get github.com/AikidoSec/firewall-go@$GITHUB_SHA
           go get github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin@$GITHUB_SHA
           go mod tidy
-          sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@latest|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
+          sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@[^ ]*|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
 
       - name: Run Firewall QA Tests
         uses: AikidoSec/firewall-tester-action@v1.0.7


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Allowed matching any zen-go version in QA Dockerfile replacement


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82334435?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->