### PR TITLE
Extend shell command list

### DIFF
--- a/vulnerabilities/shellinjection/contains_shell_syntax.go
+++ b/vulnerabilities/shellinjection/contains_shell_syntax.go
@@ -86,6 +86,19 @@ var commands = []string{
 	"passwd",
 	"arch",
 	"printenv",
+	"logname",
+	"pstree",
+	"hostnamectl",
+	"set",
+	"lsattr",
+	"killall5",
+	"dmesg",
+	"history",
+	"free",
+	"uptime",
+	"finger",
+	"top",
+	"shopt",
 
 	// Colon is a null command
 	// it might occur in URLs that are passed as arguments to a binary


### PR DESCRIPTION
Now matching the list in [`firewall-node`](https://github.com/AikidoSec/firewall-node/blob/e2adc5a0c9e44a36d49af85f63ebc45062fc7078/library/vulnerabilities/shell-injection/containsShellSyntax.ts#L34).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Extended list of shell commands to include additional common utilities


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99439218?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->