### PR TITLE
Add warning when zen.tool.go does not exist in main package

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -33,7 +33,7 @@ func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, too
 		fmt.Fprintf(stderr, "zen-go: compiling package %s\n", pkgPath)
 	}
 
-	if err := checkZenToolFileIncluded(pkgPath, toolArgs); err != nil {
+	if err := checkZenToolFileIncluded(pkgPath, toolArgs, stderr); err != nil {
 		return err
 	}
 
@@ -196,7 +196,7 @@ func updateImportcfgInArgs(stderr io.Writer, args []string, importcfgPath string
 // without zen.tool.go. This happens when users run e.g. `go build main.go`
 // instead of `go build .`, which causes zen.tool.go to be excluded from the
 // build and results in cryptic compiler errors.
-func checkZenToolFileIncluded(pkgPath string, toolArgs []string) error {
+func checkZenToolFileIncluded(pkgPath string, toolArgs []string, stderr io.Writer) error {
 	if pkgPath != "main" {
 		return nil
 	}
@@ -227,6 +227,7 @@ func checkZenToolFileIncluded(pkgPath string, toolArgs []string) error {
 		return errors.New("zen-go: zen.tool.go exists but was not included in the build, use 'go build -toolexec=\"zen-go toolexec\" .' instead of specifying individual files")
 	}
 
+	fmt.Fprintf(stderr, "zen-go: warning: zen.tool.go not found in %s. zen.tool.go must be in the same directory as your main package. Run 'zen-go init' from that directory to set up instrumentation.\n", sourceDir)
 	return nil
 }
 

--- a/cmd/zen-go/cmd_toolexec_test.go
+++ b/cmd/zen-go/cmd_toolexec_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -418,7 +420,7 @@ func TestCheckZenToolFileIncluded(t *testing.T) {
 		mainGoPath := filepath.Join(tmpDir, "main.go")
 		toolArgs := []string{"-p", "main", "-o", "/tmp/out.a", mainGoPath}
 
-		err = checkZenToolFileIncluded("main", toolArgs)
+		err = checkZenToolFileIncluded("main", toolArgs, io.Discard)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "zen.tool.go exists but was not included in the build")
@@ -432,20 +434,23 @@ func TestCheckZenToolFileIncluded(t *testing.T) {
 
 		toolArgs := []string{"-p", "main", "-o", "/tmp/out.a", mainGoPath, zenToolPath}
 
-		err := checkZenToolFileIncluded("main", toolArgs)
+		err := checkZenToolFileIncluded("main", toolArgs, io.Discard)
 
 		assert.NoError(t, err)
 	})
 
-	t.Run("no error when zen.tool.go does not exist", func(t *testing.T) {
+	t.Run("warns when zen.tool.go does not exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		mainGoPath := filepath.Join(tmpDir, "main.go")
 
 		toolArgs := []string{"-p", "main", "-o", "/tmp/out.a", mainGoPath}
 
-		err := checkZenToolFileIncluded("main", toolArgs)
+		var stderr strings.Builder
+		err := checkZenToolFileIncluded("main", toolArgs, &stderr)
 
 		assert.NoError(t, err)
+		assert.Contains(t, stderr.String(), "zen.tool.go not found in")
+		assert.Contains(t, stderr.String(), "must be in the same directory as your main package")
 	})
 
 	t.Run("no error for non-main packages", func(t *testing.T) {
@@ -460,7 +465,7 @@ func TestCheckZenToolFileIncluded(t *testing.T) {
 
 		toolArgs := []string{"-p", "github.com/example/pkg", "-o", "/tmp/out.a", goFilePath}
 
-		err = checkZenToolFileIncluded("github.com/example/pkg", toolArgs)
+		err = checkZenToolFileIncluded("github.com/example/pkg", toolArgs, io.Discard)
 
 		assert.NoError(t, err)
 	})
@@ -468,7 +473,7 @@ func TestCheckZenToolFileIncluded(t *testing.T) {
 	t.Run("no error when no go files in args", func(t *testing.T) {
 		toolArgs := []string{"-p", "main", "-o", "/tmp/out.a"}
 
-		err := checkZenToolFileIncluded("main", toolArgs)
+		err := checkZenToolFileIncluded("main", toolArgs, io.Discard)
 
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
`zen.tool.go` must be in the same folder as the `main` package, if it's not there, it can create linker issues which are not obvious. Added a warning to help diagnose the problem.

Example:
```bash
❯ go build -toolexec="zen-go toolexec" -o app ./cmd
# myapp/cmd
zen-go: warning: zen.tool.go not found in cmd. zen.tool.go must be in the same directory as your main package. Run 'zen-go init' from that directory to set up instrumentation.
# myapp/cmd
cannot find package github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo.v4 (using -importcfg)
/opt/homebrew/Cellar/go/1.26.1/libexec/pkg/tool/darwin_arm64/link: cannot open file : open : no such file or directory
exit status 2
```

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Emitted warning when zen.tool.go missing from main package build.
* Modified checkZenToolFileIncluded to accept stderr and print warnings.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/105011296?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->