### PR TITLE
Add docs for chi and net/http sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Zen operates autonomously on the same server as your Go app to:
 
 ### Web frameworks
 
+- ✅ [`net/http`](docs/net-http.md) (standard library)
+- ✅ [`Chi`](docs/net-http.md) v5
 - ✅ [`Gin`](docs/gin.md)
 - ✅ [`Echo`](docs/echo.md) v4
 
@@ -102,6 +104,7 @@ export AIKIDO_TOKEN=<YOUR-TOKEN-HERE>
 
 Add middleware to enable user tracking and rate limiting for your framework:
 
+- [net/http / Chi](./docs/net-http.md)
 - [Gin](./docs/gin.md)
 - [Echo](./docs/echo.md)
 

--- a/docs/echo.md
+++ b/docs/echo.md
@@ -7,10 +7,10 @@ If you haven't already, follow the [installation instructions](../README.md#inst
 ## Setting a user
 If you want to use user-blocking, know which user performed an attack and rate-limit on a user basis, you have to set  a user using the following function :
 ```go
-// Setting a user : 
+// Setting a user:
 zen.SetUser(c.Request().Context(), id, name)
 
-// So an example for Bob with id 1 :
+// So an example for Bob with id 1:
 zen.SetUser(c.Request().Context(), "1", "Bob")
 ```
 It's advised to do this in your authentication middleware, and before you add the Aikido Middleware (used for rate-limiting and user blocking, [See here](#middleware))

--- a/docs/net-http.md
+++ b/docs/net-http.md
@@ -1,0 +1,51 @@
+# net/http (Standard Library) and Chi
+
+## Installation
+
+If you haven't already, follow the [installation instructions](../README.md#installation) in the main README.
+
+No additional dependencies are required for `net/http`, support is included in the core `firewall-go` module.
+
+Chi uses the standard `http.Handler` interface, so the setup below applies to both `net/http` and Chi.
+
+## Setting a user
+If you want to use user-blocking, know which user performed an attack and rate-limit on a user basis, you have to set a user using the following function:
+```go
+// Setting a user:
+zen.SetUser(r.Context(), id, name)
+
+// So an example for Bob with id 1:
+zen.SetUser(r.Context(), "1", "Bob")
+```
+It's advised to do this in your authentication middleware, and before you add the Aikido Middleware (used for rate-limiting and user blocking, [See here](#middleware))
+
+## Middleware
+To use rate-limiting or user-blocking we require you to add some middleware yourself.
+Here is an example of how to do that, you can tailor the responses to something that is more appropriate for your app.
+```go
+// ...
+handler := AikidoMiddleware(mux)
+// ...
+func AikidoMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		blockResult := zen.ShouldBlockRequest(r.Context())
+		if blockResult != nil {
+			switch blockResult.Type {
+			case "rate-limited":
+				message := "You are rate limited by Zen."
+				if blockResult.Trigger == "ip" {
+					message += " (Your IP: " + *blockResult.IP + ")"
+				}
+				http.Error(w, message, http.StatusTooManyRequests)
+				return
+			case "blocked":
+				http.Error(w, "You are blocked by Zen.", http.StatusForbidden)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+```
+The important part here is the call to `zen.ShouldBlockRequest()` which returns whether to block the request and the reason why.


### PR DESCRIPTION
Chi uses standard net/http handlers, so we can share docs for the middleware.