### PR TITLE
Detect sql dialect from driver type name

### DIFF
--- a/instrumentation/sinks/database/sql/dialect.go
+++ b/instrumentation/sinks/database/sql/dialect.go
@@ -1,0 +1,29 @@
+package sql
+
+import (
+	"database/sql/driver"
+	"reflect"
+	"strings"
+)
+
+// GetDialectFromDriver determines the SQL dialect by inspecting the driver type.
+func GetDialectFromDriver(d driver.Driver) string {
+	if d == nil {
+		return "generic"
+	}
+	return resolveDialectFromDriverType(reflect.TypeOf(d).String())
+}
+
+func resolveDialectFromDriverType(typeName string) string {
+	lower := strings.ToLower(typeName)
+	switch {
+	case strings.Contains(lower, "mysql"):
+		return "mysql"
+	case strings.Contains(lower, "pq") || strings.Contains(lower, "postgres") || strings.Contains(lower, "pgx"):
+		return "postgres"
+	case strings.Contains(lower, "sqlite"):
+		return "sqlite"
+	default:
+		return "generic"
+	}
+}

--- a/instrumentation/sinks/database/sql/dialect_test.go
+++ b/instrumentation/sinks/database/sql/dialect_test.go
@@ -1,0 +1,47 @@
+//go:build !integration
+
+package sql_test
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	sinksql "github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeMysqlDriver2 struct{}
+
+func (d *fakeMysqlDriver2) Open(name string) (driver.Conn, error) { return nil, nil }
+
+type fakePostgresDriver struct{}
+
+func (d *fakePostgresDriver) Open(name string) (driver.Conn, error) { return nil, nil }
+
+type fakeSQLiteDriver struct{}
+
+func (d *fakeSQLiteDriver) Open(name string) (driver.Conn, error) { return nil, nil }
+
+type fakeUnknownDriver struct{}
+
+func (d *fakeUnknownDriver) Open(name string) (driver.Conn, error) { return nil, nil }
+
+func TestGetDialectFromDriver(t *testing.T) {
+	tests := []struct {
+		name            string
+		driver          driver.Driver
+		expectedDialect string
+	}{
+		{"mysql", &fakeMysqlDriver2{}, "mysql"},
+		{"postgres", &fakePostgresDriver{}, "postgres"},
+		{"sqlite", &fakeSQLiteDriver{}, "sqlite"},
+		{"unknown", &fakeUnknownDriver{}, "generic"},
+		{"nil", nil, "generic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedDialect, sinksql.GetDialectFromDriver(tt.driver))
+		})
+	}
+}

