### PR TITLE
Add SetContext and Wrap to public package

### DIFF
--- a/instrumentation/request/context.go
+++ b/instrumentation/request/context.go
@@ -1,0 +1,39 @@
+package request
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/AikidoSec/firewall-go/internal/request"
+)
+
+type ContextData struct {
+	Source        string
+	Route         string
+	RouteParams   map[string]string
+	RemoteAddress *string
+	Body          any
+}
+
+// SetContext sets the context for the given request.
+func SetContext(ctx context.Context, r *http.Request, data ContextData) context.Context {
+	return request.SetContext(ctx, r, request.ContextData{
+		Source:        data.Source,
+		Route:         data.Route,
+		RouteParams:   data.RouteParams,
+		RemoteAddress: data.RemoteAddress,
+		Body:          data.Body,
+	})
+}
+
+// HasContext returns true if the context has a request context set.
+func HasContext(ctx context.Context) bool {
+	return request.GetContext(ctx) != nil
+}
+
+// Wrap calls fn while making the request context available to sinks
+// (e.g. database/sql, os/exec) that cannot receive a context.Context directly.
+// The request context is only accessible for the duration of fn.
+func Wrap(ctx context.Context, fn func()) {
+	request.WrapWithGLS(ctx, fn)
+}

--- a/instrumentation/request/context_test.go
+++ b/instrumentation/request/context_test.go
@@ -1,0 +1,103 @@
+package request
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetContext(t *testing.T) {
+	req, err := http.NewRequest("POST", "http://example.com/api/users?q=1", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	ip := "10.0.0.1"
+	routeParams := map[string]string{"id": "42"}
+	body := map[string]string{"name": "test"}
+
+	ctx := SetContext(context.Background(), req, ContextData{
+		Source:        "gin",
+		Route:         "/api/users/:id",
+		RouteParams:   routeParams,
+		RemoteAddress: &ip,
+		Body:          body,
+	})
+
+	reqCtx := request.GetContext(ctx)
+	require.NotNil(t, reqCtx)
+
+	assert.Equal(t, "gin", reqCtx.Source)
+	assert.Equal(t, "/api/users/:id", reqCtx.Route)
+	assert.Equal(t, "POST", reqCtx.Method)
+	assert.Equal(t, "/api/users", reqCtx.Path)
+	assert.Equal(t, &ip, reqCtx.RemoteAddress)
+	assert.Equal(t, routeParams, reqCtx.RouteParams)
+}
+
+func TestHasContext(t *testing.T) {
+	t.Run("returns false for empty context", func(t *testing.T) {
+		assert.False(t, HasContext(context.Background()))
+	})
+
+	t.Run("returns true after SetContext", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com/path", http.NoBody)
+		require.NoError(t, err)
+		ctx := SetContext(context.Background(), req, ContextData{
+			Source: "test",
+			Route:  "/path",
+		})
+		assert.True(t, HasContext(ctx))
+	})
+
+	t.Run("returns false for nil context", func(t *testing.T) {
+		//nolint:staticcheck // We want to test the nil case
+		assert.False(t, HasContext(nil))
+	})
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("makes context available via GLS", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com/wrapped", http.NoBody)
+		require.NoError(t, err)
+		ctx := SetContext(context.Background(), req, ContextData{
+			Source: "wrap-test",
+			Route:  "/wrapped",
+		})
+
+		var glsCtx *request.Context
+		Wrap(ctx, func() {
+			glsCtx = request.GetContext(context.Background())
+		})
+
+		require.NotNil(t, glsCtx)
+		assert.Equal(t, "wrap-test", glsCtx.Source)
+		assert.Equal(t, "/wrapped", glsCtx.Route)
+	})
+
+	t.Run("GLS context not available after Wrap returns", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "http://example.com/done", http.NoBody)
+		require.NoError(t, err)
+		ctx := SetContext(context.Background(), req, ContextData{
+			Source: "test",
+			Route:  "/done",
+		})
+
+		Wrap(ctx, func() {})
+
+		glsCtx := request.GetContext(context.Background())
+		assert.Nil(t, glsCtx)
+	})
+
+	t.Run("calls fn when context is nil", func(t *testing.T) {
+		called := false
+		//nolint:staticcheck // We want to test the nil case
+		Wrap(nil, func() {
+			called = true
+		})
+		assert.True(t, called)
+	})
+}

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -2,7 +2,7 @@ package gin
 
 import (
 	"github.com/AikidoSec/firewall-go/instrumentation/http"
-	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
 )
@@ -56,7 +56,7 @@ func GetMiddleware() gin.HandlerFunc {
 			http.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
 		}()
 
-		request.WrapWithGLS(reqCtx, func() {
+		request.Wrap(reqCtx, func() {
 			c.Next()
 		})
 	}

--- a/instrumentation/sources/go-chi/chi.v5/middleware.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
-	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -27,7 +27,7 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 			}
 
 			// If a context is already set, then middleware has already run
-			if request.GetContext(r.Context()) != nil {
+			if request.HasContext(r.Context()) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -71,7 +71,7 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 			// Wrap the ResponseWriter to capture the status code
 			recorder := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
-			request.WrapWithGLS(reqCtx, func() {
+			request.Wrap(reqCtx, func() {
 				next.ServeHTTP(recorder, wrappedR)
 			})
 

--- a/instrumentation/sources/labstack/echo.v4/middleware.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/http"
-	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v4"
 )
@@ -51,7 +51,7 @@ func GetMiddleware() echo.MiddlewareFunc {
 			}
 
 			var err error
-			request.WrapWithGLS(reqCtx, func() {
+			request.Wrap(reqCtx, func() {
 				err = next(c)
 			})
 

--- a/instrumentation/sources/labstack/echo.v5/middleware.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/http"
-	"github.com/AikidoSec/firewall-go/internal/request"
+	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v5"
 )
@@ -50,7 +50,7 @@ func GetMiddleware() echo.MiddlewareFunc {
 			}
 
 			var err error
-			request.WrapWithGLS(reqCtx, func() {
+			request.Wrap(reqCtx, func() {
 				err = next(c)
 			})
 

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -7,8 +7,8 @@ import (
 	"sync/atomic"
 
 	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
+	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/internal/log"
-	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 )
 
@@ -58,7 +58,7 @@ func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.R
 			writer: w,
 		}
 
-		request.WrapWithGLS(ctx, func() {
+		request.Wrap(ctx, func() {
 			orig(recorder, wrappedR)
 		})
 


### PR DESCRIPTION
- Moved required functions to a public package to reduce use of internal package within sub-modules.
- Added `HasContext`
- Public wrap function no longer contains GLS in name as it's an internal implementation detail.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added public request package with SetContext, HasContext, and Wrap.

**⚡ Enhancements**
* Introduced HasContext helper and used it to check request contexts.

**🔧 Refactors**
* Replaced internal request imports with new public instrumentation/request package.
* Replaced WrapWithGLS calls with Wrap across middleware implementations.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91855961?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->