### PR TITLE
Add support for X-Forwarded-For in net/http and chi

### DIFF
--- a/docs/echo.md
+++ b/docs/echo.md
@@ -5,7 +5,9 @@
 If you haven't already, follow the [installation instructions](../README.md#installation) in the main README.
 
 ## Setting a user
-If you want to use user-blocking, know which user performed an attack and rate-limit on a user basis, you have to set  a user using the following function :
+
+If you want to use user-blocking, know which user performed an attack and rate-limit on a user basis, you have to set a user using the following function :
+
 ```go
 // Setting a user:
 zen.SetUser(c.Request().Context(), id, name)
@@ -13,11 +15,14 @@ zen.SetUser(c.Request().Context(), id, name)
 // So an example for Bob with id 1:
 zen.SetUser(c.Request().Context(), "1", "Bob")
 ```
+
 It's advised to do this in your authentication middleware, and before you add the Aikido Middleware (used for rate-limiting and user blocking, [See here](#middleware))
 
 ## Middleware
+
 To use rate-limiting or user-blocking we require you to add some middleware yourself.
 Here is an example of how to do that, you can tailor the responses to something that is more appropriate for your app.
+
 ```go
 // ...
 e.Use(AikidoMiddleware())
@@ -43,4 +48,29 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 		}
 	}
 }
+```
+
+## Proxy settings
+
+The middleware uses Echo's built-in `c.RealIP()` to determine the client's IP address. By default this uses a legacy fallback that checks `X-Forwarded-For` then `X-Real-IP` without validating the source, which can allow IP spoofing.
+
+You should explicitly configure Echo's `IPExtractor` to match your infrastructure:
+
+```go
+e := echo.New()
+
+// Behind a reverse proxy - trust X-Forwarded-For from private network ranges
+e.IPExtractor = echo.ExtractIPFromXFFHeader(
+    echo.TrustLoopback(true),
+    echo.TrustPrivateNet(true),
+)
+
+// Behind a reverse proxy that sets X-Real-IP
+e.IPExtractor = echo.ExtractIPFromRealIPHeader(
+    echo.TrustLoopback(true),
+    echo.TrustPrivateNet(true),
+)
+
+// No proxy - app is directly exposed to the internet
+e.IPExtractor = echo.ExtractIPDirect()
 ```

--- a/docs/gin.md
+++ b/docs/gin.md
@@ -47,3 +47,30 @@ func AikidoMiddleware() gin.HandlerFunc {
 }
 ```
 The important part here is the call to `zen.ShouldBlockRequest()` which returns whether to block the request and the reason why.
+
+## Proxy settings
+
+The middleware uses Gin's built-in `c.ClientIP()` to determine the client's IP address, which reads from `X-Forwarded-For` and `X-Real-IP` headers.
+
+**By default, Gin trusts all proxies**, which means a client can spoof their IP by setting these headers directly. You should explicitly configure which proxies to trust:
+
+```go
+// Trust specific proxy IPs or CIDR ranges
+router.SetTrustedProxies([]string{"10.0.0.0/8", "172.16.0.0/12"})
+
+// Disable proxy trust entirely if your app is directly exposed
+router.SetTrustedProxies(nil)
+```
+
+If you're running behind a known platform, Gin has built-in constants for common CDN/platform headers:
+
+```go
+// Cloudflare (uses CF-Connecting-IP)
+router.TrustedPlatform = gin.PlatformCloudflare
+
+// Google App Engine (uses X-Appengine-Remote-Addr)
+router.TrustedPlatform = gin.PlatformGoogleAppEngine
+
+// Fly.io (uses Fly-Client-IP)
+router.TrustedPlatform = gin.PlatformFlyIO
+```

--- a/docs/net-http.md
+++ b/docs/net-http.md
@@ -49,3 +49,25 @@ func AikidoMiddleware(next http.Handler) http.Handler {
 }
 ```
 The important part here is the call to `zen.ShouldBlockRequest()` which returns whether to block the request and the reason why.
+
+## Proxy settings
+
+The middleware automatically uses the `X-Forwarded-For` header to determine the client's IP address when your app runs behind a reverse proxy or load balancer.
+
+If your server is publicly exposed without a proxy in front of it, set `AIKIDO_TRUST_PROXY=false` to prevent clients from spoofing their IP address (which could bypass rate limiting):
+
+```bash
+AIKIDO_TRUST_PROXY=false ./your-app
+```
+
+If your infrastructure uses a different header to carry the real client IP, set `AIKIDO_CLIENT_IP_HEADER` to its name:
+
+```bash
+# For DigitalOcean App Platform
+AIKIDO_CLIENT_IP_HEADER=do-connecting-ip ./your-app
+```
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `AIKIDO_TRUST_PROXY` | `true` | Trust proxy headers to determine the client IP |
+| `AIKIDO_CLIENT_IP_HEADER` | `X-Forwarded-For` | Header name to read the client IP from |

