### PR TITLE
Add bypassed context flag

### DIFF
--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -11,8 +11,10 @@ import (
 )
 
 type contextKey struct{}
+type bypassedContextKey struct{}
 
 var reqCtxKey contextKey
+var bypassedCtxKey bypassedContextKey
 
 type ContextData struct {
 	Source        string
@@ -24,7 +26,7 @@ type ContextData struct {
 
 func SetContext(ctx context.Context, r *http.Request, data ContextData) context.Context {
 	if data.RemoteAddress != nil && config.IsIPBypassed(*data.RemoteAddress) {
-		return ctx
+		return context.WithValue(ctx, bypassedCtxKey, true)
 	}
 
 	route := data.Route
@@ -57,6 +59,17 @@ func SetContext(ctx context.Context, r *http.Request, data ContextData) context.
 		executedMiddleware: false, // We start with no middleware executed.
 	}
 	return context.WithValue(ctx, reqCtxKey, c)
+}
+
+func IsBypassed(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v := ctx.Value(bypassedCtxKey)
+	if v == nil {
+		return false
+	}
+	return v.(bool)
 }
 
 func GetContext(ctx context.Context) *Context {

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -151,6 +151,18 @@ func TestSetContext_BypassedIP(t *testing.T) {
 
 	result := GetContext(setCtx)
 	require.Nil(t, result)
+	assert.True(t, IsBypassed(setCtx))
+}
+
+func TestIsBypassed(t *testing.T) {
+	t.Run("returns false for nil context", func(t *testing.T) {
+		//nolint:staticcheck // We want to test the nil case
+		assert.False(t, IsBypassed(nil))
+	})
+
+	t.Run("returns false for context without bypass flag", func(t *testing.T) {
+		assert.False(t, IsBypassed(context.Background()))
+	})
 }
 
 func TestGetContext(t *testing.T) {


### PR DESCRIPTION
Stores a bypassed flag in the context when a request's IP is bypassed. This allows callers to distinguish between "no
  request context" and "bypassed request".

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added bypassed request flag to context and IsBypassed accessor
* Changed SetContext to record bypassed flag for bypassed IPs

**🔧 Refactors**
* Removed EnsureContextPropagated function to simplify context propagation logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94962636?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->