### PR TITLE
Add module names in attack details

### DIFF
--- a/end2end/tests/default/path_traversal_test.go
+++ b/end2end/tests/default/path_traversal_test.go
@@ -33,6 +33,7 @@ func TestPathTraversal(t *testing.T) {
 		assert.Equal(t, "path_traversal", attack["kind"])
 		assert.Equal(t, true, attack["blocked"])
 		assert.Contains(t, attack["payload"], maliciousPath)
+		assert.Equal(t, "os", attack["module"])
 
 		request, ok := event["request"].(map[string]any)
 		require.True(t, ok)

--- a/end2end/tests/default/sql_injection_test.go
+++ b/end2end/tests/default/sql_injection_test.go
@@ -48,6 +48,7 @@ func TestSQLInjection(t *testing.T) {
 		assert.Equal(t, "sql_injection", attack["kind"])
 		assert.Equal(t, true, attack["blocked"])
 		assert.Contains(t, attack["payload"], maliciousInput)
+		assert.NotEmpty(t, attack["module"])
 
 		metadata, ok := attack["metadata"].(map[string]any)
 		require.True(t, ok)

--- a/instrumentation/sinks/database/sql/examine.go
+++ b/instrumentation/sinks/database/sql/examine.go
@@ -21,10 +21,10 @@ func ExamineContext(ctx context.Context, query string, op string, dialect string
 
 	hooks.OnOperationCall(op, operation.KindSQL)
 
-	err := vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
+	err := vulnerabilities.ScanWithOptions(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
 		Statement: query,
 		Dialect:   dialect,
-	})
+	}, vulnerabilities.ScanOptions{Module: "database/sql"})
 	if err != nil {
 		// Extract attack kind from error if available, otherwise default to SQL injection
 		attackKind := vulnerabilities.KindSQLInjection

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -585,7 +585,7 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 		assert.Equal(t, "sql_injection", client.capturedAttack.Kind)
 		assert.True(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "database/sql.DB.Query(Row)Context", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "database/sql", client.capturedAttack.Module)
 		assert.Equal(t, ".query", client.capturedAttack.Path)
 		assert.Equal(t, "1' OR 1=1", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{

--- a/instrumentation/sinks/jackc/pgx.v5/examine.go
+++ b/instrumentation/sinks/jackc/pgx.v5/examine.go
@@ -21,10 +21,10 @@ func ExamineContext(ctx context.Context, query string, op string) error {
 
 	hooks.OnOperationCall(op, operation.KindSQL)
 
-	err := vulnerabilities.Scan(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
+	err := vulnerabilities.ScanWithOptions(ctx, op, sqlinjection.SQLInjectionVulnerability, &sqlinjection.ScanArgs{
 		Statement: query,
 		Dialect:   "postgres",
-	})
+	}, vulnerabilities.ScanOptions{Module: "github.com/jackc/pgx/v5"})
 	if err != nil {
 		// Extract attack kind from error if available, otherwise default to SQL injection
 		attackKind := vulnerabilities.KindSQLInjection

--- a/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
@@ -467,7 +467,7 @@ func TestQueryIsAutomaticallyInstrumented(t *testing.T) {
 		assert.Equal(t, "sql_injection", client.capturedAttack.Kind)
 		assert.True(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "pgx.Conn.Query", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "github.com/jackc/pgx/v5", client.capturedAttack.Module)
 		assert.Equal(t, ".query", client.capturedAttack.Path)
 		assert.Equal(t, "1' OR 1=1", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{

--- a/instrumentation/sinks/net/http/dial_context.go
+++ b/instrumentation/sinks/net/http/dial_context.go
@@ -53,12 +53,13 @@ func ssrfDialContext(originalDialContext func(ctx context.Context, network, addr
 // If no direct match is found, it walks the redirect chain to find the origin
 // hostname and checks that against user input instead.
 func scanSSRF(ctx context.Context, hostname string, port uint32, resolvedIPs []string) error {
-	scanErr := vulnerabilities.Scan(ctx, "net/http.Client.Do",
+	scanOpts := vulnerabilities.ScanOptions{Module: "net/http"}
+	scanErr := vulnerabilities.ScanWithOptions(ctx, "net/http.Client.Do",
 		ssrf.SSRFVulnerability, &ssrf.ScanArgs{
 			Hostname:    hostname,
 			Port:        port,
 			ResolvedIPs: resolvedIPs,
-		})
+		}, scanOpts)
 	if scanErr != nil {
 		return wrapSSRFError(scanErr)
 	}
@@ -73,12 +74,12 @@ func scanSSRF(ctx context.Context, hostname string, port uint32, resolvedIPs []s
 		return nil
 	}
 
-	scanErr = vulnerabilities.Scan(ctx, "net/http.Client.Do",
+	scanErr = vulnerabilities.ScanWithOptions(ctx, "net/http.Client.Do",
 		ssrf.SSRFVulnerability, &ssrf.ScanArgs{
 			Hostname:    originHostname,
 			Port:        originPort,
 			ResolvedIPs: resolvedIPs,
-		})
+		}, scanOpts)
 	if scanErr != nil {
 		return wrapSSRFError(scanErr)
 	}

--- a/instrumentation/sinks/net/http/dial_context_test.go
+++ b/instrumentation/sinks/net/http/dial_context_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -344,4 +345,30 @@ func TestSsrfDialContext_AllowsPrivateIPNotInUserInput(t *testing.T) {
 
 	assert.NoError(t, err, "should allow private IP not originating from user input")
 	assert.NotNil(t, conn, "should return the connection")
+}
+
+func TestSsrfDialContext_ReportsModuleName(t *testing.T) {
+	setupProtection(t)
+
+	mockClient := testutil.NewMockCloudClient()
+	agent.SetCloudClient(mockClient)
+
+	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
+	ip := "1.2.3.4"
+	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	original := dialerReturning("10.0.0.1:80")
+	wrapped := ssrfDialContext(original)
+	_, _ = wrapped(ctx, "tcp", "10.0.0.1:80")
+
+	select {
+	case <-mockClient.AttackDetectedEventSent:
+		assert.Equal(t, "net/http", mockClient.CapturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
 }

--- a/instrumentation/sinks/os/examine.go
+++ b/instrumentation/sinks/os/examine.go
@@ -24,6 +24,7 @@ func Examine(path string) error {
 		CheckPathStart: true,
 	}, vulnerabilities.ScanOptions{
 		DeferReporting: false,
+		Module:         "os",
 	})
 
 	return err

--- a/instrumentation/sinks/os/exec/examine.go
+++ b/instrumentation/sinks/os/exec/examine.go
@@ -43,7 +43,7 @@ func Examine(cmdCtx context.Context, op string, args []string) error {
 	//   cmd := exec.Command("sh", "-c", "$0", userInput)
 	fullCommand := strings.Join(commandsToScan, " ")
 
-	return vulnerabilities.Scan(ctx, op, shellinjection.ShellInjectionVulnerability, &shellinjection.ScanArgs{
+	return vulnerabilities.ScanWithOptions(ctx, op, shellinjection.ShellInjectionVulnerability, &shellinjection.ScanArgs{
 		Command: fullCommand,
-	})
+	}, vulnerabilities.ScanOptions{Module: "os/exec"})
 }

--- a/instrumentation/sinks/os/exec/examine_test.go
+++ b/instrumentation/sinks/os/exec/examine_test.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/os/exec"
 	"github.com/AikidoSec/firewall-go/internal/agent"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/internal/testutil"
 	"github.com/AikidoSec/firewall-go/zen"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,4 +52,38 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 
 	require.Equal(t, 1, stats.Operations["os/exec.Cmd.Run"].Total, "Run should be called once")
 	require.Equal(t, 1, stats.Operations["os/exec.Cmd.Start"].Total, "Start should be called once")
+}
+
+func TestExamine_ReportsModuleName(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+
+	originalBlocking := config.IsBlockingEnabled()
+	defer config.SetBlocking(originalBlocking)
+	config.SetBlocking(true)
+
+	mockClient := testutil.NewMockCloudClient()
+	agent.SetCloudClient(mockClient)
+
+	req := httptest.NewRequest("GET", "/test?cmd=ls%20.", nil)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	_ = exec.Examine(ctx, "os/exec.Cmd.Run", []string{"sh", "-c", "ls ."})
+
+	select {
+	case <-mockClient.AttackDetectedEventSent:
+		assert.Equal(t, "os/exec", mockClient.CapturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
 }

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -102,7 +102,7 @@ func TestOpenFileIsAutomaticallyInstrumented(t *testing.T) {
 		assert.True(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "os.OpenFile", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "os", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{
@@ -166,7 +166,7 @@ func TestOpenFileIsNotBlockedWhenInMonitoringMode(t *testing.T) {
 		assert.False(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "os.OpenFile", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "os", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{

--- a/instrumentation/sinks/path/examine.go
+++ b/instrumentation/sinks/path/examine.go
@@ -27,6 +27,7 @@ func Examine(args []string) error {
 		CheckPathStart: true,
 	}, vulnerabilities.ScanOptions{
 		DeferReporting: true,
+		Module:         "path",
 	})
 
 	return err

--- a/instrumentation/sinks/path/filepath/examine.go
+++ b/instrumentation/sinks/path/filepath/examine.go
@@ -27,6 +27,7 @@ func Examine(args []string) error {
 		CheckPathStart: true,
 	}, vulnerabilities.ScanOptions{
 		DeferReporting: true,
+		Module:         "path/filepath",
 	})
 
 	return err

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -120,7 +120,7 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 		assert.True(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{
@@ -183,7 +183,7 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 		assert.False(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{

--- a/instrumentation/sinks/path/integration_test.go
+++ b/instrumentation/sinks/path/integration_test.go
@@ -120,7 +120,7 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 		assert.True(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "path.Join", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "path", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{
@@ -183,7 +183,7 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 		assert.False(t, client.capturedAttack.Blocked)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, "path.Join", client.capturedAttack.Operation)
-		assert.Equal(t, "Module", client.capturedAttack.Module)
+		assert.Equal(t, "path", client.capturedAttack.Module)
 		assert.Equal(t, ".path", client.capturedAttack.Path)
 		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
 		assert.Equal(t, map[string]string{

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -135,6 +135,7 @@ func (ctx *Context) GetIP() string {
 // DeferredAttack stores attack information and error to be reported/blocked later
 type DeferredAttack struct {
 	Operation     string
+	Module        string
 	Kind          string
 	Source        string
 	PathToPayload string

--- a/vulnerabilities/attack.go
+++ b/vulnerabilities/attack.go
@@ -44,6 +44,7 @@ func getDisplayNameForAttackKind(kind AttackKind) string {
 type interceptorResult struct {
 	Kind          AttackKind
 	Operation     string
+	Module        string
 	Source        string
 	PathToPayload string
 	Metadata      map[string]string
@@ -75,7 +76,7 @@ func getAttackDetected(ctx context.Context, res interceptorResult) *agent.Detect
 		Attack: aikido_types.AttackDetails{
 			Kind:      string(res.Kind),
 			Operation: res.Operation,
-			Module:    "Module",
+			Module:    res.Module,
 			Blocked:   config.IsBlockingEnabled(),
 			Source:    res.Source,
 			Path:      res.PathToPayload,
@@ -154,6 +155,7 @@ func storeDeferredAttack(ctx context.Context, res *interceptorResult) error {
 
 	deferredAttack := &request.DeferredAttack{
 		Operation:     res.Operation,
+		Module:        res.Module,
 		Kind:          string(res.Kind),
 		Source:        res.Source,
 		PathToPayload: res.PathToPayload,
@@ -180,6 +182,7 @@ func reportDeferredAttack(ctx context.Context) {
 
 	res := &interceptorResult{
 		Operation:     deferredAttack.Operation,
+		Module:        deferredAttack.Module,
 		Kind:          AttackKind(deferredAttack.Kind),
 		Source:        deferredAttack.Source,
 		PathToPayload: deferredAttack.PathToPayload,

--- a/vulnerabilities/attack_test.go
+++ b/vulnerabilities/attack_test.go
@@ -106,6 +106,7 @@ func TestGetAttackDetected(t *testing.T) {
 	result := interceptorResult{
 		Kind:          KindSQLInjection,
 		Operation:     "query",
+		Module:        "database/sql",
 		Source:        "body",
 		PathToPayload: ".name",
 		Payload:       "1 OR 1=1",
@@ -119,6 +120,7 @@ func TestGetAttackDetected(t *testing.T) {
 	assert.Equal(t, "POST", atk.Request.Method)
 	assert.Equal(t, string(KindSQLInjection), atk.Attack.Kind)
 	assert.Equal(t, "query", atk.Attack.Operation)
+	assert.Equal(t, "database/sql", atk.Attack.Module)
 
 	// Verify metadata is cloned
 	atk.Attack.Metadata["key"] = "modified"
@@ -170,6 +172,7 @@ func TestStoreDeferredAttack(t *testing.T) {
 		result := &interceptorResult{
 			Kind:          KindPathTraversal,
 			Operation:     "filepath.Join",
+			Module:        "path/filepath",
 			Source:        "query",
 			PathToPayload: ".path",
 			Payload:       "../etc/passwd",
@@ -189,6 +192,7 @@ func TestStoreDeferredAttack(t *testing.T) {
 		require.NotNil(t, deferredAttack)
 
 		assert.Equal(t, "filepath.Join", deferredAttack.Operation)
+		assert.Equal(t, "path/filepath", deferredAttack.Module)
 		assert.Equal(t, string(KindPathTraversal), deferredAttack.Kind)
 		assert.Equal(t, "../etc/passwd", deferredAttack.Payload)
 		assert.NotNil(t, deferredAttack.Error)
@@ -307,6 +311,7 @@ func TestReportDeferredAttack(t *testing.T) {
 		result := &interceptorResult{
 			Kind:          KindPathTraversal,
 			Operation:     "filepath.Join",
+			Module:        "path/filepath",
 			Source:        "query",
 			PathToPayload: ".path",
 			Payload:       "../etc/passwd",
@@ -320,6 +325,7 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		select {
 		case <-client.attackDetectedEventSent:
+			assert.Equal(t, "path/filepath", client.capturedAttack.Module)
 		case <-time.After(1 * time.Second):
 			t.Fatal("timeout waiting for first attack event")
 		}

--- a/vulnerabilities/scan.go
+++ b/vulnerabilities/scan.go
@@ -23,6 +23,7 @@ type Vulnerability[T any] struct {
 
 type ScanOptions struct {
 	DeferReporting bool
+	Module         string
 }
 
 func Scan[T any](ctx context.Context, operation string, vulnerability Vulnerability[T], args T) error {
@@ -118,6 +119,7 @@ func scanSource[T any](ctx context.Context, source string, sourceData any, opera
 		if results != nil && results.DetectedAttack {
 			attack := &interceptorResult{
 				Operation:     operation,
+				Module:        opts.Module,
 				Kind:          vulnerability.Kind,
 				Source:        source,
 				PathToPayload: path,

--- a/vulnerabilities/scan_test.go
+++ b/vulnerabilities/scan_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -421,6 +423,39 @@ func TestScanWithOptions_ForceProtectionOff(t *testing.T) {
 				assert.NoError(t, err, tt.description)
 			}
 		})
+	}
+}
+
+func TestScanWithOptions_ModuleIsPassedThrough(t *testing.T) {
+	ip := "127.0.0.1"
+	args := mockScanArgs{Value: "test"}
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+	defer config.SetBlocking(original)
+
+	originalClient := agent.GetCloudClient()
+	t.Cleanup(func() { agent.SetCloudClient(originalClient) })
+
+	client := &mockCloudClient{
+		attackDetectedEventSent: make(chan struct{}, 1),
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/test?q=attack", http.NoBody)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	_ = ScanWithOptions(ctx, "testOp", mockVulnerability, args, ScanOptions{Module: "my-module"})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "my-module", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
 	}
 }
 


### PR DESCRIPTION
Module had a hardcoded default value, now is set to the package name.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added module names to attack details and propagated them through scan/reporting paths


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97373175?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->