--- a/instrumentation/sources/go-chi/chi.v5/middleware.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware.go
@@ -1,13 +1,10 @@
 package chi
 
 import (
-	"log/slog"
 	"mime/multipart"
 	"net/http"
-	"net/netip"
 
 	zenhttp "github.com/AikidoSec/firewall-go/internal/http"
-	"github.com/AikidoSec/firewall-go/internal/log"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/go-chi/chi/v5"
@@ -35,13 +32,7 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 				return
 			}
 
-			var ip string
-			addrPort, err := netip.ParseAddrPort(r.RemoteAddr)
-			if err != nil {
-				log.Debug("could not parse ip", slog.Any("error", err))
-			} else {
-				ip = addrPort.Addr().String()
-			}
+			ip := zenhttp.GetClientIP(r)
 
 			routeCtx := chi.RouteContext(r.Context())
 			var route string

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -1,10 +1,8 @@
 package http
 
 import (
-	"log/slog"
 	"mime/multipart"
 	"net/http"
-	"net/netip"
 	"strings"
 	"sync/atomic"
 
@@ -24,13 +22,7 @@ func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.R
 			return
 		}
 
-		var ip string
-		addrPort, err := netip.ParseAddrPort(r.RemoteAddr)
-		if err != nil {
-			log.Debug("could not parse ip", slog.Any("error", err))
-		} else {
-			ip = addrPort.Addr().String()
-		}
+		ip := zenhttp.GetClientIP(r)
 
 		pattern := r.Pattern
 		// ServeMux patterns can start with the method and/or host

