### PR TITLE
Default AIKIDO_BLOCK_INVALID_SQL to off

### DIFF
--- a/docs/invalid-sql-queries.md
+++ b/docs/invalid-sql-queries.md
@@ -2,7 +2,10 @@
 
 Zen blocks SQL queries that it can't tokenize when they contain user input. This prevents attackers from bypassing SQL injection detection with malformed queries. For example, ClickHouse ignores invalid SQL after `;`, and SQLite runs queries before an unclosed `/*` comment.
 
-This is on by default. In blocking mode, these queries are blocked. In detection-only mode, they are reported but still executed.
+This is off by default. To enable it, set the environment variable:
 
-If you see false positives (legitimate queries being blocked), set the
-`AIKIDO_BLOCK_INVALID_SQL` environment variable to `false`.
+```
+AIKIDO_BLOCK_INVALID_SQL=true ./app
+```
+
+In blocking mode, these queries are blocked. In detection-only mode, they are reported but still executed.

--- a/vulnerabilities/sqlinjection/vulnerability.go
+++ b/vulnerabilities/sqlinjection/vulnerability.go
@@ -21,11 +21,7 @@ type ScanArgs struct {
 }
 
 func shouldBlockInvalidSqlQueries() bool {
-	v := os.Getenv("AIKIDO_BLOCK_INVALID_SQL")
-	if v == "" {
-		return true
-	}
-	v = strings.ToLower(v)
+	v := strings.ToLower(os.Getenv("AIKIDO_BLOCK_INVALID_SQL"))
 	return v == "true" || v == "1"
 }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Defaulted AIKIDO_BLOCK_INVALID_SQL environment flag to disabled when unset


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99110824?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->