### PR TITLE
Improve zen-go cmd coverage

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -183,7 +183,7 @@ func updateImportcfgInArgs(stderr io.Writer, args []string, importcfgPath string
 		return args, nil
 	}
 
-	updatedArgs := replaceImportcfgArg(args, newImportcfg)
+	updatedArgs := importcfg.ReplaceImportcfgArg(args, newImportcfg)
 	if isDebug() {
 		fmt.Fprintf(stderr, "zen-go: replaced importcfg with %s\n", newImportcfg)
 	}
@@ -191,22 +191,6 @@ func updateImportcfgInArgs(stderr io.Writer, args []string, importcfgPath string
 	return updatedArgs, nil
 }
 
-func replaceImportcfgArg(args []string, newPath string) []string {
-	result := make([]string, len(args))
-	copy(result, args)
-
-	for i := range len(result) {
-		if result[i] == "-importcfg" && i+1 < len(result) {
-			result[i+1] = newPath
-			return result
-		}
-		if strings.HasPrefix(result[i], "-importcfg=") {
-			result[i] = "-importcfg=" + newPath
-			return result
-		}
-	}
-	return result
-}
 
 // checkZenToolFileIncluded checks if the main package is being compiled
 // without zen.tool.go. This happens when users run e.g. `go build main.go`

--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -191,7 +191,6 @@ func updateImportcfgInArgs(stderr io.Writer, args []string, importcfgPath string
 	return updatedArgs, nil
 }
 
-
 // checkZenToolFileIncluded checks if the main package is being compiled
 // without zen.tool.go. This happens when users run e.g. `go build main.go`
 // instead of `go build .`, which causes zen.tool.go to be excluded from the

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -172,7 +172,6 @@ func writeExtendedLinkerImportcfg(originalContent []byte, newLines []string) (st
 	return tmpFile.Name(), nil
 }
 
-
 // insertLinkerFlags inserts flags before the last argument (the archive file),
 // since the Go linker expects flags before positional arguments.
 func insertLinkerFlags(args []string, flags ...string) []string {

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -53,7 +53,7 @@ func toolexecLinkCommand(stdout io.Writer, stderr io.Writer, tool string, toolAr
 					fmt.Fprintf(stderr, "zen-go: warning: failed to write extended importcfg: %v\n", err)
 				} else {
 					defer func() { _ = os.Remove(newImportcfgPath) }()
-					args = replaceLinkerImportcfgArg(args, newImportcfgPath)
+					args = importcfg.ReplaceImportcfgArg(args, newImportcfgPath)
 				}
 			}
 		}
@@ -172,22 +172,6 @@ func writeExtendedLinkerImportcfg(originalContent []byte, newLines []string) (st
 	return tmpFile.Name(), nil
 }
 
-func replaceLinkerImportcfgArg(args []string, newPath string) []string {
-	result := make([]string, len(args))
-	copy(result, args)
-
-	for i := range len(result) {
-		if result[i] == "-importcfg" && i+1 < len(result) {
-			result[i+1] = newPath
-			return result
-		}
-		if strings.HasPrefix(result[i], "-importcfg=") {
-			result[i] = "-importcfg=" + newPath
-			return result
-		}
-	}
-	return result
-}
 
 // insertLinkerFlags inserts flags before the last argument (the archive file),
 // since the Go linker expects flags before positional arguments.

--- a/cmd/zen-go/cmd_toolexec_link_test.go
+++ b/cmd/zen-go/cmd_toolexec_link_test.go
@@ -111,7 +111,6 @@ func TestResolveMissingDeps(t *testing.T) {
 	assert.GreaterOrEqual(t, 1, len(newLines))
 }
 
-
 func TestWriteExtendedLinkerImportcfg(t *testing.T) {
 	originalContent := []byte("# import config\npackagefile fmt=/path/to/fmt.a")
 	newLines := []string{

--- a/cmd/zen-go/cmd_toolexec_link_test.go
+++ b/cmd/zen-go/cmd_toolexec_link_test.go
@@ -111,40 +111,6 @@ func TestResolveMissingDeps(t *testing.T) {
 	assert.GreaterOrEqual(t, 1, len(newLines))
 }
 
-func TestReplaceLinkerImportcfgArg(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		newPath  string
-		expected []string
-	}{
-		{
-			name:     "space separator",
-			args:     []string{"-o", "out", "-importcfg", "/old/path", "file.a"},
-			newPath:  "/new/path",
-			expected: []string{"-o", "out", "-importcfg", "/new/path", "file.a"},
-		},
-		{
-			name:     "equals separator",
-			args:     []string{"-o=out", "-importcfg=/old/path", "file.a"},
-			newPath:  "/new/path",
-			expected: []string{"-o=out", "-importcfg=/new/path", "file.a"},
-		},
-		{
-			name:     "no importcfg",
-			args:     []string{"-o", "out", "file.a"},
-			newPath:  "/new/path",
-			expected: []string{"-o", "out", "file.a"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := replaceLinkerImportcfgArg(tt.args, tt.newPath)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
 
 func TestWriteExtendedLinkerImportcfg(t *testing.T) {
 	originalContent := []byte("# import config\npackagefile fmt=/path/to/fmt.a")

--- a/cmd/zen-go/cmd_toolexec_test.go
+++ b/cmd/zen-go/cmd_toolexec_test.go
@@ -355,6 +355,18 @@ func TestUpdateImportcfgInArgs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, args, result)
 	})
+
+	t.Run("replaces importcfg arg when new imports are added", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "importcfg")
+		require.NoError(t, os.WriteFile(cfgPath, []byte("# import config\n"), 0o600))
+
+		args := []string{"-importcfg", cfgPath, "-o", "out.a"}
+		result, err := updateImportcfgInArgs(os.Stderr, args, cfgPath, map[string]string{"fmt": "fmt"}, tmpDir)
+		require.NoError(t, err)
+		assert.NotEqual(t, cfgPath, result[1])
+		assert.NotEqual(t, args, result)
+	})
 }
 
 func TestWriteTempFile(t *testing.T) {

--- a/cmd/zen-go/cmd_toolexec_test.go
+++ b/cmd/zen-go/cmd_toolexec_test.go
@@ -122,6 +122,55 @@ func TestExtractFlag(t *testing.T) {
 	}
 }
 
