### PR TITLE
Add CI check to ensure zen-internals binaries are updated

### DIFF
--- a/.github/workflows/check-zen-internals.yml
+++ b/.github/workflows/check-zen-internals.yml
@@ -1,0 +1,37 @@
+name: 🔍 Check zen-internals binary is up to date
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-zen-internals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check zen-internals binary matches version in Makefile
+        run: |
+          VERSION=$(grep '^ZEN_INTERNALS_VERSION=' Makefile | cut -d= -f2)
+          echo "ZEN_INTERNALS_VERSION: $VERSION"
+
+          BASE_URL="https://github.com/AikidoSec/zen-internals/releases/download/${VERSION}"
+          EXPECTED=$(curl -fsSL "${BASE_URL}/libzen_internals.wasm.sha256sum")
+          COMMITTED=$(cat internal/vulnerabilities/zeninternals/libzen_internals.wasm.sha256sum)
+
+          if [ "$EXPECTED" != "$COMMITTED" ]; then
+            echo "Error: committed sha256sum does not match version ${VERSION}"
+            echo "Expected: $EXPECTED"
+            echo "Got:      $COMMITTED"
+            echo ""
+            echo "Run 'make binaries' and commit the updated binary."
+            exit 1
+          fi
+
+          echo "Binary matches version ${VERSION}"


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added CI workflow to verify zen-internals binary matches Makefile


<sup>[More info](https://app.aikido.dev/featurebranch/scan/83000980?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->