### PR TITLE
Add basic SSRF detection based on private IPs

### DIFF
--- a/internal/vulnerabilities/ssrf/find_hostname_in_userinput.go
+++ b/internal/vulnerabilities/ssrf/find_hostname_in_userinput.go
@@ -1,0 +1,99 @@
+package ssrf
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+func findHostnameInUserInput(userInput, hostname string, port uint32) bool {
+	if len(userInput) <= 1 {
+		return false
+	}
+	if hostname == "" {
+		return false
+	}
+
+	hostnameOptions := getHostnameOptions(hostname)
+	if len(hostnameOptions) == 0 {
+		return false
+	}
+
+	variants := []string{userInput, "http://" + userInput, "https://" + userInput}
+
+	for _, variant := range variants {
+		parsed, err := url.Parse(variant)
+		if err != nil {
+			continue
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			continue
+		}
+
+		parsedHostname := strings.ToLower(parsed.Hostname())
+		for _, option := range hostnameOptions {
+			if parsedHostname == option {
+				parsedPort := getPortFromURL(parsed)
+
+				// Unable to parse port (e.g. invalid port string) — assume match
+				if parsedPort < 0 {
+					return true
+				}
+
+				// No port requirement specified
+				if port == 0 {
+					return true
+				}
+
+				if parsedPort >= 0 && parsedPort <= 65535 && uint32(parsedPort) == port {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// getHostnameOptions returns possible hostname representations for matching.
+func getHostnameOptions(hostname string) []string {
+	var options []string
+
+	// Try parsing as-is (wrapped in a URL)
+	if parsed, err := url.Parse("http://" + hostname); err == nil && parsed.Hostname() != "" {
+		options = append(options, strings.ToLower(parsed.Hostname()))
+	}
+
+	// Try wrapping in brackets for IPv6 addresses like ::1
+	if parsed, err := url.Parse("http://[" + hostname + "]"); err == nil && parsed.Hostname() != "" {
+		lower := strings.ToLower(parsed.Hostname())
+		if len(options) == 0 || options[0] != lower {
+			options = append(options, lower)
+		}
+	}
+
+	return options
+}
+
+// getPortFromURL extracts the port from a parsed URL.
+// Returns -1 if the port string is present but invalid.
+// Returns 0 if no port is specified and the scheme is not http/https.
+func getPortFromURL(u *url.URL) int {
+	portStr := u.Port()
+	if portStr != "" {
+		p, err := strconv.Atoi(portStr)
+		if err != nil {
+			return -1
+		}
+		return p
+	}
+
+	switch u.Scheme {
+	case "http":
+		return 80
+	case "https":
+		return 443
+	default:
+		return 0
+	}
+}

--- a/internal/vulnerabilities/ssrf/find_hostname_in_userinput_test.go
+++ b/internal/vulnerabilities/ssrf/find_hostname_in_userinput_test.go
@@ -1,0 +1,142 @@
+package ssrf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindHostnameInUserInput(t *testing.T) {
+	t.Run("returns false if user input and hostname are empty", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("", "", 0))
+	})
+
+	t.Run("returns false if user input is empty", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("", "example.com", 0))
+	})
+
+	t.Run("returns false if hostname is empty", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://example.com", "", 0))
+	})
+
+	t.Run("parses hostname from user input", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://localhost", "localhost", 0))
+	})
+
+	t.Run("parses hostname from user input with path", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://localhost/path", "localhost", 0))
+	})
+
+	t.Run("does not parse hostname with misspelled protocol", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http:/localhost", "localhost", 0))
+	})
+
+	t.Run("does not parse hostname without protocol separator", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http:localhost", "localhost", 0))
+	})
+
+	t.Run("does not parse hostname with misspelled protocol and path", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http:/localhost/path/path", "localhost", 0))
+	})
+
+	t.Run("parses hostname without protocol and with path", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("localhost/path/path", "localhost", 0))
+	})
+
+	t.Run("flags ftp as protocol", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("ftp://localhost", "localhost", 0))
+	})
+
+	t.Run("parses hostname without protocol", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("localhost", "localhost", 0))
+	})
+
+	t.Run("ignores invalid urls", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://", "localhost", 0))
+	})
+
+	t.Run("user input is smaller than hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("localhost", "localhost localhost", 0))
+	})
+
+	t.Run("finds IP address inside URL", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://169.254.169.254/latest/meta-data/", "169.254.169.254", 0))
+	})
+
+	t.Run("finds IP address with strange notation", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://2130706433", "2130706433", 0))
+		assert.True(t, findHostnameInUserInput("http://127.1", "127.1", 0))
+		assert.True(t, findHostnameInUserInput("http://127.0.1", "127.0.1", 0))
+	})
+
+	t.Run("works with ports", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://localhost", "localhost", 8080))
+		assert.True(t, findHostnameInUserInput("http://localhost:8080", "localhost", 8080))
+		assert.True(t, findHostnameInUserInput("http://localhost:8080", "localhost", 0))
+		assert.False(t, findHostnameInUserInput("http://localhost:8080", "localhost", 4321))
+	})
+
+	t.Run("loopback IPv6 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://[::1]:8081", "::1", 0))
+	})
+
+	t.Run("loopback IPv6 with zeros found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://[0000:0000:0000:0000:0000:0000:0000:0001]:8081", "0000:0000:0000:0000:0000:0000:0000:0001", 0))
+	})
+
+	t.Run("different capitalization found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://localHost:8081", "localhost", 0))
+	})
+
+	t.Run("2130706433 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://2130706433:8081", "2130706433", 0))
+	})
+
+	t.Run("0x7f000001 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://0x7f000001:8081", "0x7f000001", 0))
+	})
+
+	t.Run("0177.0.0.01 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://0177.0.0.01:8081", "0177.0.0.01", 0))
+	})
+
+	t.Run("0x7f.0x0.0x0.0x1 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://0x7f.0x0.0x0.0x1:8081", "0x7f.0x0.0x0.0x1", 0))
+	})
+
+	t.Run("::ffff:127.0.0.1 found", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://[::ffff:127.0.0.1]:8081", "::ffff:127.0.0.1", 0))
+	})
+
+	t.Run("loopback IPv6 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://[::1]:8081", "localhost", 0))
+	})
+
+	t.Run("loopback IPv6 with zeros not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://[0000:0000:0000:0000:0000:0000:0000:0001]:8081", "localhost", 0))
+	})
+
+	t.Run("different capitalization not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://localHost:8081", "example.com", 0))
+	})
+
+	t.Run("2130706433 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://2130706433:8081", "example.com", 0))
+	})
+
+	t.Run("0x7f000001 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://0x7f000001:8081", "example.com", 0))
+	})
+
+	t.Run("0177.0.0.01 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://0177.0.0.01:8081", "example.com", 0))
+	})
+
+	t.Run("0x7f.0x0.0x0.0x1 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://0x7f.0x0.0x0.0x1:8081", "example.com", 0))
+	})
+
+	t.Run("::ffff:127.0.0.1 not found for different hostname", func(t *testing.T) {
+		assert.False(t, findHostnameInUserInput("http://[::ffff:127.0.0.1]:8081", "example.com", 0))
+	})
+}

