### PR TITLE
 Add health checks for the sample app databases

### DIFF
--- a/sample-apps/common.mk
+++ b/sample-apps/common.mk
@@ -19,7 +19,7 @@ dev: check-zen-go
 	@PORT=$(PORT) go run -toolexec="$(ZENGO) toolexec" .
 
 start-database:
-	@cd ../databases/ && docker compose up $(DB_SERVICE) -d
+	@cd ../databases/ && docker compose up $(DB_SERVICE) -d --wait
 
 stop-database:
 	@cd ../databases/ && docker compose down

--- a/sample-apps/databases/docker-compose.yml
+++ b/sample-apps/databases/docker-compose.yml
@@ -6,13 +6,17 @@ services:
     volumes:
       - postgres_db_data:/var/lib/postgresql/data
       - ./postgres_init.sql:/docker-entrypoint-initdb.d/init.sql
-
     environment:
       POSTGRES_DB: "db"
       POSTGRES_USER: "user"
       POSTGRES_PASSWORD: "password"
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d db"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
   mysql_database:
     image: mysql
     container_name: sample_mysql_db
@@ -28,6 +32,11 @@ services:
     ports:
       - "3306:3306"
     command: --init-file /data/application/init.sql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "user", "-ppassword"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
   mssql_database:
     build: ./mssql_database
     container_name: sample_mssql_db
@@ -39,6 +48,11 @@ services:
       - "1433:1433"
     volumes:
       - mssql_db_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'Strong!Passw0rd' -Q 'SELECT 1' -b -o /dev/null"]
+      interval: 1s
+      timeout: 5s
+      retries: 30
 
 volumes:
   postgres_db_data:

--- a/sample-apps/echo-pgx-sql/db.go
+++ b/sample-apps/echo-pgx-sql/db.go
@@ -80,7 +80,7 @@ func connectToDb() *sql.DB {
 	var err error
 	var db *sql.DB
 	// Connect to PostgreSQL
-	connStr := "postgresql://localhost:5432/db?user=user&password=password"
+	connStr := "postgresql://localhost:5432/db?user=user&password=password&sslmode=disable"
 	db, err = sql.Open("pgx", connStr)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Ensuring the databases are actually up before running the end2end tests, otherwise can result in occasional failures.