### PR TITLE
Adjust log for calling SetUser after ShouldBlockRequest

### DIFF
--- a/zen/set_rate_limit_group.go
+++ b/zen/set_rate_limit_group.go
@@ -12,7 +12,7 @@ import (
 var ErrRateLimitGroupIDEmpty = errors.New("group id cannot be empty")
 
 // SetRateLimitGroup associates a group with the current request context which is used for rate limiting.
-// This function must be called before the Zen middleware is executed.
+// This function must be called before zen.ShouldBlockRequest() is called.
 func SetRateLimitGroup(ctx context.Context, id string) (context.Context, error) {
 	if config.IsZenDisabled() {
 		return ctx, nil
@@ -24,7 +24,7 @@ func SetRateLimitGroup(ctx context.Context, id string) (context.Context, error) 
 
 	reqCtx := request.GetContext(ctx)
 	if reqCtx == nil || reqCtx.HasMiddlewareExecuted() {
-		log.Info("zen.SetRateLimitGroup(...) must be called before the Zen middleware is executed.")
+		log.Info("zen.SetRateLimitGroup(...) must be called before zen.ShouldBlockRequest().")
 		return ctx, nil
 	}
 

--- a/zen/set_rate_limit_group.go
+++ b/zen/set_rate_limit_group.go
@@ -23,7 +23,10 @@ func SetRateLimitGroup(ctx context.Context, id string) (context.Context, error) 
 	}
 
 	reqCtx := request.GetContext(ctx)
-	if reqCtx == nil || reqCtx.HasMiddlewareExecuted() {
+	if reqCtx == nil {
+		return ctx, nil
+	}
+	if reqCtx.HasMiddlewareExecuted() {
 		log.Info("zen.SetRateLimitGroup(...) must be called before zen.ShouldBlockRequest().")
 		return ctx, nil
 	}

--- a/zen/set_user.go
+++ b/zen/set_user.go
@@ -13,8 +13,8 @@ import (
 var ErrUserIDOrNameEmpty = errors.New("user id or name cannot be empty")
 
 // SetUser associates a user with the current request context for user-based
-// blocking and rate limiting. This function must be called before the Zen
-// middleware is executed.
+// blocking and rate limiting. This function must be called before
+// zen.ShouldBlockRequest() is called.
 func SetUser(ctx context.Context, id string, name string) (context.Context, error) {
 	if config.IsZenDisabled() {
 		return ctx, nil
@@ -26,7 +26,7 @@ func SetUser(ctx context.Context, id string, name string) (context.Context, erro
 
 	reqCtx := request.GetContext(ctx)
 	if reqCtx == nil || reqCtx.HasMiddlewareExecuted() {
-		log.Info("zen.SetUser(...) must be called before the Zen middleware is executed.")
+		log.Info("zen.SetUser(...) must be called before zen.ShouldBlockRequest().")
 		return ctx, nil
 	}
 

--- a/zen/set_user.go
+++ b/zen/set_user.go
@@ -25,7 +25,10 @@ func SetUser(ctx context.Context, id string, name string) (context.Context, erro
 	}
 
 	reqCtx := request.GetContext(ctx)
-	if reqCtx == nil || reqCtx.HasMiddlewareExecuted() {
+	if reqCtx == nil {
+		return ctx, nil
+	}
+	if reqCtx.HasMiddlewareExecuted() {
 		log.Info("zen.SetUser(...) must be called before zen.ShouldBlockRequest().")
 		return ctx, nil
 	}


### PR DESCRIPTION
Adjusting log message as 'Zen middleware' isn't clear. 
Also not logging the message if there's no request context, it's likely that it wasn't compiled with `zen-go` so isn't relevant. For example, if doing local development.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Adjusted logs and early-returns for SetUser and SetRateLimitGroup functions.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82684004?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->