### PR TITLE
Fix HTTPS/h2 breakage by injecting DialContext in-place instead of cloning

### DIFF
--- a/instrumentation/sinks/net/http/instrumention_test.go
+++ b/instrumentation/sinks/net/http/instrumention_test.go
@@ -3,11 +3,13 @@
 package http_test
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,4 +104,99 @@ func TestHTTPClientInstrumentation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "ok", string(body))
 	})
+}
+
+// Regression test for https://github.com/AikidoSec/firewall-go/issues/400
+//
+// WrapTransport used to call t.Clone() before injecting the SSRF DialContext.
+// Calling Clone() on a transport that has already negotiated h2 shares the
+// underlying http2Transport (and its connection pool) between the original and
+// the clone. Any subsequent h2 POST to a different authority through that clone
+// would fail with EOF.
+//
+// The fix injects DialContext directly onto the original transport instead.
+// Note: this test does not reproduce the EOF locally (httptest loopback doesn't
+// trigger it), but documents the scenario and guards against the pattern returning.
+func TestHTTPClientInstrumentation_H2ReverseProxy(t *testing.T) {
+	require.NoError(t, zen.Protect())
+	require.True(t, zen.ShouldProtect(), "protection must be active — test is meaningless without instrumentation wrapping transports")
+
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // test-only: trusting local httptest cert
+	}
+
+	// upstream1 is hit first to prime the wrapped transport's h2 connection
+	// pool before the "user" request arrives.
+	upstream1 := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream1-ok"))
+	}))
+	upstream1.EnableHTTP2 = true
+	upstream1.StartTLS()
+	defer upstream1.Close()
+
+	// upstream2 is the target of the user's outbound request.
+	var upstream2Proto string
+	upstream2 := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstream2Proto = r.Proto
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream2-ok"))
+	}))
+	upstream2.EnableHTTP2 = true
+	upstream2.StartTLS()
+	defer upstream2.Close()
+
+	// outboundClient uses a shared transport across both upstreams. The
+	// instrumentation will inject SSRF DialContext in-place on first use.
+	outboundClient := &http.Client{
+		Transport: &http.Transport{
+			ForceAttemptHTTP2: true,
+			TLSClientConfig:   tlsCfg,
+		},
+	}
+
+	// Prime the transport with an h2 connection to upstream1 before the user request arrives.
+	primeResp, err := outboundClient.Get(upstream1.URL + "/prime")
+	require.NoError(t, err, "priming request to upstream1 must succeed")
+	primeResp.Body.Close()
+	t.Logf("prime request done, upstream1 URL: %s", upstream1.URL)
+
+	// Now simulate the user's reverse-proxy handler making an outbound h2 POST
+	// to a different upstream (upstream2) through the same transport.
+	var outboundErr string
+	inbound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstream2.URL+"/v1/chat/completions", strings.NewReader("{}"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := outboundClient.Do(req)
+		if err != nil {
+			outboundErr = err.Error()
+			t.Logf("outbound error: %v", err)
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}))
+	defer inbound.Close()
+
+	resp, err := http.Post(inbound.URL, "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	t.Logf("upstream2 negotiated protocol: %q", upstream2Proto)
+	t.Logf("outbound error (empty = none): %q", outboundErr)
+	t.Logf("proxy status: %d, body: %q", resp.StatusCode, string(body))
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "proxy should not return 502 (EOF from wrapped h2 transport)")
+	assert.Equal(t, "upstream2-ok", string(body))
+	assert.Equal(t, "HTTP/2.0", upstream2Proto, "outbound request to upstream2 should use HTTP/2")
 }