+func TestIsVersionQuery(t *testing.T) {
+	assert.True(t, isVersionQuery([]string{"-V=full"}))
+	assert.True(t, isVersionQuery([]string{"-V"}))
+	assert.True(t, isVersionQuery([]string{"-p", "main", "-V=full"}))
+	assert.False(t, isVersionQuery([]string{"-p", "main", "-o", "out.a"}))
+	assert.False(t, isVersionQuery([]string{}))
+}
+
+func TestExtractCompilerFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantPkg        string
+		wantImportcfg  string
+		wantOutput     string
+	}{
+		{
+			name:          "all flags space-separated",
+			args:          []string{"-p", "main", "-importcfg", "/tmp/cfg", "-o", "/tmp/out.a"},
+			wantPkg:       "main",
+			wantImportcfg: "/tmp/cfg",
+			wantOutput:    "/tmp/out.a",
+		},
+		{
+			name:          "all flags equals form",
+			args:          []string{"-p=main", "-importcfg=/tmp/cfg", "-o=/tmp/out.a"},
+			wantPkg:       "main",
+			wantImportcfg: "/tmp/cfg",
+			wantOutput:    "/tmp/out.a",
+		},
+		{
+			name:          "missing flags return empty",
+			args:          []string{"-trimpath", "/tmp"},
+			wantPkg:       "",
+			wantImportcfg: "",
+			wantOutput:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkg, importcfg, output := extractCompilerFlags(tt.args)
+			assert.Equal(t, tt.wantPkg, pkg)
+			assert.Equal(t, tt.wantImportcfg, importcfg)
+			assert.Equal(t, tt.wantOutput, output)
+		})
+	}
+}
+
 func TestPassthrough(t *testing.T) {
 	mockTool := createMockTool(t, "tool", "echo")
 

--- a/cmd/zen-go/internal/importcfg/importcfg.go
+++ b/cmd/zen-go/internal/importcfg/importcfg.go
@@ -99,6 +99,26 @@ func createTempFile(objdir string) (*os.File, error) {
 	return os.CreateTemp("", "importcfg_*.txt")
 }
 
+// ReplaceImportcfgArg returns a copy of args with the -importcfg value replaced by newPath.
+// It handles both "-importcfg <path>" and "-importcfg=<path>" forms.
+// If no -importcfg flag is found, args is returned unchanged.
+func ReplaceImportcfgArg(args []string, newPath string) []string {
+	result := make([]string, len(args))
+	copy(result, args)
+
+	for i := range len(result) {
+		if result[i] == "-importcfg" && i+1 < len(result) {
+			result[i+1] = newPath
+			return result
+		}
+		if strings.HasPrefix(result[i], "-importcfg=") {
+			result[i] = "-importcfg=" + newPath
+			return result
+		}
+	}
+	return result
+}
+
 // GetPackageExport returns the file path to the compiled export data for the given import path.
 // It runs 'go list -export' from the module root.
 func GetPackageExport(importPath string) (string, error) {

--- a/cmd/zen-go/internal/importcfg/importcfg_test.go
+++ b/cmd/zen-go/internal/importcfg/importcfg_test.go
@@ -108,6 +108,32 @@ func TestFindModuleRoot_NoGoMod(t *testing.T) {
 	assert.Empty(t, root)
 }
 
+func TestReplaceImportcfgArg(t *testing.T) {
+	t.Run("space-separated form", func(t *testing.T) {
+		args := []string{"-p", "main", "-importcfg", "/old/path", "-o", "out.a"}
+		result := ReplaceImportcfgArg(args, "/new/path")
+		assert.Equal(t, "/new/path", result[3])
+	})
+
+	t.Run("equals form", func(t *testing.T) {
+		args := []string{"-p", "main", "-importcfg=/old/path", "-o", "out.a"}
+		result := ReplaceImportcfgArg(args, "/new/path")
+		assert.Equal(t, "-importcfg=/new/path", result[2])
+	})
+
+	t.Run("no importcfg flag", func(t *testing.T) {
+		args := []string{"-p", "main", "-o", "out.a"}
+		result := ReplaceImportcfgArg(args, "/new/path")
+		assert.Equal(t, args, result)
+	})
+
+	t.Run("does not modify original slice", func(t *testing.T) {
+		args := []string{"-importcfg", "/old/path"}
+		_ = ReplaceImportcfgArg(args, "/new/path")
+		assert.Equal(t, "/old/path", args[1])
+	})
+}
+
 func TestExtendImportcfg_ParsesExistingEntries(t *testing.T) {
 	tmpDir := t.TempDir()
 	importcfgPath := filepath.Join(tmpDir, "importcfg")


### PR DESCRIPTION
Improve overall test coverage in the main pkg for zen-go CLI.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added ReplaceImportcfgArg helper and updated callers to use it

**🔧 Refactors**
* Centralized importcfg arg replacement into internal importcfg package, removed duplicates


<sup>[More info](https://app.aikido.dev/featurebranch/scan/84496730?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->