### PR TITLE
Strip port from user IP in net/http source

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -59,6 +59,25 @@ func TestMiddlewareAddsContext(t *testing.T) {
 	router.ServeHTTP(w, r)
 }
 
+func TestMiddlewareSetsIPInContext(t *testing.T) {
+	router := gin.New()
+	router.ContextWithFallback = true
+	router.Use(zengin.GetMiddleware())
+
+	router.GET("/route", func(c *gin.Context) {
+		ctx := request.GetContext(c)
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "192.168.1.1", ctx.GetIP())
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	r.RemoteAddr = "192.168.1.1:1234"
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
 func TestMiddlewareGLSFallback(t *testing.T) {
 	router := gin.New()
 	router.ContextWithFallback = true

--- a/instrumentation/sources/go-chi/chi.v5/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware_test.go
@@ -59,6 +59,24 @@ func TestMiddlewareAddsContext(t *testing.T) {
 	router.ServeHTTP(w, r)
 }
 
+func TestMiddlewareSetsIPInContext(t *testing.T) {
+	router := chi.NewRouter()
+	router.Use(zenchi.GetMiddleware())
+
+	router.Get("/route", func(w http.ResponseWriter, r *http.Request) {
+		ctx := request.GetContext(r.Context())
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "192.168.1.1", ctx.GetIP())
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	r.RemoteAddr = "192.168.1.1:1234"
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
 func TestMiddlewareGLSFallback(t *testing.T) {
 	router := chi.NewRouter()
 	router.Use(zenchi.GetMiddleware())

--- a/instrumentation/sources/labstack/echo.v4/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware_test.go
@@ -60,6 +60,25 @@ func TestMiddlewareAddsContext(t *testing.T) {
 	router.ServeHTTP(w, r)
 }
 
+func TestMiddlewareSetsIPInContext(t *testing.T) {
+	router := echo.New()
+	router.Use(zenecho.GetMiddleware())
+
+	router.GET("/route", func(e echo.Context) error {
+		ctx := request.GetContext(e.Request().Context())
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "192.168.1.1", ctx.GetIP())
+		return nil
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	r.RemoteAddr = "192.168.1.1:1234"
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
 func TestMiddlewareGLSFallback(t *testing.T) {
 	router := echo.New()
 	router.Use(zenecho.GetMiddleware())

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -1,8 +1,10 @@
 package http
 
 import (
+	"log/slog"
 	"mime/multipart"
 	"net/http"
+	"net/netip"
 	"strings"
 	"sync/atomic"
 
@@ -22,7 +24,13 @@ func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.R
 			return
 		}
 
-		ip := r.RemoteAddr
+		var ip string
+		addrPort, err := netip.ParseAddrPort(r.RemoteAddr)
+		if err != nil {
+			log.Debug("could not parse ip", slog.Any("error", err))
+		} else {
+			ip = addrPort.Addr().String()
+		}
 
 		pattern := r.Pattern
 		// ServeMux patterns can start with the method and/or host

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -108,6 +108,21 @@ func TestMiddlewareAddsContext(t *testing.T) {
 	handler(w, r)
 }
 
+func TestMiddlewareSetsIPInContext(t *testing.T) {
+	handler := Middleware(func(w http.ResponseWriter, r *http.Request) {
+		ctx := request.GetContext(r.Context())
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "192.168.1.1", ctx.GetIP())
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	r.RemoteAddr = "192.168.1.1:1234"
+	w := httptest.NewRecorder()
+
+	handler(w, r)
+}
+
 func TestMiddlewareGLSFallback(t *testing.T) {
 	handler := Middleware(func(w http.ResponseWriter, r *http.Request) {
 		// Test that we can get context using context.Background() (should fallback to GLS)


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Stripped port from request RemoteAddr and parsed IPv4/IPv6


<sup>[More info](https://app.aikido.dev/featurebranch/scan/83043893?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->