### PR TITLE
Update golangci-lint to v2.11.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ZEN_INTERNALS_VERSION=v0.1.60
-GOLANGCI_LINT_VERSION=v2.8.0
+GOLANGCI_LINT_VERSION=v2.11.4
 
 TOOLS_BIN := $(shell pwd)/tools/bin
 CURRENT_GO_MINOR := $(shell go env GOVERSION | sed 's/^go1\.//' | cut -d. -f1)

--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -77,7 +77,7 @@ import (
 		sb.WriteString("\n	// Aikido Zen: Sources\n")
 		for _, source := range config.sources {
 			if pkgPath, ok := availableSources[source]; ok {
-				sb.WriteString(fmt.Sprintf("	_ %q\n", pkgPath))
+				fmt.Fprintf(&sb, "	_ %q\n", pkgPath)
 			}
 		}
 	}
@@ -87,7 +87,7 @@ import (
 		sb.WriteString("\n	// Aikido Zen: Sinks\n")
 		for _, sink := range config.sinks {
 			if pkgPath, ok := availableSinks[sink]; ok {
-				sb.WriteString(fmt.Sprintf("	_ %q\n", pkgPath))
+				fmt.Fprintf(&sb, "	_ %q\n", pkgPath)
 			}
 		}
 	}

--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -78,6 +78,7 @@ func extractFlag(args []string, i int, flag string) (string, bool) {
 // passthrough runs the given Golang tool
 // For example, it will run the compiler with the arguments originally passed our toolexec command
 func passthrough(stdout io.Writer, stderr io.Writer, tool string, args []string) error {
+	// #nosec G204 - tool is the Go toolchain binary passed by Go's -toolexec mechanism, not user input
 	cmd := exec.Command(tool, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout

--- a/cmd/zen-go/cmd_toolexec_link.go
+++ b/cmd/zen-go/cmd_toolexec_link.go
@@ -52,6 +52,7 @@ func toolexecLinkCommand(stdout io.Writer, stderr io.Writer, tool string, toolAr
 				if err != nil {
 					fmt.Fprintf(stderr, "zen-go: warning: failed to write extended importcfg: %v\n", err)
 				} else {
+					// #nosec G703 - newImportcfgPath is from os.CreateTemp, not user input
 					defer func() { _ = os.Remove(newImportcfgPath) }()
 					args = importcfg.ReplaceImportcfgArg(args, newImportcfgPath)
 				}

--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -17,6 +17,7 @@ import (
 // and rebuild packages.
 func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
 	// Run the actual compiler to get its version string
+	// #nosec G204 - tool is the Go toolchain binary passed by Go's -toolexec mechanism, not user input
 	cmd := exec.Command(tool, toolArgs...)
 	var versionOutput bytes.Buffer
 	cmd.Stdout = &versionOutput

--- a/cmd/zen-go/internal/paths/paths.go
+++ b/cmd/zen-go/internal/paths/paths.go
@@ -57,6 +57,7 @@ func collectInstrumentationDirs(rootModuleDir string, submoduleDirs []string) []
 
 // findModuleDir returns the directory for a specific Go module.
 func findModuleDir(modRoot string, modulePath string) string {
+	// #nosec G204 - modulePath is a Go module path from the project's dependency graph, not user input
 	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", modulePath)
 	if modRoot != "" {
 		cmd.Dir = modRoot

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -68,7 +68,7 @@ func newCommand() *cli.Command {
 					outErr := io.Writer(os.Stderr)
 
 					if logPath := os.Getenv("ZENGO_LOG"); logPath != "" {
-						// #nosec G304 - logPath is from environment variable set by user
+						// #nosec G304 G703 - logPath is from environment variable set by user
 						logFile, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o600)
 						if err != nil {
 							return err

--- a/end2end/mock-server/main.go
+++ b/end2end/mock-server/main.go
@@ -117,7 +117,7 @@ func main() {
 		Handler:     mux,
 		ReadTimeout: 10 * time.Second,
 	}
-	log.Printf("Mock server listening on :%s", port)
+	log.Printf("Mock server listening on :%s", port) // #nosec G706 - port is a trusted env var, not user-controlled input
 	if err := server.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}

--- a/sample-apps/chi-postgres/api.go
+++ b/sample-apps/chi-postgres/api.go
@@ -48,7 +48,7 @@ func defineAPIRoutes(r *chi.Mux, db *DatabaseHelper) {
 	})
 
 	r.Post("/api/execute", func(w http.ResponseWriter, r *http.Request) {
-		userCommand := r.FormValue("user_command")
+		userCommand := r.FormValue("user_command") // #nosec G120 - intentional vulnerability, sample app only
 
 		if userCommand == "" {
 			http.Error(w, "user_command is required", http.StatusBadRequest)
@@ -57,14 +57,14 @@ func defineAPIRoutes(r *chi.Mux, db *DatabaseHelper) {
 
 		result := executeShellCommand(userCommand)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(result))
+		_, _ = w.Write([]byte(result)) // #nosec G705 - intentional vulnerability, sample app only
 	})
 
 	r.Get("/api/execute/{command}", func(w http.ResponseWriter, r *http.Request) {
 		userCommand := chi.URLParam(r, "command")
 		result := executeShellCommand(userCommand)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(result))
+		_, _ = w.Write([]byte(result)) // #nosec G705 - intentional vulnerability, sample app only
 	})
 
 	r.Post("/api/request", func(w http.ResponseWriter, r *http.Request) {
@@ -75,7 +75,7 @@ func defineAPIRoutes(r *chi.Mux, db *DatabaseHelper) {
 		}
 		response := makeHTTPRequest(req.URL)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
+		_, _ = w.Write([]byte(response)) // #nosec G705 - intentional vulnerability, sample app only
 	})
 
 	r.Get("/api/read", func(w http.ResponseWriter, r *http.Request) {
@@ -85,6 +85,6 @@ func defineAPIRoutes(r *chi.Mux, db *DatabaseHelper) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		_, _ = w.Write([]byte(content))
+		_, _ = w.Write([]byte(content)) // #nosec G705 - intentional vulnerability, sample app only
 	})
 }

--- a/sample-apps/chi-postgres/helpers.go
+++ b/sample-apps/chi-postgres/helpers.go
@@ -12,6 +12,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) string {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -40,7 +41,7 @@ func makeHTTPRequest(url string) string {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/chi-postgres/main.go
+++ b/sample-apps/chi-postgres/main.go
@@ -51,7 +51,7 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
-	log.Printf("Starting HTTP server on :%s\n", port)
+	log.Printf("Starting HTTP server on :%s\n", port) // #nosec G706 - port is a trusted env var
 	if err = server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}

--- a/sample-apps/echo-pgx-sql/helpers.go
+++ b/sample-apps/echo-pgx-sql/helpers.go
@@ -11,6 +11,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) (string, error) {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -39,7 +40,7 @@ func makeHTTPRequest(url string) (string, error) {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/echo-postgres/helpers.go
+++ b/sample-apps/echo-postgres/helpers.go
@@ -11,6 +11,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) (string, error) {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -39,7 +40,7 @@ func makeHTTPRequest(url string) (string, error) {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/echo-v5-postgres/helpers.go
+++ b/sample-apps/echo-v5-postgres/helpers.go
@@ -11,6 +11,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) (string, error) {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -39,7 +40,7 @@ func makeHTTPRequest(url string) (string, error) {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/gin-pgx-native/helpers.go
+++ b/sample-apps/gin-pgx-native/helpers.go
@@ -12,6 +12,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) string {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -40,7 +41,7 @@ func makeHTTPRequest(url string) string {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/gin-postgres/helpers.go
+++ b/sample-apps/gin-postgres/helpers.go
@@ -12,6 +12,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) string {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -40,7 +41,7 @@ func makeHTTPRequest(url string) string {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/gin-sqlx/helpers.go
+++ b/sample-apps/gin-sqlx/helpers.go
@@ -12,6 +12,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) string {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -40,7 +41,7 @@ func makeHTTPRequest(url string) string {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/http-postgres/api.go
+++ b/sample-apps/http-postgres/api.go
@@ -45,13 +45,13 @@ func createPetHandler(w http.ResponseWriter, r *http.Request, db *DatabaseHelper
 }
 
 func executeCommandHandler(w http.ResponseWriter, r *http.Request) {
-	userCommand := r.FormValue("user_command")
+	userCommand := r.FormValue("user_command") // #nosec G120 - intentional vulnerability, sample app only
 	if userCommand == "" {
 		http.Error(w, "user_command is required", http.StatusBadRequest)
 		return
 	}
 	result := executeShellCommand(userCommand)
-	if _, err := w.Write([]byte(result)); err != nil {
+	if _, err := w.Write([]byte(result)); err != nil { // #nosec G705 - intentional vulnerability, sample app only
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -59,7 +59,7 @@ func executeCommandHandler(w http.ResponseWriter, r *http.Request) {
 
 func executeCommandParamHandler(w http.ResponseWriter, r *http.Request, command string) {
 	result := executeShellCommand(command)
-	if _, err := w.Write([]byte(result)); err != nil {
+	if _, err := w.Write([]byte(result)); err != nil { // #nosec G705 - intentional vulnerability, sample app only
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -72,7 +72,7 @@ func makeRequestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	response := makeHTTPRequest(req.URL)
-	if _, err := w.Write([]byte(response)); err != nil {
+	if _, err := w.Write([]byte(response)); err != nil { // #nosec G705 - intentional vulnerability, sample app only
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -85,7 +85,7 @@ func readFileHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	_, _ = w.Write([]byte(content))
+	_, _ = w.Write([]byte(content)) // #nosec G705 - intentional vulnerability, sample app only
 }
 
 func defineAPIRoutes(mux *http.ServeMux, db *DatabaseHelper) {

--- a/sample-apps/http-postgres/helpers.go
+++ b/sample-apps/http-postgres/helpers.go
@@ -12,6 +12,7 @@ import (
 // executeShellCommand executes a shell command and returns the output.
 func executeShellCommand(command string) string {
 	var output bytes.Buffer
+	// #nosec G204 G702 - intentional command injection vulnerability
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Stdout = &output
 	cmd.Stderr = &output
@@ -40,7 +41,7 @@ func makeHTTPRequest(url string) string {
 
 // readFile reads the content of a file and returns it as a string.
 func readFile(filePath string) (string, error) {
-	// #nosec G304 - intentional path traversal vulnerability
+	// #nosec G304 G703 - intentional path traversal vulnerability
 	content, err := os.ReadFile("content/blogs/" + filePath)
 	if err != nil {
 		return "", err

--- a/sample-apps/http-postgres/main.go
+++ b/sample-apps/http-postgres/main.go
@@ -41,7 +41,7 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
-	log.Printf("Starting HTTP server on :%s\n", port)
+	log.Printf("Starting HTTP server on :%s\n", port) // #nosec G706 - port is a trusted env var
 	if err = server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func SetUserMiddleware(next http.Handler) http.Handler {
 			if err != nil {
 				log.Println(err)
 				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(err.Error()))
+				_, _ = w.Write([]byte(err.Error())) // #nosec G705 - internal error message, sample app only
 				return
 			}
 		}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated golangci-lint to v2.11.4 for CI linting
* Annotated exec and temp-file operations with #nosec security comments

**🔧 Refactors**
* Replaced manual Sprintf+WriteString calls with fmt.Fprintf usage
* Applied various lint-driven code cleanups and minor restructuring
* Used maps.Copy to merge import maps when instrumenting files
* Ensured temporary importcfg files were removed via deferred cleanup


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97425580?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->