### PR TITLE
Skip outbound blocking for bypassed IPs

### DIFF
--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -6,11 +6,16 @@ import (
 
 	"github.com/AikidoSec/firewall-go/instrumentation/hooks"
 	"github.com/AikidoSec/firewall-go/instrumentation/operation"
+	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 )
 
 func Examine(r *http.Request) error {
 	if !zen.ShouldProtect() {
+		return nil
+	}
+
+	if request.IsBypassed(r.Context()) {
 		return nil
 	}
 

--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -15,10 +15,6 @@ func Examine(r *http.Request) error {
 		return nil
 	}
 
-	if request.IsBypassed(r.Context()) {
-		return nil
-	}
-
 	hooks.OnOperationCall("net/http.Client.Do", operation.KindOutgoingHTTP)
 
 	if r.URL == nil {
@@ -30,6 +26,11 @@ func Examine(r *http.Request) error {
 
 	// Report any hostnames to the dashboard
 	hooks.OnDomain(hostname, uint32(port))
+
+	// If bypassed IP, report hostname, but don't attempt to block it
+	if request.IsBypassed(r.Context()) {
+		return nil
+	}
 
 	if hooks.ShouldBlockHostname(hostname) {
 		return zen.ErrOutboundBlocked(hostname)

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -3,10 +3,16 @@
 package http
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/internal/testutil"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/stretchr/testify/assert"
@@ -72,4 +78,37 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 	stats := agent.Stats().GetAndClear()
 	require.Contains(t, stats.Operations, "net/http.Client.Do")
 	require.Equal(t, 3, stats.Operations["net/http.Client.Do"].Total, "should track 3 HTTP calls")
+}
+
+func TestExamine_BypassedIPSkipsOutboundBlocking(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	originalClient := agent.GetCloudClient()
+	defer func() {
+		zen.SetDisabled(originalDisabled)
+		agent.SetCloudClient(originalClient)
+	}()
+
+	require.NoError(t, zen.Protect())
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	block := true
+	config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+		ConfigUpdatedAt: time.Now().UnixMilli(),
+		BypassedIPs:     []string{"10.10.10.10"},
+		Block:           &block,
+		Domains: []aikido_types.OutboundDomain{
+			{Hostname: "malicious.com", Mode: "block"},
+		},
+	}, nil)
+
+	incomingReq := httptest.NewRequest("GET", "/api/fetch?url=http://malicious.com", nil)
+	ip := "10.10.10.10"
+	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+		RemoteAddress: &ip,
+	})
+	require.True(t, request.IsBypassed(ctx), "context should be marked as bypassed")
+
+	outboundReq, _ := http.NewRequestWithContext(ctx, "GET", "http://malicious.com", http.NoBody)
+	err := Examine(outboundReq)
+	assert.NoError(t, err, "bypassed IP should not trigger outbound blocking")
 }

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -108,7 +108,18 @@ func TestExamine_BypassedIPSkipsOutboundBlocking(t *testing.T) {
 	})
 	require.True(t, request.IsBypassed(ctx), "context should be marked as bypassed")
 
+	agent.State().GetAndClearHostnames()
+	agent.Stats().GetAndClear()
+
 	outboundReq, _ := http.NewRequestWithContext(ctx, "GET", "http://malicious.com", http.NoBody)
 	err := Examine(outboundReq)
+
 	assert.NoError(t, err, "bypassed IP should not trigger outbound blocking")
+
+	stats := agent.Stats().GetAndClear()
+	require.Contains(t, stats.Operations, "net/http.Client.Do", "should still track operation stats for bypassed IPs")
+
+	hostnames := agent.State().GetAndClearHostnames()
+	require.Len(t, hostnames, 1, "should still report hostname for bypassed IPs")
+	assert.Equal(t, "malicious.com", hostnames[0].URL)
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Skipped outbound blocking for requests flagged as bypassed while reporting.

**🔧 Refactors**
* Added internal request import to support bypassed-IP checking functionality.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97030640?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->