### PR TITLE
Add max depth for extract strings from user input

### DIFF
--- a/vulnerabilities/extract_strings_from_user_input.go
+++ b/vulnerabilities/extract_strings_from_user_input.go
@@ -31,9 +31,15 @@ func buildPathToPayload(pathToPayload []pathPart) string {
 	return path
 }
 
+const maxDepth = 1024
+
 // extractStringsFromUserInput recursively extracts strings from user input
 func extractStringsFromUserInput(obj interface{}, pathToPayload []pathPart) map[string]string {
 	results := make(map[string]string)
+
+	if len(pathToPayload) >= maxDepth {
+		return results
+	}
 
 	val := reflect.ValueOf(obj)
 	switch val.Kind() {

--- a/vulnerabilities/extract_strings_from_user_input_test.go
+++ b/vulnerabilities/extract_strings_from_user_input_test.go
@@ -3,6 +3,8 @@ package vulnerabilities
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractStringsFromUserInput(t *testing.T) {
@@ -287,5 +289,15 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf("Expected %v, got %v", expected, actual)
 		}
+	})
+
+	t.Run("it stops recursing at max depth", func(t *testing.T) {
+		path := make([]pathPart, maxDepth)
+		for i := range path {
+			path[i] = pathPart{Type: "object", Key: "k"}
+		}
+		obj := map[string]interface{}{"key": "value"}
+		actual := extractStringsFromUserInput(obj, path)
+		assert.Empty(t, actual)
 	})
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added maximum recursion depth guard to string extraction from user input


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99480243?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->