--- a/instrumentation/sinks/database/sql/disabled_test.go
+++ b/instrumentation/sinks/database/sql/disabled_test.go
@@ -47,7 +47,7 @@ func TestExamineContext_Disabled(t *testing.T) {
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
 
-	err := sql.ExamineContext(ctx, maliciousQuery, "database/sql.DB.QueryContext")
+	err := sql.ExamineContext(ctx, maliciousQuery, "database/sql.DB.QueryContext", "generic")
 
 	require.NoError(t, err, "ExamineContext should return early with no error when zen is disabled")
 
@@ -92,7 +92,7 @@ func TestExamineContext_NotLoaded(t *testing.T) {
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
 
-	err := sql.ExamineContext(ctx, maliciousQuery, "database/sql.DB.QueryContext")
+	err := sql.ExamineContext(ctx, maliciousQuery, "database/sql.DB.QueryContext", "generic")
 
 	require.NoError(t, err, "ExamineContext should return early with no error when zen is not loaded")
 

--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -11,12 +11,6 @@ import (
 	"github.com/AikidoSec/firewall-go/zen"
 )
 
-// Examine checks for SQL injection on non-context database methods.
-// Use this for methods like Query, QueryRow, Exec, and Prepare.
-func Examine(query string, op string, dialect string) error {
-	return ExamineContext(context.Background(), query, op, dialect)
-}
-
 // ExamineContext checks for SQL injection vulnerabilities in database queries.
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.

--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -13,14 +13,14 @@ import (
 
 // Examine checks for SQL injection on non-context database methods.
 // Use this for methods like Query, QueryRow, Exec, and Prepare.
-func Examine(query string, op string) error {
-	return ExamineContext(context.Background(), query, op)
+func Examine(query string, op string, dialect string) error {
+	return ExamineContext(context.Background(), query, op, dialect)
 }
 
 // ExamineContext checks for SQL injection vulnerabilities in database queries.
 // This function is called by the instrumentation framework to scan SQL queries
 // before they are executed against the database.
-func ExamineContext(ctx context.Context, query string, op string) error {
+func ExamineContext(ctx context.Context, query string, op string, dialect string) error {
 	if !zen.ShouldProtect() {
 		return nil
 	}
@@ -29,7 +29,7 @@ func ExamineContext(ctx context.Context, query string, op string) error {
 
 	err := vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
 		Statement: query,
-		Dialect:   "default",
+		Dialect:   dialect,
 	})
 	if err != nil {
 		// Extract attack kind from error if available, otherwise default to SQL injection

--- a/instrumentation/sinks/database/sql/examine_test.go
+++ b/instrumentation/sinks/database/sql/examine_test.go
@@ -40,9 +40,9 @@ func TestExamineContext_TracksOperationStats(t *testing.T) {
 
 	// Execute multiple queries
 	query := "SELECT * FROM users WHERE id = 1"
-	_ = sql.ExamineContext(ctx, query, "database/sql.DB.Query")
-	_ = sql.ExamineContext(ctx, query, "database/sql.DB.Query")
-	_ = sql.ExamineContext(ctx, "INSERT INTO users VALUES (1)", "database/sql.DB.Exec")
+	_ = sql.ExamineContext(ctx, query, "database/sql.DB.Query", "generic")
+	_ = sql.ExamineContext(ctx, query, "database/sql.DB.Query", "generic")
+	_ = sql.ExamineContext(ctx, "INSERT INTO users VALUES (1)", "database/sql.DB.Exec", "generic")
 
 	// Get stats and verify operations were tracked
 	stats := agent.Stats().GetAndClear()

--- a/instrumentation/sinks/database/sql/fake_driver_test.go
+++ b/instrumentation/sinks/database/sql/fake_driver_test.go
@@ -8,6 +8,13 @@ import (
 
 func init() {
 	sql.Register("test", &testDriver{})
+	sql.Register("fake-mysql", &fakeMysqlDriver{})
+}
+
+type fakeMysqlDriver struct{}
+
+func (d *fakeMysqlDriver) Open(name string) (driver.Conn, error) {
+	return &testConn{}, nil
 }
 
 type testDriver struct{}

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -589,13 +589,54 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 		assert.Equal(t, ".query", client.capturedAttack.Path)
 		assert.Equal(t, "1' OR 1=1", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{
-			"dialect": "default",
+			"dialect": "generic",
 			"sql":     "SELECT * FROM users WHERE id = '1' OR 1=1",
 		}, client.capturedAttack.Metadata)
 		assert.Nil(t, nil, client.capturedAttack.User)
 
 		assert.NotEmpty(t, client.capturedAgentInfo)
 
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestDialectIsPassedThrough(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	db, err := sql.Open("fake-mysql", "")
+	require.NoError(t, err)
+
+	request.WrapWithGLS(ctx, func() {
+		_, err := db.QueryContext(ctx, "SELECT * FROM users WHERE id = '1' OR 1=1")
+		require.Error(t, err)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "mysql", client.capturedAttack.Metadata["dialect"])
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for attack event")
 	}

--- a/instrumentation/sinks/database/sql/zen.instrument.yml
+++ b/instrumentation/sinks/database/sql/zen.instrument.yml
@@ -3,15 +3,27 @@ meta:
   description: Protection from SQL Injection.
 
 rules:
+  # Inject go:linkname declarations for ExamineContext and GetDialectFromDriver
+  - id: database/sql.linkname
+    type: inject-decl
+    package: database/sql
+    anchor: Open
+    links:
+      - github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
+    template: |
+      //go:linkname __aikido_sql_ExamineContext github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql.ExamineContext
+      func __aikido_sql_ExamineContext(context.Context, string, string, string) error
+
+      //go:linkname __aikido_sql_GetDialectFromDriver github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql.GetDialectFromDriver
+      func __aikido_sql_GetDialectFromDriver(driver.Driver) string
+
   # DB methods
   - id: database/sql.DB.QueryContext
     type: prepend
     receiver: "*database/sql.DB"
     function: QueryContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.Query(Row)Context")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.Query(Row)Context", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
@@ -20,10 +32,8 @@ rules:
     type: prepend
     receiver: "*database/sql.DB"
     function: ExecContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.ExecContext")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.ExecContext", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
@@ -32,10 +42,8 @@ rules:
     type: prepend
     receiver: "*database/sql.DB"
     function: PrepareContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.PrepareContext")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.DB.PrepareContext", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
@@ -45,10 +53,8 @@ rules:
     type: prepend
     receiver: "*database/sql.Tx"
     function: QueryContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.Query(Row)Context")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.Query(Row)Context", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.db.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
@@ -57,10 +63,8 @@ rules:
     type: prepend
     receiver: "*database/sql.Tx"
     function: ExecContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.ExecContext")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.ExecContext", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.db.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
@@ -69,11 +73,8 @@ rules:
     type: prepend
     receiver: "*database/sql.Tx"
     function: PrepareContext
-    imports:
-      sink: github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql
     template: |
-      _aikido_block := sink.ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.PrepareContext")
+      _aikido_block := __aikido_sql_ExamineContext({{ .Function.Argument 0 }}, {{ .Function.Argument 1 }}, "database/sql.Tx.PrepareContext", __aikido_sql_GetDialectFromDriver({{ .Function.Receiver }}.db.Driver()))
       if _aikido_block != nil {
         return nil, _aikido_block
       }
-


### PR DESCRIPTION
Once a connection is open, the driver name is lost. To determine which dialect to use, we're using the type name of the driver itself.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GetDialectFromDriver to detect SQL dialect from driver type

**⚡ Enhancements**
* Changed ExamineContext signature to accept dialect and removed Examine
* Updated zen.instrument.yml to inject linknames and pass dialect to ExamineContext


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94240648?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->