### PR TITLE
Warn on requests if zen.Protect() isn't called

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -16,6 +16,7 @@ func GetMiddleware() gin.HandlerFunc {
 		}
 
 		if !zen.ShouldProtect() {
+			zen.WarnIfNotProtected()
 			c.Next()
 			return
 		}

--- a/instrumentation/sources/go-chi/chi.v5/middleware.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware.go
@@ -19,6 +19,7 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !zen.ShouldProtect() {
+				zen.WarnIfNotProtected()
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/instrumentation/sources/labstack/echo.v4/middleware.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware.go
@@ -15,6 +15,7 @@ func GetMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if !zen.ShouldProtect() {
+				zen.WarnIfNotProtected()
 				return next(c)
 			}
 

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -17,6 +17,7 @@ import (
 func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !zen.ShouldProtect() {
+			zen.WarnIfNotProtected()
 			orig(w, r)
 			return
 		}

--- a/internal/agent/config/disabled.go
+++ b/internal/agent/config/disabled.go
@@ -1,9 +1,17 @@
 package config
 
-import "sync/atomic"
+import (
+	"sync"
+	"sync/atomic"
 
-var isZenDisabled atomic.Bool
-var isZenLoaded atomic.Bool
+	"github.com/AikidoSec/firewall-go/internal/log"
+)
+
+var (
+	isZenDisabled atomic.Bool
+	isZenLoaded   atomic.Bool
+	warnOnce      sync.Once
+)
 
 func SetZenDisabled(disabled bool) {
 	isZenDisabled.Store(disabled)
@@ -25,4 +33,21 @@ func IsZenLoaded() bool {
 // Protection runs when zen is not disabled AND has been loaded successfully.
 func ShouldProtect() bool {
 	return !IsZenDisabled() && IsZenLoaded()
+}
+
+// WarnIfNotProtected logs a warning once if zen.Protect() has not been called
+// and Zen is not explicitly disabled. This helps customers notice when they
+// have configured the middleware but forgotten to call zen.Protect().
+func WarnIfNotProtected() {
+	if IsZenLoaded() || IsZenDisabled() {
+		return
+	}
+	warnOnce.Do(func() {
+		log.Warn("Aikido middleware is active but zen.Protect() was not called. Requests will not be protected.")
+	})
+}
+
+// ResetWarnOnce resets the WarnIfNotProtected once guard.
+func ResetWarnOnce() {
+	warnOnce = sync.Once{}
 }

--- a/internal/agent/config/disabled_test.go
+++ b/internal/agent/config/disabled_test.go
@@ -1,9 +1,13 @@
 package config_test
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,4 +70,73 @@ func TestShouldProtect(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestWarnIfNotProtected(t *testing.T) {
+	saveAndRestore := func(t *testing.T) {
+		origDisabled := config.IsZenDisabled()
+		origLoaded := config.IsZenLoaded()
+		origLogger := log.Logger()
+		t.Cleanup(func() {
+			config.SetZenDisabled(origDisabled)
+			config.SetZenLoaded(origLoaded)
+			config.ResetWarnOnce()
+			log.SetLogger(origLogger)
+		})
+	}
+
+	t.Run("warns when not loaded and not disabled", func(t *testing.T) {
+		saveAndRestore(t)
+
+		var buf bytes.Buffer
+		log.SetLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+		config.SetZenDisabled(false)
+		config.SetZenLoaded(false)
+
+		config.WarnIfNotProtected()
+
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=WARN"))
+		assert.Contains(t, buf.String(), "zen.Protect() was not called")
+	})
+
+	t.Run("does not warn when disabled", func(t *testing.T) {
+		saveAndRestore(t)
+
+		var buf bytes.Buffer
+		log.SetLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+		config.SetZenDisabled(true)
+		config.SetZenLoaded(false)
+
+		config.WarnIfNotProtected()
+
+		assert.Equal(t, 0, strings.Count(buf.String(), "level=WARN"))
+	})
+
+	t.Run("does not warn when loaded", func(t *testing.T) {
+		saveAndRestore(t)
+
+		var buf bytes.Buffer
+		log.SetLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+		config.SetZenDisabled(false)
+		config.SetZenLoaded(true)
+
+		config.WarnIfNotProtected()
+
+		assert.Equal(t, 0, strings.Count(buf.String(), "level=WARN"))
+	})
+
+	t.Run("warns only once", func(t *testing.T) {
+		saveAndRestore(t)
+
+		var buf bytes.Buffer
+		log.SetLogger(slog.New(slog.NewTextHandler(&buf, nil)))
+		config.SetZenDisabled(false)
+		config.SetZenLoaded(false)
+
+		config.WarnIfNotProtected()
+		config.WarnIfNotProtected()
+		config.WarnIfNotProtected()
+
+		assert.Equal(t, 1, strings.Count(buf.String(), "level=WARN"))
+	})
 }

--- a/zen/protect.go
+++ b/zen/protect.go
@@ -253,3 +253,10 @@ func IsDisabled() bool {
 func ShouldProtect() bool {
 	return config.ShouldProtect()
 }
+
+// WarnIfNotProtected logs a warning once if zen.Protect() has not been called
+// and zen is not explicitly disabled. Call this when ShouldProtect() returns false
+// to help customers notice they forgot to call zen.Protect().
+func WarnIfNotProtected() {
+	config.WarnIfNotProtected()
+}


### PR DESCRIPTION
Helps diagnose issues where data won't be arriving to Aikido.

**Tested on sample app:**
<img width="799" height="106" alt="image" src="https://github.com/user-attachments/assets/ad7cfa11-bc3b-4e69-8c96-882ab1b12cd1" />
