### PR TITLE
Add \r and \f as shell separators and dangerous characters

### DIFF
--- a/internal/vulnerabilities/shellinjection/contains_shell_syntax.go
+++ b/internal/vulnerabilities/shellinjection/contains_shell_syntax.go
@@ -34,6 +34,8 @@ var dangerousChars = []string{
 	"\n",
 	"\t",
 	"~",
+	"\r",
+	"\f",
 }
 
 var commands = []string{
@@ -100,7 +102,7 @@ var pathPrefixes = []string{
 	"/usr/local/sbin/",
 }
 
-var separators = []string{" ", "\t", "\n", ";", "&", "|", "(", ")", "<", ">"}
+var separators = []string{" ", "\t", "\n", ";", "&", "|", "(", ")", "<", ">", "\r", "\f"}
 
 // "killall" should be matched before "kill"
 func byLength(a, b string) bool {

--- a/internal/vulnerabilities/shellinjection/contains_shell_syntax_test.go
+++ b/internal/vulnerabilities/shellinjection/contains_shell_syntax_test.go
@@ -90,4 +90,26 @@ func TestContainsShellSyntax(t *testing.T) {
 			t.Errorf("Expected %v for shell injection detection, but got %v", expected, result)
 		}
 	})
+
+	t.Run("it detects carriage return as separator", func(t *testing.T) {
+		checkSep := func(str, cmd string) {
+			if !containsShellSyntax(str, cmd) {
+				t.Errorf("Expected shell syntax detected in %q for command %q", str, cmd)
+			}
+		}
+		checkSep("ls\rrm", "rm")
+		checkSep("echo test\rrm -rf /", "rm")
+		checkSep("rm\rls", "rm")
+	})
+
+	t.Run("it detects form feed as separator", func(t *testing.T) {
+		checkSep := func(str, cmd string) {
+			if !containsShellSyntax(str, cmd) {
+				t.Errorf("Expected shell syntax detected in %q for command %q", str, cmd)
+			}
+		}
+		checkSep("ls\frm", "rm")
+		checkSep("echo test\frm -rf /", "rm")
+		checkSep("rm\fls", "rm")
+	})
 }

--- a/internal/vulnerabilities/shellinjection/detect_shell_injection_test.go
+++ b/internal/vulnerabilities/shellinjection/detect_shell_injection_test.go
@@ -129,4 +129,24 @@ func TestDetectShellInjection(t *testing.T) {
 	t.Run("detects subshell execution within backticks inside double quotes", func(t *testing.T) {
 		isShellInjection(t, "ls \"$(echo `whoami`)\"", "`whoami`")
 	})
+
+	t.Run("detects carriage return in user input", func(t *testing.T) {
+		isShellInjection(t, "ls \rrm", "\rrm")
+		isShellInjection(t, "ls \rrm -rf", "\rrm -rf")
+	})
+
+	t.Run("detects form feed in user input", func(t *testing.T) {
+		isShellInjection(t, "ls \frm", "\frm")
+		isShellInjection(t, "ls \frm -rf", "\frm -rf")
+	})
+
+	t.Run("detects carriage return in user input when user input is command", func(t *testing.T) {
+		isShellInjection(t, "sleep\r10", "sleep\r10")
+		isShellInjection(t, "shutdown\r-h\rnow", "shutdown\r-h\rnow")
+	})
+
+	t.Run("detects form feed in user input when user input is command", func(t *testing.T) {
+		isShellInjection(t, "sleep\f10", "sleep\f10")
+		isShellInjection(t, "shutdown\f-h\fnow", "shutdown\f-h\fnow")
+	})
 }


### PR DESCRIPTION
Based on:
https://github.com/AikidoSec/firewall-python/pull/584

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added carriage-return and form-feed as shell separators and dangerous characters


<sup>[More info](https://app.aikido.dev/featurebranch/scan/82997152?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->