### PR TITLE
Block SQL queries that fail tokenization

### DIFF
--- a/docs/invalid-sql-queries.md
+++ b/docs/invalid-sql-queries.md
@@ -1,0 +1,8 @@
+# Blocking invalid SQL queries
+
+Zen blocks SQL queries that it can't tokenize when they contain user input. This prevents attackers from bypassing SQL injection detection with malformed queries. For example, ClickHouse ignores invalid SQL after `;`, and SQLite runs queries before an unclosed `/*` comment.
+
+This is on by default. In blocking mode, these queries are blocked. In detection-only mode, they are reported but still executed.
+
+If you see false positives (legitimate queries being blocked), set the
+`AIKIDO_BLOCK_INVALID_SQL` environment variable to `false`.

--- a/vulnerabilities/sqlinjection/detect_sql_injection.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection.go
@@ -7,17 +7,17 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/zeninternals"
 )
 
-func detectSQLInjection(query string, userInput string, dialect int) bool {
+func detectSQLInjection(query string, userInput string, dialect int) int {
 	// Lowercase versions of query and user input
 	queryLowercase := strings.ToLower(query)
 	userInputLowercase := strings.ToLower(userInput)
 
 	if shouldReturnEarly(queryLowercase, userInputLowercase) {
-		return false
+		return 0
 	}
 
 	// Executing our final check with zen_internals
-	return zeninternals.DetectSQLInjection(queryLowercase, userInputLowercase, dialect) == 1
+	return zeninternals.DetectSQLInjection(queryLowercase, userInputLowercase, dialect)
 }
 
 var isAlphanumeric = regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString

--- a/vulnerabilities/sqlinjection/detect_sql_injection.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection.go
@@ -7,13 +7,20 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/zeninternals"
 )
 
+const (
+	sqlInjectionSafe             = 0
+	sqlInjectionDetected         = 1
+	sqlInjectionInternalError    = 2
+	sqlInjectionFailedToTokenize = 3
+)
+
 func detectSQLInjection(query string, userInput string, dialect int) int {
 	// Lowercase versions of query and user input
 	queryLowercase := strings.ToLower(query)
 	userInputLowercase := strings.ToLower(userInput)
 
 	if shouldReturnEarly(queryLowercase, userInputLowercase) {
-		return 0
+		return sqlInjectionSafe
 	}
 
 	return zeninternals.DetectSQLInjection(queryLowercase, userInputLowercase, dialect)

--- a/vulnerabilities/sqlinjection/detect_sql_injection.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection.go
@@ -16,7 +16,6 @@ func detectSQLInjection(query string, userInput string, dialect int) int {
 		return 0
 	}
 
-	// Executing our final check with zen_internals
 	return zeninternals.DetectSQLInjection(queryLowercase, userInputLowercase, dialect)
 }
 

--- a/vulnerabilities/sqlinjection/detect_sql_injection_test.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection_test.go
@@ -147,7 +147,7 @@ func TestFailedToTokenize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.Equal(t, 3, detectSQLInjection(tt.query, tt.input, 0), "Expected failed to tokenize")
+			assert.Equal(t, 3, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection because query is not valid SQL")
 		})
 	}
 }

--- a/vulnerabilities/sqlinjection/detect_sql_injection_test.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection_test.go
@@ -39,8 +39,6 @@ func TestIsNotSQLInjection(t *testing.T) {
 		{"SELECT * FROM hashtags WHERE name = '#hashtag'", "#hashtag"},
 
 		// It checks whether the string is safely escaped
-		{"SELECT * FROM comments WHERE comment = 'I'm writing you'", "I'm writing you"},
-		{"SELECT * FROM comments WHERE comment = \"I\"m writing you\"", "I\"m writing you"},
 		{"SELECT * FROM comments WHERE comment = \"I'm writing you\"", "I'm writing you"},
 		{"SELECT * FROM comments WHERE comment = 'I\"m writing you'", "I\"m writing you"},
 		{"SELECT * FROM comments WHERE comment = \"I`m writing you\"", "I`m writing you"},
@@ -75,7 +73,7 @@ func TestIsNotSQLInjection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.False(t, detectSQLInjection(tt.query, tt.input, 0), "Expected no SQL injection")
+			assert.Equal(t, 0, detectSQLInjection(tt.query, tt.input, 0), "Expected no SQL injection")
 		})
 	}
 }
