### PR TITLE
Warn if application isn't compiled with zen-go CLI

### DIFF
--- a/cmd/zen-go/cmd_toolexec_link_test.go
+++ b/cmd/zen-go/cmd_toolexec_link_test.go
@@ -165,6 +165,47 @@ func TestWriteExtendedLinkerImportcfg(t *testing.T) {
 	assert.Contains(t, string(content), "packagefile io=/path/to/io.a")
 }
 
+func TestInsertLinkerFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		flags    []string
+		expected []string
+	}{
+		{
+			name:     "inserts before archive file",
+			args:     []string{"-o", "output", "-importcfg", "/tmp/cfg", "main.a"},
+			flags:    []string{"-X", "pkg.Var=value"},
+			expected: []string{"-o", "output", "-importcfg", "/tmp/cfg", "-X", "pkg.Var=value", "main.a"},
+		},
+		{
+			name:     "works with existing -X flags",
+			args:     []string{"-X", "main.version=1.0", "main.a"},
+			flags:    []string{"-X", "pkg.Var=value"},
+			expected: []string{"-X", "main.version=1.0", "-X", "pkg.Var=value", "main.a"},
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			flags:    []string{"-X", "pkg.Var=value"},
+			expected: []string{"-X", "pkg.Var=value"},
+		},
+		{
+			name:     "single arg",
+			args:     []string{"main.a"},
+			flags:    []string{"-X", "pkg.Var=value"},
+			expected: []string{"-X", "pkg.Var=value", "main.a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertLinkerFlags(tt.args, tt.flags...)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestWriteLinkDepsForArchive_NoLinkDeps(t *testing.T) {
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "test.a")

--- a/internal/agent/config/disabled.go
+++ b/internal/agent/config/disabled.go
@@ -7,6 +7,10 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/log"
 )
 
+// compiledWithZenGo is set to "true" at link time by zen-go toolexec via -ldflags -X.
+// When empty, the binary was not compiled with zen-go and instrumentation is inactive.
+var compiledWithZenGo string
+
 var (
 	isZenDisabled atomic.Bool
 	isZenLoaded   atomic.Bool
@@ -45,6 +49,11 @@ func WarnIfNotProtected() {
 	warnOnce.Do(func() {
 		log.Warn("Aikido middleware is active but zen.Protect() was not called. Requests will not be protected.")
 	})
+}
+
+// IsCompiledWithZenGo returns true if the binary was compiled with zen-go toolexec.
+func IsCompiledWithZenGo() bool {
+	return compiledWithZenGo == "true"
 }
 
 // ResetWarnOnce resets the WarnIfNotProtected once guard.

--- a/internal/agent/config/disabled_test.go
+++ b/internal/agent/config/disabled_test.go
@@ -72,6 +72,12 @@ func TestShouldProtect(t *testing.T) {
 	}
 }
 
+func TestIsCompiledWithZenGo(t *testing.T) {
+	// The variable is not set during normal test execution (no -ldflags -X),
+	// so it should return false by default.
+	assert.False(t, config.IsCompiledWithZenGo())
+}
+
 func TestWarnIfNotProtected(t *testing.T) {
 	saveAndRestore := func(t *testing.T) {
 		origDisabled := config.IsZenDisabled()

--- a/zen/protect.go
+++ b/zen/protect.go
@@ -180,6 +180,10 @@ func doProtect(cfg *Config) {
 
 	config.SetZenLoaded(true)
 
+	if !config.IsCompiledWithZenGo() {
+		log.Warn("This application is not compiled with zen-go. Instrumentation is not active and requests will not be protected.")
+	}
+
 	log.Info("Aikido Zen loaded!",
 		slog.String("version", globals.EnvironmentConfig.Version))
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added runtime warning when app was not compiled with zen-go.
* Introduced compiledWithZenGo variable and IsCompiledWithZenGo accessor.
* Updated zen-go to inject linker -X flag and handle importcfg.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82997256?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->