--- a/internal/http/ip_from_request.go
+++ b/internal/http/ip_from_request.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"net/http"
+	"net/netip"
+	"os"
+	"strings"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
+)
+
+// GetClientIP returns the client's IP address from the request.
+//
+// By default, it trusts proxy headers and reads the client IP from the
+// x-forwarded-for header (or the header named by AIKIDO_CLIENT_IP_HEADER).
+// It returns the first valid non-private IP found in that header, falling
+// back to the TCP remote address if none is found.
+//
+// Set AIKIDO_TRUST_PROXY=false to disable proxy header trust entirely and
+// always use the raw TCP remote address instead.
+func GetClientIP(r *http.Request) string {
+	socketIP := parseRemoteAddr(r.RemoteAddr)
+
+	if !isTrustProxy() {
+		return socketIP
+	}
+
+	headerName := getClientIPHeaderName()
+	headerValue := r.Header.Get(headerName)
+	if headerValue == "" {
+		return socketIP
+	}
+
+	if ip := extractFirstPublicIPFromHeader(headerValue); ip != "" {
+		return ip
+	}
+
+	return socketIP
+}
+
+// isTrustProxy returns whether proxy headers should be trusted.
+// Defaults to true; set AIKIDO_TRUST_PROXY=false to disable.
+func isTrustProxy() bool {
+	val := os.Getenv("AIKIDO_TRUST_PROXY")
+	if val == "" {
+		return true
+	}
+	switch strings.ToLower(val) {
+	case "false", "0", "no", "n", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// getClientIPHeaderName returns the header name to use for the client IP.
+// Defaults to "x-forwarded-for"; override with AIKIDO_CLIENT_IP_HEADER.
+func getClientIPHeaderName() string {
+	if name := os.Getenv("AIKIDO_CLIENT_IP_HEADER"); name != "" {
+		return name
+	}
+	return "X-Forwarded-For"
+}
+
+// extractFirstPublicIPFromHeader parses a comma-separated list of IPs from
+// a header value and returns the first valid non-private IP address.
+func extractFirstPublicIPFromHeader(headerValue string) string {
+	for part := range strings.SplitSeq(headerValue, ",") {
+		ip := parseIPFromHeaderPart(strings.TrimSpace(part))
+		if ip == "" {
+			continue
+		}
+		if !ipaddr.IsPrivateIP(ip) {
+			return ip
+		}
+	}
+	return ""
+}
+
+// parseIPFromHeaderPart extracts an IP address from a single header part,
+// handling IPv6 bracket notation and optional port numbers.
+func parseIPFromHeaderPart(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	// IPv6 in brackets: [::1] or [::1]:port, extract between brackets
+	if strings.HasPrefix(s, "[") {
+		end := strings.Index(s, "]")
+		if end == -1 {
+			return ""
+		}
+		inner := s[1:end]
+		addr, err := netip.ParseAddr(inner)
+		if err != nil {
+			return ""
+		}
+		return addr.String()
+	}
+
+	// Try plain IP address first (covers bare IPv6 like ::1)
+	if addr, err := netip.ParseAddr(s); err == nil {
+		return addr.String()
+	}
+
+	// Try ip:port (covers IPv4 with port like 1.2.3.4:8080)
+	if addrPort, err := netip.ParseAddrPort(s); err == nil {
+		return addrPort.Addr().String()
+	}
+
+	return ""
+}
+
+// parseRemoteAddr extracts the IP address from an addr:port string (r.RemoteAddr).
+func parseRemoteAddr(remoteAddr string) string {
+	addrPort, err := netip.ParseAddrPort(remoteAddr)
+	if err != nil {
+		return ""
+	}
+	return addrPort.Addr().String()
+}

--- a/internal/http/ip_from_request_test.go
+++ b/internal/http/ip_from_request_test.go
@@ -1,0 +1,176 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClientIP_NoHeaders_UsesRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_TrustProxyFalse_IgnoresHeader(t *testing.T) {
+	t.Setenv("AIKIDO_TRUST_PROXY", "false")
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "5.6.7.8")
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_TrustProxyFalseVariants(t *testing.T) {
+	for _, val := range []string{"false", "0", "no", "n", "off", "False", "FALSE"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("AIKIDO_TRUST_PROXY", val)
+
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = "1.2.3.4:1234"
+			r.Header.Set("X-Forwarded-For", "5.6.7.8")
+
+			assert.Equal(t, "1.2.3.4", GetClientIP(r))
+		})
+	}
+}
+
+func TestGetClientIP_SinglePublicIP(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "5.6.7.8")
+
+	assert.Equal(t, "5.6.7.8", GetClientIP(r))
+}
+
+func TestGetClientIP_CommaSeparated_ReturnsFirstPublic(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "5.6.7.8, 9.10.11.12")
+
+	assert.Equal(t, "5.6.7.8", GetClientIP(r))
+}
+
+func TestGetClientIP_CommaSeparated_SkipsPrivateIPs(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	// 10.0.0.1 is private, 5.6.7.8 is public
+	r.Header.Set("X-Forwarded-For", "10.0.0.1, 5.6.7.8")
+
+	assert.Equal(t, "5.6.7.8", GetClientIP(r))
+}
+
+func TestGetClientIP_AllPrivateIPs_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "10.0.0.1, 192.168.1.1, 127.0.0.1")
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_InvalidIPInHeader_FallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "not-an-ip")
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_EmptyHeader_UsesRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "")
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_IPv4WithPort(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "5.6.7.8:9000")
+
+	assert.Equal(t, "5.6.7.8", GetClientIP(r))
+}
+
+func TestGetClientIP_IPv6Brackets(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "[2001:db8::1]")
+
+	// 2001:db8::/32 is documentation range (private), so falls back
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_IPv6BracketsWithPort(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	// Use a public IPv6 address
+	r.Header.Set("X-Forwarded-For", "[2607:f8b0:4004:c09::6a]:9000")
+
+	assert.Equal(t, "2607:f8b0:4004:c09::6a", GetClientIP(r))
+}
+
+func TestGetClientIP_BareIPv6Public(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "2607:f8b0:4004:c09::6a")
+
+	assert.Equal(t, "2607:f8b0:4004:c09::6a", GetClientIP(r))
+}
+
+func TestGetClientIP_CustomHeader(t *testing.T) {
+	t.Setenv("AIKIDO_CLIENT_IP_HEADER", "X-Real-IP")
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Real-IP", "5.6.7.8")
+
+	assert.Equal(t, "5.6.7.8", GetClientIP(r))
+}
+
+func TestGetClientIP_CustomHeaderNotPresent_FallsBackToRemoteAddr(t *testing.T) {
+	t.Setenv("AIKIDO_CLIENT_IP_HEADER", "X-Real-IP")
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	// X-Real-IP not set
+
+	assert.Equal(t, "1.2.3.4", GetClientIP(r))
+}
+
+func TestGetClientIP_DefaultHeaderNotUsedWhenCustomSet(t *testing.T) {
+	t.Setenv("AIKIDO_CLIENT_IP_HEADER", "X-Real-IP")
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.2.3.4:1234"
+	r.Header.Set("X-Forwarded-For", "5.6.7.8") // not used
+	r.Header.Set("X-Real-IP", "9.10.11.12")
+
+	assert.Equal(t, "9.10.11.12", GetClientIP(r))
+}
+
+func TestGetClientIP_LoopbackRemoteAddr_NoHeader(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1234"
+
+	assert.Equal(t, "127.0.0.1", GetClientIP(r))
+}
+
+func TestGetClientIP_InvalidRemoteAddr_ReturnsEmpty(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "invalid"
+
+	assert.Equal(t, "", GetClientIP(r))
+}
+
+func TestGetClientIP_NoRemoteAddr_NoHeader_ReturnsEmpty(t *testing.T) {
+	r := &http.Request{
+		Header: make(http.Header),
+	}
+
+	assert.Equal(t, "", GetClientIP(r))
+}


### PR DESCRIPTION
Based on the implementation in `firewall-node`, this isn't required in `echo` and `gin` as they have built in support.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GetClientIP util that respected X-Forwarded-For and env.

**⚡ Enhancements**
* Updated net/http middleware to use GetClientIP for remote address.
* Updated chi middleware to use GetClientIP and preserve route params.

**🔧 Refactors**
* Removed unused logging and netip imports from middleware files.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/84845784?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->