### PR TITLE
Fix flaky test in reporting hostnames in net/http client

### DIFF
--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -25,7 +25,7 @@ func Examine(r *http.Request) error {
 	port := getPort(r)
 
 	// Report any hostnames to the dashboard
-	go agent.OnDomain(hostname, uint32(port))
+	agent.OnDomain(hostname, uint32(port))
 
 	if config.ShouldBlockHostname(hostname) {
 		return zen.ErrOutboundBlocked(hostname)


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made domain reporting synchronous by removing goroutine invocation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/84846074?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->