### PR TITLE
Add user exclusions to rate limiting

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -31,7 +31,7 @@ jobs:
           sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@[^ ]*|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@v1.0.11
+        uses: AikidoSec/firewall-tester-action@v1.0.12
         with:
           dockerfile_path: ./zen-demo-go/Dockerfile
           app_port: 3000

--- a/internal/agent/aikido_types/init_data.go
+++ b/internal/agent/aikido_types/init_data.go
@@ -45,17 +45,18 @@ type OutboundDomain struct {
 }
 
 type CloudConfigData struct {
-	Success                  bool             `json:"success"`
-	ServiceID                int              `json:"serviceId"`
-	ConfigUpdatedAt          int64            `json:"configUpdatedAt"`
-	HeartbeatIntervalInMS    int              `json:"heartbeatIntervalInMS"`
-	Endpoints                []Endpoint       `json:"endpoints"`
-	BlockedUserIds           []string         `json:"blockedUserIds"`
-	BypassedIPs              []string         `json:"allowedIPAddresses"`
-	ReceivedAnyStats         bool             `json:"receivedAnyStats"`
-	Block                    *bool            `json:"block,omitempty"`
-	BlockNewOutgoingRequests bool             `json:"blockNewOutgoingRequests"`
-	Domains                  []OutboundDomain `json:"domains"`
+	Success                         bool             `json:"success"`
+	ServiceID                       int              `json:"serviceId"`
+	ConfigUpdatedAt                 int64            `json:"configUpdatedAt"`
+	HeartbeatIntervalInMS           int              `json:"heartbeatIntervalInMS"`
+	Endpoints                       []Endpoint       `json:"endpoints"`
+	BlockedUserIds                  []string         `json:"blockedUserIds"`
+	ExcludedUserIdsFromRateLimiting []string         `json:"excludedUserIdsFromRateLimiting"`
+	BypassedIPs                     []string         `json:"allowedIPAddresses"`
+	ReceivedAnyStats                bool             `json:"receivedAnyStats"`
+	Block                           *bool            `json:"block,omitempty"`
+	BlockNewOutgoingRequests        bool             `json:"blockNewOutgoingRequests"`
+	Domains                         []OutboundDomain `json:"domains"`
 }
 
 func (c *CloudConfigData) UpdatedAt() time.Time {

--- a/internal/agent/config/service_config.go
+++ b/internal/agent/config/service_config.go
@@ -43,19 +43,20 @@ type UserAgentDetail struct {
 }
 
 type ServiceConfigData struct {
-	ConfigUpdatedAt          time.Time
-	Endpoints                []Endpoint
-	BlockedUserIDs           map[string]bool
-	BypassedIPs              ipaddr.MatchList
-	AllowedIPs               map[string]ipaddr.MatchList
-	BlockedIPs               map[string]ipaddr.MatchList
-	MonitoredIPs             map[string]ipaddr.MatchList
-	BlockedUserAgents        *regexp.Regexp
-	MonitoredUserAgents      *regexp.Regexp
-	UserAgentDetails         []UserAgentDetail
-	Block                    bool
-	BlockNewOutgoingRequests bool
-	Domains                  []aikido_types.OutboundDomain
+	ConfigUpdatedAt                 time.Time
+	Endpoints                       []Endpoint
+	BlockedUserIDs                  map[string]bool
+	ExcludedUserIDsFromRateLimiting map[string]bool
+	BypassedIPs                     ipaddr.MatchList
+	AllowedIPs                      map[string]ipaddr.MatchList
+	BlockedIPs                      map[string]ipaddr.MatchList
+	MonitoredIPs                    map[string]ipaddr.MatchList
+	BlockedUserAgents               *regexp.Regexp
+	MonitoredUserAgents             *regexp.Regexp
+	UserAgentDetails                []UserAgentDetail
+	Block                           bool
+	BlockNewOutgoingRequests        bool
+	Domains                         []aikido_types.OutboundDomain
 }
 
 func setServiceConfig(cloudConfigFromAgent *aikido_types.CloudConfigData, listsConfig *aikido_types.ListsConfigData) {
@@ -90,6 +91,11 @@ func setServiceConfig(cloudConfigFromAgent *aikido_types.CloudConfigData, listsC
 	serviceConfig.BlockedUserIDs = map[string]bool{}
 	for _, userID := range cloudConfigFromAgent.BlockedUserIds {
 		serviceConfig.BlockedUserIDs[userID] = true
+	}
+
+	serviceConfig.ExcludedUserIDsFromRateLimiting = map[string]bool{}
+	for _, userID := range cloudConfigFromAgent.ExcludedUserIdsFromRateLimiting {
+		serviceConfig.ExcludedUserIDsFromRateLimiting[userID] = true
 	}
 
 	serviceConfig.BypassedIPs = ipaddr.BuildMatchList("bypassedIPs", "bypassed", cloudConfigFromAgent.BypassedIPs)
@@ -309,6 +315,13 @@ func IsUserBlocked(userID string) bool {
 	defer serviceConfigMutex.RUnlock()
 
 	return keyExists(serviceConfig.BlockedUserIDs, userID)
+}
+
+func IsUserExcludedFromRateLimiting(userID string) bool {
+	serviceConfigMutex.RLock()
+	defer serviceConfigMutex.RUnlock()
+
+	return keyExists(serviceConfig.ExcludedUserIDsFromRateLimiting, userID)
 }
 
 func SetUserBlocked(userID string) {

--- a/internal/agent/config/service_config_test.go
+++ b/internal/agent/config/service_config_test.go
@@ -65,10 +65,11 @@ func TestUpdateServiceConfig(t *testing.T) {
 					AllowedIPAddresses: []string{"192.168.1.1"},
 				},
 			},
-			BlockedUserIds:   []string{"user1", "user2"},
-			BypassedIPs:      []string{"10.0.0.1"},
-			ReceivedAnyStats: true,
-			Block:            &blockTrue,
+			BlockedUserIds:                  []string{"user1", "user2"},
+			ExcludedUserIdsFromRateLimiting: []string{"excluded1", "excluded2"},
+			BypassedIPs:                     []string{"10.0.0.1"},
+			ReceivedAnyStats:                true,
+			Block:                           &blockTrue,
 		}
 
 		listsConfig := &aikido_types.ListsConfigData{
@@ -102,6 +103,11 @@ func TestUpdateServiceConfig(t *testing.T) {
 		assert.True(t, IsUserBlocked("user1"))
 		assert.True(t, IsUserBlocked("user2"))
 		assert.False(t, IsUserBlocked("user3"))
+
+		// Verify excluded users from rate limiting
+		assert.True(t, IsUserExcludedFromRateLimiting("excluded1"))
+		assert.True(t, IsUserExcludedFromRateLimiting("excluded2"))
+		assert.False(t, IsUserExcludedFromRateLimiting("excluded3"))
 
 		// Verify bypassed IPs
 		assert.True(t, IsIPBypassed("10.0.0.1"))

--- a/internal/agent/ratelimiting/rate_limiting.go
+++ b/internal/agent/ratelimiting/rate_limiting.go
@@ -105,6 +105,10 @@ func getOrCreateCounts(m map[entityKey]*slidingwindow.Window, key entityKey, win
 
 // ShouldRateLimitRequest checks if a request should be rate limited based on user or IP
 func (rl *RateLimiter) ShouldRateLimitRequest(method string, route string, user string, ip string, group string) *Status {
+	if user != "" && config.IsUserExcludedFromRateLimiting(user) {
+		return &Status{Block: false}
+	}
+
 	// Priority: group > user > ip
 	switch {
 	case group != "":

--- a/internal/agent/ratelimiting/rate_limiting_test.go
+++ b/internal/agent/ratelimiting/rate_limiting_test.go
@@ -5,10 +5,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 	"github.com/AikidoSec/firewall-go/internal/slidingwindow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func setupExcludedUsers(userIDs []string) {
+	blockFalse := false
+	globals.AikidoConfig = &aikido_types.AikidoConfigData{}
+	config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+		ExcludedUserIdsFromRateLimiting: userIDs,
+		Block:                           &blockFalse,
+	}, nil)
+}
 
 var fiveMinutesInMS = int(time.Duration(5 * time.Minute).Milliseconds())
 
@@ -159,6 +171,54 @@ func TestShouldRateLimitRequest(t *testing.T) {
 		status := rl.ShouldRateLimitRequest("GET", "/api/test", "user1", "192.168.1.1", "group1")
 		assert.True(t, status.Block)
 		assert.Equal(t, "group", status.Trigger)
+	})
+
+	t.Run("excluded user is not rate limited", func(t *testing.T) {
+		setupExcludedUsers([]string{"excluded-user"})
+		rl := New()
+		key := endpointKey{Method: "POST", Route: "/login"}
+		rl.rateLimitingMap[key] = &endpointData{
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
+			Counts: make(map[entityKey]*slidingwindow.Window),
+		}
+
+		for range 5 {
+			status := rl.ShouldRateLimitRequest("POST", "/login", "excluded-user", "192.168.1.1", "")
+			assert.False(t, status.Block)
+		}
+	})
+
+	t.Run("excluded user is not rate limited even in a group", func(t *testing.T) {
+		setupExcludedUsers([]string{"excluded-user"})
+		rl := New()
+		key := endpointKey{Method: "POST", Route: "/login"}
+		rl.rateLimitingMap[key] = &endpointData{
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
+			Counts: make(map[entityKey]*slidingwindow.Window),
+		}
+
+		for range 5 {
+			status := rl.ShouldRateLimitRequest("POST", "/login", "excluded-user", "192.168.1.1", "group1")
+			assert.False(t, status.Block)
+		}
+	})
+
+	t.Run("non-excluded user is still rate limited", func(t *testing.T) {
+		setupExcludedUsers([]string{"excluded-user"})
+		rl := New()
+		key := endpointKey{Method: "POST", Route: "/login"}
+		rl.rateLimitingMap[key] = &endpointData{
+			Config: rateLimitConfig{MaxRequests: 3, WindowSizeInMS: fiveMinutesInMS},
+			Counts: make(map[entityKey]*slidingwindow.Window),
+		}
+
+		rl.ShouldRateLimitRequest("POST", "/login", "normal-user", "192.168.1.1", "")
+		rl.ShouldRateLimitRequest("POST", "/login", "normal-user", "192.168.1.1", "")
+		rl.ShouldRateLimitRequest("POST", "/login", "normal-user", "192.168.1.1", "")
+
+		status := rl.ShouldRateLimitRequest("POST", "/login", "normal-user", "192.168.1.1", "")
+		assert.True(t, status.Block)
+		assert.Equal(t, "user", status.Trigger)
 	})
 }
 


### PR DESCRIPTION
Copying behaviour from `firewall-node`:
- https://github.com/AikidoSec/firewall-node/pull/996
- https://github.com/AikidoSec/firewall-node/pull/998

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added excluded user IDs to cloud and service config and parsing
* Rate limiter was modified to bypass checks for excluded users
* Updated QA tester action reference to v1.0.12 in workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103287570?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->