### PR TITLE
Add minimum version check of zen-go in rules files

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -119,7 +119,7 @@ func instrumentFiles(stderr io.Writer, toolArgs []string, pkgPath, objdir string
 	newArgs := make([]string, 0, len(toolArgs))
 	allAddedImports := make(map[string]string) // alias -> import path
 	var allAddedLinkDeps []string
-	instrumentor, err := instrumentor.NewInstrumentor()
+	instrumentor, err := instrumentor.NewInstrumentor(version)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -27,7 +27,7 @@ func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string
 	}
 
 	// Compute hash of instrumentation rules
-	inst, err := instrumentor.NewInstrumentor()
+	inst, err := instrumentor.NewInstrumentor(version)
 	if err != nil {
 		return err
 	}

--- a/cmd/zen-go/internal/buildid/hash_test.go
+++ b/cmd/zen-go/internal/buildid/hash_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestComputeInstrumentationHash(t *testing.T) {
-	inst, err := instrumentor.NewInstrumentor()
+	inst, err := instrumentor.NewInstrumentor("999.0.0")
 	require.NoError(t, err)
 
 	hash := ComputeInstrumentationHash(inst, "test-version")

--- a/cmd/zen-go/internal/instrumentor/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor.go
@@ -20,8 +20,10 @@ type Instrumentor struct {
 	InjectDeclRules []rules.InjectDeclRule
 }
 
-// NewInstrumentor creates a new Instrumentor, loading rules from YAML files
-func NewInstrumentor() (*Instrumentor, error) {
+// NewInstrumentor creates a new Instrumentor, loading rules from YAML files.
+// currentVersion is the zen-go version string used to check min-zen-go-version
+// requirements declared in zen.instrument.yml files.
+func NewInstrumentor(currentVersion string) (*Instrumentor, error) {
 	dirs := paths.FindInstrumentationDirs()
 	if len(dirs) == 0 {
 		return &Instrumentor{}, nil
@@ -36,6 +38,11 @@ func NewInstrumentor() (*Instrumentor, error) {
 		allRules.WrapRules = append(allRules.WrapRules, rulesData.WrapRules...)
 		allRules.PrependRules = append(allRules.PrependRules, rulesData.PrependRules...)
 		allRules.InjectDeclRules = append(allRules.InjectDeclRules, rulesData.InjectDeclRules...)
+		allRules.MinVersions = append(allRules.MinVersions, rulesData.MinVersions...)
+	}
+
+	if err := rules.CheckMinVersions(allRules.MinVersions, currentVersion); err != nil {
+		return nil, err
 	}
 
 	return NewInstrumentorWithRules(allRules), nil

--- a/cmd/zen-go/internal/instrumentor/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor.go
@@ -41,20 +41,21 @@ func NewInstrumentor(currentVersion string) (*Instrumentor, error) {
 		allRules.MinVersions = append(allRules.MinVersions, rulesData.MinVersions...)
 	}
 
-	if err := rules.CheckMinVersions(allRules.MinVersions, currentVersion); err != nil {
-		return nil, err
-	}
+	return NewInstrumentorWithRules(allRules, currentVersion)
 
-	return NewInstrumentorWithRules(allRules), nil
 }
 
-// NewInstrumentorWithRules creates an Instrumentor with the given rules
-func NewInstrumentorWithRules(rules *rules.InstrumentationRules) *Instrumentor {
-	return &Instrumentor{
-		WrapRules:       rules.WrapRules,
-		PrependRules:    rules.PrependRules,
-		InjectDeclRules: rules.InjectDeclRules,
+// NewInstrumentorWithRules creates an Instrumentor with the given rules.
+// currentVersion is checked against min-zen-go-version requirements from the rules.
+func NewInstrumentorWithRules(r *rules.InstrumentationRules, currentVersion string) (*Instrumentor, error) {
+	if err := rules.CheckMinVersions(r.MinVersions, currentVersion); err != nil {
+		return nil, err
 	}
+	return &Instrumentor{
+		WrapRules:       r.WrapRules,
+		PrependRules:    r.PrependRules,
+		InjectDeclRules: r.InjectDeclRules,
+	}, nil
 }
 
 type InstrumentFileResult struct {

--- a/cmd/zen-go/internal/instrumentor/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor_test.go
@@ -775,6 +775,17 @@ type File struct{}
 	assert.Contains(t, string(osResult.Code), "sink.Check(name)")
 }
 
+func TestNewInstrumentorWithRules_MinVersionNotMet(t *testing.T) {
+	r := &rules.InstrumentationRules{
+		MinVersions: []rules.MinVersionEntry{
+			{File: "test/zen.instrument.yml", Version: "1.0.0"},
+		},
+	}
+	_, err := NewInstrumentorWithRules(r, "0.2.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "please upgrade")
+}
+
 func TestIsMajorVersion(t *testing.T) {
 	assert.True(t, isMajorVersion("v2"))
 	assert.True(t, isMajorVersion("v5"))

--- a/cmd/zen-go/internal/instrumentor/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor_test.go
@@ -69,7 +69,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -96,7 +97,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testChiRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -129,7 +131,8 @@ func WithRouter() *chi.Mux {
 			WrapTmpl:    `func() *chi.Mux { r := {{.}}; r.Use(zenchi.GetMiddleware()); return r }()`,
 		},
 	}
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: wrapRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: wrapRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "github.com/go-chi/chi/v5/middleware")
 
 	require.NoError(t, err)
@@ -150,7 +153,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -177,7 +181,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -201,7 +206,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -223,7 +229,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -250,7 +257,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -277,7 +285,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -303,7 +312,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -315,7 +325,8 @@ func TestInstrumentFile_InvalidFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "nonexistent.go")
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -334,7 +345,8 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{WrapRules: testGinRules()}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	assert.Error(t, err)
@@ -407,7 +419,8 @@ type Rows struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "database/sql")
 
 	require.NoError(t, err)
@@ -442,7 +455,8 @@ func DoSomething() {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main")
 
 	require.NoError(t, err)
@@ -486,7 +500,8 @@ func (c *Cmd) Wait() error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "os/exec")
 
 	require.NoError(t, err)
@@ -522,7 +537,8 @@ type File struct{}
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -555,7 +571,8 @@ func OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "main") // Compiling "main" package
 
 	require.NoError(t, err)
@@ -585,7 +602,8 @@ func (f *File) OpenFile(name string) error {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{PrependRules: prependRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -619,7 +637,8 @@ func __example_check(string) error`,
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -654,7 +673,8 @@ func SomeOtherFunc() {
 		},
 	}
 
-	inst := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules})
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{InjectDeclRules: injectDeclRules}, "0.0.0")
+	require.NoError(t, err)
 	result, err := inst.InstrumentFile(tmpFile, "os")
 
 	require.NoError(t, err)
@@ -710,7 +730,8 @@ rules:
 		allRules.InjectDeclRules = append(allRules.InjectDeclRules, rulesData.InjectDeclRules...)
 	}
 
-	inst := NewInstrumentorWithRules(allRules)
+	inst, err := NewInstrumentorWithRules(allRules, "0.0.0")
+	require.NoError(t, err)
 
 	// Verify rules from both directories are present
 	assert.Len(t, inst.WrapRules, 1)

--- a/cmd/zen-go/internal/instrumentor/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor_test.go
@@ -356,7 +356,7 @@ func main() {
 	tmpFile := filepath.Join(tmpDir, "main.go")
 	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
 
-	inst, err := NewInstrumentor()
+	inst, err := NewInstrumentor("999.0.0")
 	require.NoError(t, err)
 
 	inst.WrapRules = []rules.WrapRule{

--- a/cmd/zen-go/internal/rules/rules.go
+++ b/cmd/zen-go/internal/rules/rules.go
@@ -20,6 +20,7 @@ type RulesFile struct {
 type RulesMeta struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
+	MinVersion  string `yaml:"min-zen-go-version"`
 }
 
 // Rule represents a single instrumentation rule
@@ -38,11 +39,18 @@ type Rule struct {
 	Template  string            `yaml:"template"`
 }
 
+// MinVersionEntry records a minimum zen-go version requirement from a rules file.
+type MinVersionEntry struct {
+	File    string
+	Version string
+}
+
 // InstrumentationRules holds all loaded rules
 type InstrumentationRules struct {
 	WrapRules       []WrapRule
 	PrependRules    []PrependRule
 	InjectDeclRules []InjectDeclRule
+	MinVersions     []MinVersionEntry
 }
 
 // WrapRule wraps a function call expression
@@ -109,6 +117,7 @@ func LoadRulesFromDir(dir string) (*InstrumentationRules, error) {
 		result.WrapRules = append(result.WrapRules, rules.WrapRules...)
 		result.PrependRules = append(result.PrependRules, rules.PrependRules...)
 		result.InjectDeclRules = append(result.InjectDeclRules, rules.InjectDeclRules...)
+		result.MinVersions = append(result.MinVersions, rules.MinVersions...)
 		return nil
 	})
 	if err != nil {
@@ -132,6 +141,12 @@ func loadRulesFromFile(path string) (*InstrumentationRules, error) {
 	}
 
 	result := &InstrumentationRules{}
+
+	if rulesFile.Meta.MinVersion != "" {
+		result.MinVersions = []MinVersionEntry{
+			{File: path, Version: rulesFile.Meta.MinVersion},
+		}
+	}
 
 	for _, rule := range rulesFile.Rules {
 		switch rule.Type {

--- a/cmd/zen-go/internal/rules/version.go
+++ b/cmd/zen-go/internal/rules/version.go
@@ -47,8 +47,8 @@ type semver struct {
 }
 
 func parseSemver(s string) (semver, error) {
-	s = strings.TrimPrefix(s, "v")
-	parts := strings.SplitN(s, ".", 3)
+	raw := strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(raw, ".", 3)
 	if len(parts) != 3 {
 		return semver{}, fmt.Errorf("expected format major.minor.patch, got %q", s)
 	}

--- a/cmd/zen-go/internal/rules/version.go
+++ b/cmd/zen-go/internal/rules/version.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"cmp"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CheckMinVersions checks that currentVersion satisfies all minimum version requirements.
+// Returns an error listing the first unsatisfied requirement.
+func CheckMinVersions(minVersions []MinVersionEntry, currentVersion string) error {
+	cur, err := parseSemver(currentVersion)
+	if err != nil {
+		return fmt.Errorf("zen-go: failed to parse current version %q: %w", currentVersion, err)
+	}
+
+	for _, entry := range minVersions {
+		required, err := parseSemver(entry.Version)
+		if err != nil {
+			return fmt.Errorf("zen-go: failed to parse min-zen-go-version %q in %s: %w", entry.Version, entry.File, err)
+		}
+
+		if compareSemver(cur, required) < 0 {
+			return fmt.Errorf("zen-go: %s requires zen-go >= v%s, but current version is v%s — please upgrade zen-go",
+				shortPath(entry.File), strings.TrimPrefix(entry.Version, "v"), strings.TrimPrefix(currentVersion, "v"))
+		}
+	}
+
+	return nil
+}
+
+// shortPath trims an absolute file path to the portion after "instrumentation/",
+// e.g. "/home/user/.cache/go/mod/.../instrumentation/sinks/sql/zen.instrument.yml"
+// becomes "sinks/sql/zen.instrument.yml". If the marker is not found, returns the
+// original path.
+func shortPath(path string) string {
+	const marker = "instrumentation/"
+	if i := strings.LastIndex(path, marker); i != -1 {
+		return path[i+len(marker):]
+	}
+	return path
+}
+
+type semver struct {
+	major, minor, patch int
+}
+
+func parseSemver(s string) (semver, error) {
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return semver{}, fmt.Errorf("expected format major.minor.patch, got %q", s)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid major version: %w", err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid minor version: %w", err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return semver{}, fmt.Errorf("invalid patch version: %w", err)
+	}
+
+	return semver{major, minor, patch}, nil
+}
+
+func compareSemver(a, b semver) int {
+	if c := cmp.Compare(a.major, b.major); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.minor, b.minor); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.patch, b.patch)
+}

--- a/cmd/zen-go/internal/rules/version_test.go
+++ b/cmd/zen-go/internal/rules/version_test.go
@@ -1,0 +1,102 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckMinVersions_Satisfied(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "sinks/sql/zen.instrument.yml", Version: "0.2.0"},
+	}
+	require.NoError(t, CheckMinVersions(entries, "0.2.0"))
+	require.NoError(t, CheckMinVersions(entries, "0.3.0"))
+	require.NoError(t, CheckMinVersions(entries, "1.0.0"))
+}
+
+func TestCheckMinVersions_NotMet(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "sinks/sql/zen.instrument.yml", Version: "0.3.0"},
+	}
+	err := CheckMinVersions(entries, "0.2.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires zen-go >= v0.3.0")
+	assert.Contains(t, err.Error(), "current version is v0.2.0")
+	assert.Contains(t, err.Error(), "please upgrade")
+}
+
+func TestCheckMinVersions_Empty(t *testing.T) {
+	require.NoError(t, CheckMinVersions(nil, "0.1.0"))
+	require.NoError(t, CheckMinVersions([]MinVersionEntry{}, "0.1.0"))
+}
+
+func TestCheckMinVersions_MultipleEntries(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "a.yml", Version: "0.1.0"},
+		{File: "b.yml", Version: "0.3.0"},
+	}
+	require.NoError(t, CheckMinVersions(entries, "0.3.0"))
+
+	err := CheckMinVersions(entries, "0.2.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "b.yml")
+}
+
+func TestCheckMinVersions_InvalidCurrentVersion(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "a.yml", Version: "0.1.0"},
+	}
+	err := CheckMinVersions(entries, "bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse current version")
+}
+
+func TestCheckMinVersions_InvalidMinVersion(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "a.yml", Version: "not-a-version"},
+	}
+	err := CheckMinVersions(entries, "0.1.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse min-zen-go-version")
+}
+
+func TestCheckMinVersions_VPrefix(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "a.yml", Version: "0.2.0"},
+	}
+	require.NoError(t, CheckMinVersions(entries, "v0.2.0"))
+}
+
+func TestParseSemver(t *testing.T) {
+	v, err := parseSemver("1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, semver{1, 2, 3}, v)
+
+	v, err = parseSemver("v0.3.0")
+	require.NoError(t, err)
+	assert.Equal(t, semver{0, 3, 0}, v)
+
+	_, err = parseSemver("1.2")
+	assert.Error(t, err)
+
+	_, err = parseSemver("abc")
+	assert.Error(t, err)
+}
+
+func TestShortPath(t *testing.T) {
+	assert.Equal(t, "sinks/sql/zen.instrument.yml",
+		shortPath("/home/user/.cache/go/mod/github.com/!aikido!sec/firewall-go@v0.3.0/instrumentation/sinks/sql/zen.instrument.yml"))
+	assert.Equal(t, "sources/gin/zen.instrument.yml",
+		shortPath("/tmp/instrumentation/sources/gin/zen.instrument.yml"))
+	assert.Equal(t, "no-marker.yml", shortPath("no-marker.yml"))
+}
+
+func TestCompareSemver(t *testing.T) {
+	assert.Equal(t, 0, compareSemver(semver{1, 2, 3}, semver{1, 2, 3}))
+	assert.Equal(t, -1, compareSemver(semver{0, 2, 0}, semver{0, 3, 0}))
+	assert.Equal(t, 1, compareSemver(semver{1, 0, 0}, semver{0, 9, 9}))
+	assert.Equal(t, -1, compareSemver(semver{0, 2, 0}, semver{0, 2, 1}))
+	assert.Equal(t, 1, compareSemver(semver{0, 2, 1}, semver{0, 2, 0}))
+}

--- a/cmd/zen-go/internal/rules/version_test.go
+++ b/cmd/zen-go/internal/rules/version_test.go
@@ -83,6 +83,15 @@ func TestParseSemver(t *testing.T) {
 
 	_, err = parseSemver("abc")
 	assert.Error(t, err)
+
+	_, err = parseSemver("x.0.0")
+	assert.ErrorContains(t, err, "invalid major version")
+
+	_, err = parseSemver("0.x.0")
+	assert.ErrorContains(t, err, "invalid minor version")
+
+	_, err = parseSemver("0.0.x")
+	assert.ErrorContains(t, err, "invalid patch version")
 }
 
 func TestShortPath(t *testing.T) {


### PR DESCRIPTION
Ensure that new types of rules, etc are not silently ignored and that we instruct the user to update,.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added min-zen-go-version metadata and collected per-file minimum entries
* Implemented min-version enforcement with semver parsing and user-facing errors

**🔧 Refactors**
* Refactored Instrumentor to accept current version and enforce requirements


<sup>[More info](https://app.aikido.dev/featurebranch/scan/87500974?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->