### PR TITLE
Keep all cookie values for scanning

### DIFF
--- a/internal/agent/apidiscovery/get_api_auth_type.go
+++ b/internal/agent/apidiscovery/get_api_auth_type.go
@@ -30,7 +30,7 @@ var commonAuthCookieNames = append([]string{
 
 // GetApiAuthType returns the authentication type of the API request.
 // Returns nil if the authentication type could not be determined.
-func GetApiAuthType(headers map[string][]string, cookies map[string]string) []*aikido_types.APIAuthType {
+func GetApiAuthType(headers map[string][]string, cookies map[string][]string) []*aikido_types.APIAuthType {
 	var result []*aikido_types.APIAuthType
 
 	// Check the Authorization header
@@ -79,7 +79,7 @@ func getPhpHttpHeaderEquivalent(apiKey string) string {
 }
 
 // findAPIKeys searches for API keys in headers and cookies.
-func findAPIKeys(headers map[string][]string, cookies map[string]string) []*aikido_types.APIAuthType {
+func findAPIKeys(headers map[string][]string, cookies map[string][]string) []*aikido_types.APIAuthType {
 	var result []*aikido_types.APIAuthType
 
 	for headerIndex, header := range commonApiKeyHeaderNames {

--- a/internal/agent/apidiscovery/get_api_auth_type_test.go
+++ b/internal/agent/apidiscovery/get_api_auth_type_test.go
@@ -12,7 +12,7 @@ func TestDetectAuthorizationHeader(t *testing.T) {
 	headers := map[string][]string{
 		"authorization": {"Bearer token"},
 	}
-	cookies := map[string]string{}
+	cookies := map[string][]string{}
 	assert.Equal(t, []*aikido_types.APIAuthType{
 		{Type: "http", Scheme: "bearer"},
 	}, GetApiAuthType(headers, cookies))
@@ -37,7 +37,7 @@ func TestDetectApiKeys(t *testing.T) {
 	headers := map[string][]string{
 		"x_api_key": {"token"},
 	}
-	cookies := map[string]string{}
+	cookies := map[string][]string{}
 	assert.Equal(t, []*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("header"), Name: ("x-api-key")},
 	}, GetApiAuthType(headers, cookies))
@@ -53,16 +53,16 @@ func TestDetectApiKeys(t *testing.T) {
 // Test for detecting auth cookies
 func TestDetectAuthCookies(t *testing.T) {
 	headers := map[string][]string{}
-	cookies := map[string]string{
-		"api-key": "token",
+	cookies := map[string][]string{
+		"api-key": {"token"},
 	}
 
 	assert.Equal(t, []*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("cookie"), Name: ("api-key")},
 	}, GetApiAuthType(headers, cookies))
 
-	cookies = map[string]string{
-		"session": "test",
+	cookies = map[string][]string{
+		"session": {"test"},
 	}
 	assert.Equal(t, []*aikido_types.APIAuthType{
 		{Type: "apiKey", In: ("cookie"), Name: ("session")},
@@ -72,7 +72,7 @@ func TestDetectAuthCookies(t *testing.T) {
 // Test for no authentication
 func TestNoAuth(t *testing.T) {
 	headers := map[string][]string{}
-	cookies := map[string]string{}
+	cookies := map[string][]string{}
 
 	assert.Empty(t, GetApiAuthType(headers, cookies))
 

--- a/internal/agent/apidiscovery/get_api_info_test.go
+++ b/internal/agent/apidiscovery/get_api_info_test.go
@@ -104,7 +104,7 @@ func TestGetAPIInfo(t *testing.T) {
 
 		ctx := &request.Context{
 			Headers: map[string][]string{},
-			Cookies: map[string]string{"session": "abc123"},
+			Cookies: map[string][]string{"session": {"abc123"}},
 		}
 
 		result := GetAPIInfo(ctx)

--- a/internal/request/context.go
+++ b/internal/request/context.go
@@ -20,7 +20,7 @@ type Context struct {
 	RouteParams        map[string]string
 	RemoteAddress      *string
 	Body               any
-	Cookies            map[string]string
+	Cookies            map[string][]string
 	Source             string
 	Route              string
 	executedMiddleware bool

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -114,10 +114,10 @@ func headersToMap(headers http.Header) map[string][]string {
 	return headerInfo
 }
 
-func cookiesToMap(cookies []*http.Cookie) map[string]string {
-	cookieInfo := make(map[string]string)
+func cookiesToMap(cookies []*http.Cookie) map[string][]string {
+	cookieInfo := make(map[string][]string)
 	for _, cookie := range cookies {
-		cookieInfo[cookie.Name] = cookie.Value
+		cookieInfo[cookie.Name] = append(cookieInfo[cookie.Name], cookie.Value)
 	}
 	return cookieInfo
 }

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -129,6 +129,46 @@ func TestSetContext(t *testing.T) {
 	}
 }
 
+func TestCookiesToMap(t *testing.T) {
+	t.Run("single value per cookie name", func(t *testing.T) {
+		cookies := []*http.Cookie{
+			{Name: "session", Value: "abc"},
+			{Name: "token", Value: "xyz"},
+		}
+		result := cookiesToMap(cookies)
+		assert.Equal(t, map[string][]string{
+			"session": {"abc"},
+			"token":   {"xyz"},
+		}, result)
+	})
+
+	t.Run("multiple values for same cookie name are all kept", func(t *testing.T) {
+		cookies := []*http.Cookie{
+			{Name: "session", Value: "first"},
+			{Name: "session", Value: "second"},
+		}
+		result := cookiesToMap(cookies)
+		assert.Equal(t, map[string][]string{
+			"session": {"first", "second"},
+		}, result)
+	})
+}
+
+func TestSetContext_DuplicateCookies(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/", http.NoBody)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	// Manually set the Cookie header to include two values for the same name,
+	// since http.Request.AddCookie does not support duplicates via the API.
+	req.Header.Set("Cookie", "session=first; session=second")
+
+	resultCtx := SetContext(context.Background(), req, ContextData{Source: "test"})
+	reqCtx := GetContext(resultCtx)
+
+	assert.Equal(t, []string{"first", "second"}, reqCtx.Cookies["session"])
+}
+
 func TestSetContext_BypassedIP(t *testing.T) {
 	block := true
 	config.UpdateServiceConfig(&aikido_types.CloudConfigData{


### PR DESCRIPTION
Ensures all values are scanned instead of only the last value.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed Context.Cookies type to map[string][]string to retain values
* Updated cookiesToMap to append multiple cookie values instead of overwriting
* Adjusted API auth detection signatures and logic for cookie value slices


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98634877?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->