--- a/internal/vulnerabilities/ssrf/vulnerability.go
+++ b/internal/vulnerabilities/ssrf/vulnerability.go
@@ -1,0 +1,46 @@
+package ssrf
+
+import (
+	"errors"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
+	"github.com/AikidoSec/firewall-go/internal/vulnerabilities"
+)
+
+// SSRFVulnerability detects server-side request forgery.
+// It blocks outgoing HTTP requests to private/internal IPs when the hostname
+// originates from user input (query params, headers, body, etc.).
+//
+// This does not yet cover DNS-resolution based attacks (e.g. a public hostname
+// that resolves to a private IP), redirect-based SSRF, or IMDS/stored SSRF.
+var SSRFVulnerability = vulnerabilities.Vulnerability[*ScanArgs]{
+	ScanFunction: scanFunction,
+	Kind:         vulnerabilities.KindSSRF,
+	Error:        "A server-side request forgery has been detected.",
+}
+
+type ScanArgs struct {
+	Hostname string
+	Port     uint32
+}
+
+func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult, error) {
+	if args == nil {
+		return nil, errors.New("args cannot be nil")
+	}
+
+	if !ipaddr.IsPrivateIP(args.Hostname) {
+		return nil, nil
+	}
+
+	if findHostnameInUserInput(userInput, args.Hostname, args.Port) {
+		return &vulnerabilities.ScanResult{
+			DetectedAttack: true,
+			Metadata: map[string]string{
+				"hostname": args.Hostname,
+			},
+		}, nil
+	}
+
+	return nil, nil
+}


### PR DESCRIPTION
Does not include resolving hostnames to private IPs yet.

Based on the approach in `firewall-node` and `firewall-python`.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added SSRF vulnerability detection module that checks private IP hostnames

**⚡ Enhancements**
* Integrated SSRF scan into outgoing HTTP requests and blocked attacks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/83316490?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->