### PR TITLE
Add func result names to templating

### DIFF
--- a/cmd/zen-go/internal/transform/template.go
+++ b/cmd/zen-go/internal/transform/template.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"fmt"
 	"go/ast"
 )
 
@@ -66,4 +67,57 @@ func (f *function) Name() string {
 		return ""
 	}
 	return f.fn.Name.Name
+}
+
+// Result returns the name of the return value at the given index.
+// If the return value is unnamed, it assigns a synthetic name (_aikido_r<idx>)
+// by modifying the AST. This enables defer blocks in prepend templates to
+// capture return values via named returns.
+func (f *function) Result(idx int) string {
+	if f.fn.Type.Results == nil {
+		return ""
+	}
+
+	resultIdx := 0
+	for _, field := range f.fn.Type.Results.List {
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+
+		for i := 0; i < count; i++ {
+			if resultIdx == idx {
+				if len(field.Names) > 0 {
+					return field.Names[i].Name
+				}
+				// Unnamed result: we need to name all results in this field list
+				// to satisfy Go's "all or none" named return rule.
+				f.nameAllResults()
+				return field.Names[i].Name
+			}
+			resultIdx++
+		}
+	}
+
+	return ""
+}
+
+// nameAllResults assigns synthetic names (_aikido_r0, _aikido_r1, ...) to all
+// unnamed return values. Go requires that either all or no return values are named,
+// so we name them all.
+func (f *function) nameAllResults() {
+	if f.fn.Type.Results == nil {
+		return
+	}
+
+	idx := 0
+	for _, field := range f.fn.Type.Results.List {
+		if len(field.Names) == 0 {
+			name := fmt.Sprintf("_aikido_r%d", idx)
+			field.Names = []*ast.Ident{ast.NewIdent(name)}
+			idx++
+		} else {
+			idx += len(field.Names)
+		}
+	}
 }

--- a/cmd/zen-go/internal/transform/template_test.go
+++ b/cmd/zen-go/internal/transform/template_test.go
@@ -84,3 +84,44 @@ func TestFunction_Receiver_UnnamedReceiver(t *testing.T) {
 	f := &function{fn: fn}
 	assert.Equal(t, "", f.Receiver())
 }
+
+func TestFunction_Result_NamedReturns(t *testing.T) {
+	fn := parseFunc(t, `package p; func Foo() (result int, err error) { return 0, nil }`)
+	f := &function{fn: fn}
+
+	assert.Equal(t, "result", f.Result(0))
+	assert.Equal(t, "err", f.Result(1))
+	assert.Equal(t, "", f.Result(2))
+}
+
+func TestFunction_Result_UnnamedReturns(t *testing.T) {
+	fn := parseFunc(t, `package p; func Foo() (int, error) { return 0, nil }`)
+	f := &function{fn: fn}
+
+	assert.Equal(t, "_aikido_r0", f.Result(0))
+	assert.Equal(t, "_aikido_r1", f.Result(1))
+	assert.Equal(t, "", f.Result(2))
+}
+
+func TestFunction_Result_NoReturns(t *testing.T) {
+	fn := parseFunc(t, `package p; func Foo() {}`)
+	f := &function{fn: fn}
+	assert.Equal(t, "", f.Result(0))
+}
+
+func TestFunction_Result_SingleUnnamedReturn(t *testing.T) {
+	fn := parseFunc(t, `package p; func Foo() error { return nil }`)
+	f := &function{fn: fn}
+	assert.Equal(t, "_aikido_r0", f.Result(0))
+	assert.Equal(t, "", f.Result(1))
+}
+
+func TestFunction_Result_CalledTwice(t *testing.T) {
+	fn := parseFunc(t, `package p; func Foo() (int, error) { return 0, nil }`)
+	f := &function{fn: fn}
+
+	// Calling Result multiple times should be idempotent
+	assert.Equal(t, "_aikido_r0", f.Result(0))
+	assert.Equal(t, "_aikido_r1", f.Result(1))
+	assert.Equal(t, "_aikido_r0", f.Result(0))
+}

--- a/cmd/zen-go/internal/transform/transform_prepend_test.go
+++ b/cmd/zen-go/internal/transform/transform_prepend_test.go
@@ -1,8 +1,10 @@
 package transform
 
 import (
+	"bytes"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"testing"
 
@@ -262,6 +264,38 @@ func Foo(x int) {}`
 
 	err := TransformDeclsPrepend(decls, "p", rule, new(bool), map[string]string{})
 	require.Error(t, err)
+}
+
+func TestTransformDeclsPrepend_ResultMutatesPrintedOutput(t *testing.T) {
+	src := `package p
+
+func Foo() (int, error) {
+	return 0, nil
+}`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", src, 0)
+	require.NoError(t, err)
+
+	rule := rules.PrependRule{
+		Package:     "p",
+		FuncNames:   []string{"Foo"},
+		PrependTmpl: `defer func() { _ = {{ .Function.Result 0 }} }()`,
+	}
+
+	modified := false
+	err = TransformDeclsPrepend(f.Decls, "p", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	var buf bytes.Buffer
+	err = printer.Fprint(&buf, fset, f)
+	require.NoError(t, err)
+
+	output := buf.String()
+	// The function signature must have named returns in the printed output.
+	assert.Contains(t, output, "(_aikido_r0 int, _aikido_r1 error)")
+	// The prepended defer must reference the correct return variable name.
+	assert.Contains(t, output, "_ = _aikido_r0")
 }
 
 func TestMatchesFuncName(t *testing.T) {


### PR DESCRIPTION
Allows for capturing return values from functions that we prepend.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added support for naming function return values for templates
* Added helper that assigned synthetic names to unnamed return values


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97064550?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->