### PR TITLE
Update to Go 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ["1.24", "1.25", "1.26"]
+        go-version: ["1.25", "1.26"]
         os:
           - runner: ubuntu-latest
             name: ubuntu-x86_64
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.24", "1.25", "1.26"]
+        go-version: ["1.25", "1.26"]
       fail-fast: false
     steps:
       - name: Checkout code
@@ -95,7 +95,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.24", "1.25", "1.26"]
+        go-version: ["1.25", "1.26"]
       fail-fast: false
 
     steps:

--- a/end2end/mock-server/go.mod
+++ b/end2end/mock-server/go.mod
@@ -1,3 +1,3 @@
 module github.com/AikidoSec/firewall-go/end2end/mock-server
 
-go 1.24.2
+go 1.25

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/jtolds/gls v4.20.0+incompatible

--- a/instrumentation/sinks/jackc/pgx.v5/go.mod
+++ b/instrumentation/sinks/jackc/pgx.v5/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/AikidoSec/firewall-go => ../../../../
 

--- a/instrumentation/sources/gin-gonic/gin/go.mod
+++ b/instrumentation/sources/gin-gonic/gin/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/AikidoSec/firewall-go => ../../../../
 

--- a/instrumentation/sources/go-chi/chi.v5/go.mod
+++ b/instrumentation/sources/go-chi/chi.v5/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi.v5
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/AikidoSec/firewall-go => ../../../../
 

--- a/instrumentation/sources/labstack/echo.v4/go.mod
+++ b/instrumentation/sources/labstack/echo.v4/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo.v4
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/AikidoSec/firewall-go => ../../../../
 

--- a/sample-apps/chi-postgres/go.mod
+++ b/sample-apps/chi-postgres/go.mod
@@ -1,6 +1,6 @@
 module chi-postgres
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/echo-pgx-sql/go.mod
+++ b/sample-apps/echo-pgx-sql/go.mod
@@ -1,6 +1,6 @@
 module echo-pgx-sql
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/echo-postgres/go.mod
+++ b/sample-apps/echo-postgres/go.mod
@@ -1,6 +1,6 @@
 module echo-postgres
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/gin-pgx-native/go.mod
+++ b/sample-apps/gin-pgx-native/go.mod
@@ -1,6 +1,6 @@
 module gin-pgx-native
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/gin-postgres/go.mod
+++ b/sample-apps/gin-postgres/go.mod
@@ -1,6 +1,6 @@
 module gin-postgres
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/gin-sqlx/go.mod
+++ b/sample-apps/gin-sqlx/go.mod
@@ -1,6 +1,6 @@
 module gin-sqlx
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v1.0.0

--- a/sample-apps/http-postgres/go.mod
+++ b/sample-apps/http-postgres/go.mod
@@ -1,6 +1,6 @@
 module http-postgres
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AikidoSec/firewall-go v0.0.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/AikidoSec/firewall-go/tools
 
-go 1.24.2
+go 1.25
 
 require gotest.tools/gotestsum v1.13.0
 


### PR DESCRIPTION
Following officially supported versions of Go.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated CI matrices to use Go 1.25 and 1.26 only


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97032885?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->