### PR TITLE
Adjust continue for private IPs within forward headers

### DIFF
--- a/internal/http/ip_from_request.go
+++ b/internal/http/ip_from_request.go
@@ -67,12 +67,10 @@ func getClientIPHeaderName() string {
 func extractFirstPublicIPFromHeader(headerValue string) string {
 	for part := range strings.SplitSeq(headerValue, ",") {
 		ip := parseIPFromHeaderPart(strings.TrimSpace(part))
-		if ip == "" {
+		if ip == "" || ipaddr.IsPrivateIP(ip) {
 			continue
 		}
-		if !ipaddr.IsPrivateIP(ip) {
-			return ip
-		}
+		return ip
 	}
 	return ""
 }


### PR DESCRIPTION
From:
https://github.com/AikidoSec/firewall-go/pull/355#discussion_r2846303213

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Simplified header IP parsing to skip private addresses earlier


<sup>[More info](https://app.aikido.dev/featurebranch/scan/86735180?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->