--- a/instrumentation/sinks/net/http/instrumention_test.go
+++ b/instrumentation/sinks/net/http/instrumention_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -109,14 +110,13 @@ func TestHTTPClientInstrumentation(t *testing.T) {
 // Regression test for https://github.com/AikidoSec/firewall-go/issues/400
 //
 // WrapTransport used to call t.Clone() before injecting the SSRF DialContext.
-// Calling Clone() on a transport that has already negotiated h2 shares the
-// underlying http2Transport (and its connection pool) between the original and
-// the clone. Any subsequent h2 POST to a different authority through that clone
-// would fail with EOF.
+// Cloning a transport that has already negotiated h2 shares the underlying
+// http2Transport (and its connection pool) between the original and the clone,
+// so a subsequent h2 POST to a different authority through the clone would fail with EOF.
 //
 // The fix injects DialContext directly onto the original transport instead.
-// Note: this test does not reproduce the EOF locally (httptest loopback doesn't
-// trigger it), but documents the scenario and guards against the pattern returning.
+// Note: this doesn't reproduce the EOF locally (httptest loopback doesn't trigger it),
+// but it documents the scenario and guards against the pattern coming back.
 func TestHTTPClientInstrumentation_H2ReverseProxy(t *testing.T) {
 	require.NoError(t, zen.Protect())
 	require.True(t, zen.ShouldProtect(), "protection must be active — test is meaningless without instrumentation wrapping transports")
@@ -199,4 +199,56 @@ func TestHTTPClientInstrumentation_H2ReverseProxy(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "proxy should not return 502 (EOF from wrapped h2 transport)")
 	assert.Equal(t, "upstream2-ok", string(body))
 	assert.Equal(t, "HTTP/2.0", upstream2Proto, "outbound request to upstream2 should use HTTP/2")
+}
+
+// Reproduces https://github.com/AikidoSec/firewall-go/issues/400 against a real
+// external h2 server. Three conditions are needed to trigger the bug:
+//  1. No TLSClientConfig on the transport - setting one disables onceSetNextProtoDefaults,
+//     which installs the h2 handler, silently falling back to HTTP/1.1 and masking the bug.
+//  2. net/http's built-in ALPN h2 auto-upgrade (onceSetNextProtoDefaults), not
+//     golang.org/x/net/http2.ConfigureTransport.
+//  3. A real external h2 server - loopback httptest servers don't trigger it.
+//
+// Without the fix, WrapTransport clones the transport before the h2 handler is
+// installed, so the clone falls back to HTTP/1.1 on an h2-only connection and
+// the server's SETTINGS frame is parsed as a malformed HTTP/1.1 response.
+//
+// Run with: EXTERNAL_TESTS=1 make test-instrumentation-integration
+func TestHTTPClientInstrumentation_H2External(t *testing.T) {
+	if os.Getenv("EXTERNAL_TESTS") == "" {
+		t.Skip("skipping: set EXTERNAL_TESTS=1 to run against a real external h2 server")
+	}
+
+	require.NoError(t, zen.Protect())
+	require.True(t, zen.ShouldProtect(), "protection must be active")
+
+	// Allowlist the external host so zen doesn't block the outbound connection.
+	block := true
+	cloudConfig := &aikido_types.CloudConfigData{
+		ConfigUpdatedAt: time.Now().UnixMilli(),
+		Domains: []aikido_types.OutboundDomain{
+			{Hostname: "postman-echo.com", Mode: "allow"},
+		},
+		BlockNewOutgoingRequests: true,
+		Block:                    &block,
+	}
+	config.UpdateServiceConfig(cloudConfig, nil)
+
+	// No TLSClientConfig - required to reproduce the bug. See comment above.
+	client := &http.Client{
+		Transport: &http.Transport{},
+	}
+
+	body := strings.NewReader(`{"messages":[{"role":"user","content":"ping"}]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://postman-echo.com/post", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err, "POST to external h2 server failed")
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "HTTP/2.0", resp.Proto, "expected h2; HTTP/1.1 means TLSClientConfig masked the bug")
 }

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -110,10 +110,6 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 		return rt
 	}
 
-	if cached, ok := wrappedTransports.Load(t); ok {
-		return cached.(*ssrfTransport)
-	}
-
 	// Mutex prevents two goroutines from both reading t.DialContext before
 	// either has written the SSRF wrapper back, which would cause double-wrapping.
 	wrapMu.Lock()

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -127,11 +127,15 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	}
 	t.DialContext = ssrfDialContext(originalDialContext)
 
-	// Setting a non-nil DialContext causes Go to conservatively disable h2
-	// auto-upgrade (see Transport.ForceAttemptHTTP2 docs). If the transport
-	// didn't already have a custom DialContext, we're the ones breaking h2
-	// by injecting ours, so restore the default h2 behavior.
-	if !hadCustomDialContext && !t.ForceAttemptHTTP2 {
+	// Go disables h2 auto-upgrade when any of Dial, DialTLS, DialContext, or
+	// TLSClientConfig is set and ForceAttemptHTTP2 is false. We've just injected
+	// a DialContext, so if none of those other fields were set beforehand, we're
+	// the sole reason h2 would now be disabled, so restore the default behavior.
+	if !hadCustomDialContext &&
+		!t.ForceAttemptHTTP2 &&
+		t.TLSClientConfig == nil &&
+		t.Dial == nil &&
+		t.DialTLS == nil {
 		t.ForceAttemptHTTP2 = true
 	}
 

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -83,11 +83,18 @@ func portFromURL(u *url.URL) uint32 {
 	}
 }
 
-var wrappedTransports sync.Map // map[*http.Transport]*ssrfTransport
+var (
+	wrappedTransports sync.Map   // map[*http.Transport]*ssrfTransport
+	wrapMu            sync.Mutex // guards first-time DialContext injection per transport
+)
 
 // WrapTransport wraps an http.RoundTripper with SSRF DNS resolution checking.
 // Only *http.Transport is wrapped (DialContext is needed); other RoundTrippers
 // are returned as-is. Wrapped transports are cached per original transport pointer.
+//
+// Rather than cloning the transport (which can interfere with HTTP/2 connection
+// state), we inject the SSRF DialContext directly onto the original transport.
+// This preserves the transport's existing h2 configuration.
 func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	if !zen.ShouldProtect() {
 		return rt
@@ -107,15 +114,23 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 		return cached.(*ssrfTransport)
 	}
 
-	clone := t.Clone()
-	originalDialContext := clone.DialContext
+	// Mutex prevents two goroutines from both reading t.DialContext before
+	// either has written the SSRF wrapper back, which would cause double-wrapping.
+	wrapMu.Lock()
+	defer wrapMu.Unlock()
+
+	if cached, ok := wrappedTransports.Load(t); ok {
+		return cached.(*ssrfTransport)
+	}
+
+	originalDialContext := t.DialContext
 	if originalDialContext == nil {
 		var d net.Dialer
 		originalDialContext = d.DialContext
 	}
-	clone.DialContext = ssrfDialContext(originalDialContext)
+	t.DialContext = ssrfDialContext(originalDialContext)
 
-	wrapped := &ssrfTransport{inner: clone}
+	wrapped := &ssrfTransport{inner: t}
 	wrappedTransports.Store(t, wrapped)
 	return wrapped
 }

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -120,11 +120,20 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	}
 
 	originalDialContext := t.DialContext
+	hadCustomDialContext := originalDialContext != nil
 	if originalDialContext == nil {
 		var d net.Dialer
 		originalDialContext = d.DialContext
 	}
 	t.DialContext = ssrfDialContext(originalDialContext)
+
+	// Setting a non-nil DialContext causes Go to conservatively disable h2
+	// auto-upgrade (see Transport.ForceAttemptHTTP2 docs). If the transport
+	// didn't already have a custom DialContext, we're the ones breaking h2
+	// by injecting ours, so restore the default h2 behavior.
+	if !hadCustomDialContext && !t.ForceAttemptHTTP2 {
+		t.ForceAttemptHTTP2 = true
+	}
 
 	wrapped := &ssrfTransport{inner: t}
 	wrappedTransports.Store(t, wrapped)

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -134,8 +134,8 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	if !hadCustomDialContext &&
 		!t.ForceAttemptHTTP2 &&
 		t.TLSClientConfig == nil &&
-		t.Dial == nil &&
-		t.DialTLS == nil {
+		t.Dial == nil && //nolint:staticcheck // intentionally checking deprecated field to preserve user intent
+		t.DialTLS == nil { //nolint:staticcheck // intentionally checking deprecated field to preserve user intent
 		t.ForceAttemptHTTP2 = true
 	}
 

--- a/instrumentation/sinks/net/http/wrap_transport_test.go
+++ b/instrumentation/sinks/net/http/wrap_transport_test.go
@@ -4,6 +4,7 @@ package http
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -108,6 +109,27 @@ func TestWrapTransport_PreservesForceAttemptHTTP2_WhenDialContextWasSet(t *testi
 	assert.False(t, tr.ForceAttemptHTTP2)
 	WrapTransport(tr)
 	assert.False(t, tr.ForceAttemptHTTP2, "should not set ForceAttemptHTTP2 when transport already had a custom DialContext")
+}
+
+func TestWrapTransport_PreservesForceAttemptHTTP2_WhenTLSClientConfigWasSet(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	wrappedTransports.Range(func(key, value any) bool {
+		wrappedTransports.Delete(key)
+		return true
+	})
+
+	tr := &http.Transport{TLSClientConfig: &tls.Config{}}
+	assert.False(t, tr.ForceAttemptHTTP2)
+	WrapTransport(tr)
+	assert.False(t, tr.ForceAttemptHTTP2, "should not set ForceAttemptHTTP2 when transport already had a TLSClientConfig")
 }
 
 func TestWrapTransport_DoesNotDoubleWrap(t *testing.T) {

--- a/instrumentation/sinks/net/http/wrap_transport_test.go
+++ b/instrumentation/sinks/net/http/wrap_transport_test.go
@@ -4,6 +4,7 @@ package http
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -64,6 +65,49 @@ func TestWrapTransport_CachesWrappedTransport(t *testing.T) {
 	wrapped, ok := result1.(*ssrfTransport)
 	assert.True(t, ok, "should return an *ssrfTransport")
 	assert.Same(t, tr, wrapped.inner, "inner transport should be the original, not a clone")
+}
+
+func TestWrapTransport_SetsForceAttemptHTTP2_WhenDialContextWasNil(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	wrappedTransports.Range(func(key, value any) bool {
+		wrappedTransports.Delete(key)
+		return true
+	})
+
+	tr := &http.Transport{}
+	assert.False(t, tr.ForceAttemptHTTP2)
+	WrapTransport(tr)
+	assert.True(t, tr.ForceAttemptHTTP2, "should set ForceAttemptHTTP2 when we inject DialContext onto a transport that had none")
+}
+
+func TestWrapTransport_PreservesForceAttemptHTTP2_WhenDialContextWasSet(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	wrappedTransports.Range(func(key, value any) bool {
+		wrappedTransports.Delete(key)
+		return true
+	})
+
+	var d net.Dialer
+	tr := &http.Transport{DialContext: d.DialContext}
+	assert.False(t, tr.ForceAttemptHTTP2)
+	WrapTransport(tr)
+	assert.False(t, tr.ForceAttemptHTTP2, "should not set ForceAttemptHTTP2 when transport already had a custom DialContext")
 }
 
 func TestWrapTransport_DoesNotDoubleWrap(t *testing.T) {

--- a/instrumentation/sinks/net/http/wrap_transport_test.go
+++ b/instrumentation/sinks/net/http/wrap_transport_test.go
@@ -63,7 +63,7 @@ func TestWrapTransport_CachesWrappedTransport(t *testing.T) {
 
 	wrapped, ok := result1.(*ssrfTransport)
 	assert.True(t, ok, "should return an *ssrfTransport")
-	assert.NotSame(t, tr, wrapped.inner, "inner transport should be a clone, not the original")
+	assert.Same(t, tr, wrapped.inner, "inner transport should be the original, not a clone")
 }
 
 func TestWrapTransport_DoesNotDoubleWrap(t *testing.T) {
@@ -154,7 +154,6 @@ func TestRecordRedirect(t *testing.T) {
 		assert.Equal(t, "example.com", redirects[0].DestHostname)
 		assert.Equal(t, uint32(443), redirects[0].DestPort)
 	})
-
 }
 
 func TestRoundTrip_PropagatesInnerError(t *testing.T) {


### PR DESCRIPTION
WrapTransport was calling t.Clone() before injecting the SSRF DialContext. Clone() can interfere with the transport's HTTP/2 state, causing EOF on outbound HTTPS requests to h2 servers (issue #400).

Instead, inject the SSRF DialContext directly onto the original transport. This preserves h2 configuration intact.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Injected SSRF DialContext directly onto original transport instead of cloning
* Restored ForceAttemptHTTP2 behavior when injecting DialContext to preserve h2

**🔧 Refactors**
* Added wrapMu mutex and adjusted wrappedTransports caching for concurrency safety


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103595326?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->