### PR TITLE
Add version drift check to zen-go CLI

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/importcfg"
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/instrumentor"
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
 func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
@@ -34,6 +35,10 @@ func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, too
 	}
 
 	if err := checkZenToolFileIncluded(pkgPath, toolArgs); err != nil {
+		return err
+	}
+
+	if err := checkVersionSync(toolArgs); err != nil {
 		return err
 	}
 
@@ -228,6 +233,26 @@ func checkZenToolFileIncluded(pkgPath string, toolArgs []string) error {
 	}
 
 	return nil
+}
+
+func checkVersionSync(toolArgs []string) error {
+	var sourceDir string
+	for _, arg := range toolArgs {
+		if strings.HasSuffix(arg, ".go") {
+			sourceDir = filepath.Dir(arg)
+			break
+		}
+	}
+	if sourceDir == "" {
+		return nil
+	}
+
+	gomodPath := rules.FindGoMod(sourceDir)
+	if gomodPath == "" {
+		return nil
+	}
+
+	return rules.CheckModuleVersionSync(gomodPath)
 }
 
 func writeTempFile(origPath string, content []byte, objdir string) (string, error) {

--- a/cmd/zen-go/go.mod
+++ b/cmd/zen-go/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/mod v0.32.0 // indirect
+	golang.org/x/mod v0.32.0
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/cmd/zen-go/internal/rules/modcheck.go
+++ b/cmd/zen-go/internal/rules/modcheck.go
@@ -1,0 +1,102 @@
+package rules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+const aikidoMainModule = "github.com/AikidoSec/firewall-go"
+
+// FindGoMod walks up from startDir looking for a go.mod file.
+// Returns the path if found, or empty string if not found.
+func FindGoMod(startDir string) string {
+	dir := startDir
+	for {
+		candidate := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// CheckModuleVersionSync parses the go.mod at gomodPath and returns an error if
+// any github.com/AikidoSec/firewall-go instrumentation submodule is at a different
+// version than the main github.com/AikidoSec/firewall-go module.
+//
+// Returns nil if the main module is not required (not a firewall-go project)
+// or if all versions are aligned.
+func CheckModuleVersionSync(gomodPath string) error {
+	// #nosec G304 - gomodPath is derived from the project source directory
+	data, err := os.ReadFile(gomodPath)
+	if err != nil {
+		return nil
+	}
+
+	f, err := modfile.Parse(gomodPath, data, func(_, version string) (string, error) {
+		return version, nil
+	})
+	if err != nil {
+		return nil
+	}
+
+	var mainVersion string
+	for _, req := range f.Require {
+		if req.Mod.Path == aikidoMainModule {
+			mainVersion = req.Mod.Version
+			break
+		}
+	}
+
+	if mainVersion == "" {
+		return nil
+	}
+
+	replaced := make(map[string]bool)
+	for _, r := range f.Replace {
+		replaced[r.Old.Path] = true
+	}
+
+	if replaced[aikidoMainModule] {
+		return nil
+	}
+
+	type mismatch struct{ path, version string }
+	var mismatches []mismatch
+
+	for _, req := range f.Require {
+		if strings.HasPrefix(req.Mod.Path, aikidoMainModule+"/") && !replaced[req.Mod.Path] && req.Mod.Version != mainVersion {
+			mismatches = append(mismatches, mismatch{req.Mod.Path, req.Mod.Version})
+		}
+	}
+
+	if len(mismatches) == 0 {
+		return nil
+	}
+
+	var fixes []string
+	for _, m := range mismatches {
+		fixes = append(fixes, m.path+"@"+mainVersion)
+	}
+
+	var details []string
+	for _, m := range mismatches {
+		details = append(details, fmt.Sprintf("  %s is at %s, expected %s", m.path, m.version, mainVersion))
+	}
+
+	return fmt.Errorf(
+		"zen-go: instrumentation package version mismatch (%s is at %s):\n%s\nrun: go get %s",
+		aikidoMainModule,
+		mainVersion,
+		strings.Join(details, "\n"),
+		strings.Join(fixes, " "),
+	)
+}

--- a/cmd/zen-go/internal/rules/modcheck_test.go
+++ b/cmd/zen-go/internal/rules/modcheck_test.go
@@ -1,0 +1,151 @@
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeGoMod(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "go.mod")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestCheckModuleVersionSync_Aligned(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sinks/pgx.v5 v1.2.0
+)
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
+func TestCheckModuleVersionSync_Mismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.1.1
+)
+`)
+	err := CheckModuleVersionSync(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version mismatch")
+	assert.Contains(t, err.Error(), "v1.2.0")
+	assert.Contains(t, err.Error(), "gin is at v1.1.1")
+	assert.Contains(t, err.Error(), "go get")
+	assert.Contains(t, err.Error(), "gin@v1.2.0")
+}
+
+func TestCheckModuleVersionSync_MultipleMismatches(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.1.1
+	github.com/AikidoSec/firewall-go/instrumentation/sinks/pgx.v5 v1.0.0
+)
+`)
+	err := CheckModuleVersionSync(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gin is at v1.1.1")
+	assert.Contains(t, err.Error(), "pgx.v5 is at v1.0.0")
+	assert.Contains(t, err.Error(), "gin@v1.2.0")
+	assert.Contains(t, err.Error(), "pgx.v5@v1.2.0")
+}
+
+func TestCheckModuleVersionSync_NoFirewallModule(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/gin-gonic/gin v1.9.0
+)
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
+func TestCheckModuleVersionSync_MainModuleOnly(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+)
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
+func TestCheckModuleVersionSync_UnreadableFile(t *testing.T) {
+	require.NoError(t, CheckModuleVersionSync("/nonexistent/go.mod"))
+}
+
+func TestCheckModuleVersionSync_ReplacedSubmodule(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin => ../../instrumentation/sources/gin-gonic/gin
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
+func TestCheckModuleVersionSync_ReplacedMainModule(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.0
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.1.1
+)
+
+replace github.com/AikidoSec/firewall-go => ../../
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
+func TestFindGoMod_Found(t *testing.T) {
+	root := t.TempDir()
+	gomodPath := filepath.Join(root, "go.mod")
+	require.NoError(t, os.WriteFile(gomodPath, []byte("module example.com/app\n"), 0o644))
+
+	subdir := filepath.Join(root, "pkg", "handlers")
+	require.NoError(t, os.MkdirAll(subdir, 0o755))
+
+	assert.Equal(t, gomodPath, FindGoMod(subdir))
+	assert.Equal(t, gomodPath, FindGoMod(root))
+}
+
+func TestFindGoMod_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	assert.Equal(t, "", FindGoMod(dir))
+}


### PR DESCRIPTION
This fails the build if it notices that the main firewall-go version doesn't match an instrumentation module.

This can happen if the user runs `go get -u github.com/AikidoSec/firewall-go@latest`, instead of `go get -u github.com/AikidoSec/firewall-go/...@latest`

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added version drift check to zen-go CLI using go.mod


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104963135?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->