@@ -131,7 +129,25 @@ func TestIsSQLInjection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.True(t, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection detected")
+			assert.Equal(t, 1, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection detected")
+		})
+	}
+}
+
+func TestFailedToTokenize(t *testing.T) {
+	require.NoError(t, internal.Init())
+
+	tests := []struct {
+		query string
+		input string
+	}{
+		{"SELECT * FROM comments WHERE comment = 'I'm writing you'", "I'm writing you"},
+		{"SELECT * FROM comments WHERE comment = \"I\"m writing you\"", "I\"m writing you"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			assert.Equal(t, 3, detectSQLInjection(tt.query, tt.input, 0), "Expected failed to tokenize")
 		})
 	}
 }

--- a/vulnerabilities/sqlinjection/detect_sql_injection_test.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection_test.go
@@ -73,7 +73,7 @@ func TestIsNotSQLInjection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.Equal(t, 0, detectSQLInjection(tt.query, tt.input, 0), "Expected no SQL injection")
+			assert.Equal(t, sqlInjectionSafe, detectSQLInjection(tt.query, tt.input, 0), "Expected no SQL injection")
 		})
 	}
 }
@@ -129,7 +129,7 @@ func TestIsSQLInjection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.Equal(t, 1, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection detected")
+			assert.Equal(t, sqlInjectionDetected, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection detected")
 		})
 	}
 }
@@ -147,7 +147,7 @@ func TestFailedToTokenize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			assert.Equal(t, 3, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection because query is not valid SQL")
+			assert.Equal(t, sqlInjectionFailedToTokenize, detectSQLInjection(tt.query, tt.input, 0), "Expected SQL injection because query is not valid SQL")
 		})
 	}
 }

--- a/vulnerabilities/sqlinjection/vulnerability.go
+++ b/vulnerabilities/sqlinjection/vulnerability.go
@@ -39,7 +39,7 @@ func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult
 
 	result := detectSQLInjection(statement, userInput, dialect)
 
-	if result == 1 {
+	if result == sqlInjectionDetected {
 		return &vulnerabilities.ScanResult{
 			DetectedAttack: true,
 			Metadata: map[string]string{
@@ -49,7 +49,7 @@ func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult
 		}, nil
 	}
 
-	if result == 3 && shouldBlockInvalidSqlQueries() {
+	if result == sqlInjectionFailedToTokenize && shouldBlockInvalidSqlQueries() {
 		return &vulnerabilities.ScanResult{
 			DetectedAttack: true,
 			Metadata: map[string]string{

--- a/vulnerabilities/sqlinjection/vulnerability.go
+++ b/vulnerabilities/sqlinjection/vulnerability.go
@@ -2,6 +2,8 @@ package sqlinjection
 
 import (
 	"errors"
+	"os"
+	"strings"
 
 	"github.com/AikidoSec/firewall-go/internal/zeninternals"
 	"github.com/AikidoSec/firewall-go/vulnerabilities"
@@ -18,6 +20,15 @@ type ScanArgs struct {
 	Dialect   string
 }
 
+func shouldBlockInvalidSqlQueries() bool {
+	v := os.Getenv("AIKIDO_BLOCK_INVALID_SQL")
+	if v == "" {
+		return true
+	}
+	v = strings.ToLower(v)
+	return v == "true" || v == "1"
+}
+
 func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult, error) {
 	if args == nil {
 		return nil, errors.New("args cannot be nil")
@@ -26,12 +37,25 @@ func scanFunction(userInput string, args *ScanArgs) (*vulnerabilities.ScanResult
 	statement := args.Statement
 	dialect := zeninternals.GetSQLDialectFromString(args.Dialect)
 
-	if detectSQLInjection(statement, userInput, dialect) {
+	result := detectSQLInjection(statement, userInput, dialect)
+
+	if result == 1 {
 		return &vulnerabilities.ScanResult{
 			DetectedAttack: true,
 			Metadata: map[string]string{
 				"sql":     statement,
 				"dialect": args.Dialect,
+			},
+		}, nil
+	}
+
+	if result == 3 && shouldBlockInvalidSqlQueries() {
+		return &vulnerabilities.ScanResult{
+			DetectedAttack: true,
+			Metadata: map[string]string{
+				"sql":              statement,
+				"dialect":          args.Dialect,
+				"failedToTokenize": "true",
 			},
 		}, nil
 	}


### PR DESCRIPTION
Our SQL injection detection tokenizes queries to check them. If the tokenizer can't parse a query, we skip it and the query goes through. Some databases still execute partially valid queries though: ClickHouse ignores junk after ; and SQLite runs everything before an unclosed /*.

Now when user input shows up in a query we can't tokenize, we treat it as an attack. On by default, opt out with AIKIDO_BLOCK_INVALID_SQL=false.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Blocked queries that failed tokenization by default, opt-out enabled

**🔧 Refactors**
* Replaced boolean detector with integer status codes and constants
* Updated scanFunction to handle detector result codes and imports


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97404896?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->