### PR TITLE
Fallback to GLS when checking for bypassed request context

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -31,10 +31,9 @@ jobs:
           sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@[^ ]*|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@v1.0.12
+        uses: AikidoSec/firewall-tester-action@v1.0.14
         with:
           dockerfile_path: ./zen-demo-go/Dockerfile
           app_port: 3000
           sleep_before_test: 10
           test_timeout: 900
-          skip_tests: test_outbound_domain_blocking

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -62,14 +62,12 @@ func SetContext(ctx context.Context, r *http.Request, data ContextData) context.
 }
 
 func IsBypassed(ctx context.Context) bool {
-	if ctx == nil {
-		return false
+	if ctx != nil {
+		if v := ctx.Value(bypassedCtxKey); v != nil {
+			return v.(bool)
+		}
 	}
-	v := ctx.Value(bypassedCtxKey)
-	if v == nil {
-		return false
-	}
-	return v.(bool)
+	return isLocalBypassed()
 }
 
 func GetContext(ctx context.Context) *Context {

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -203,6 +203,45 @@ func TestIsBypassed(t *testing.T) {
 	t.Run("returns false for context without bypass flag", func(t *testing.T) {
 		assert.False(t, IsBypassed(context.Background()))
 	})
+
+	t.Run("falls back to GLS when context is nil", func(t *testing.T) {
+		block := true
+		config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+			BypassedIPs: []string{"10.10.10.10"},
+			Block:       &block,
+		}, nil)
+
+		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
+		ip := "10.10.10.10"
+		bypassedCtx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+		require.True(t, IsBypassed(bypassedCtx))
+
+		var result bool
+		WrapWithGLS(bypassedCtx, func() {
+			//nolint:staticcheck // We want to test the nil case
+			result = IsBypassed(nil)
+		})
+		assert.True(t, result)
+	})
+
+	t.Run("falls back to GLS when context has no bypass flag", func(t *testing.T) {
+		block := true
+		config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+			BypassedIPs: []string{"10.10.10.10"},
+			Block:       &block,
+		}, nil)
+
+		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
+		ip := "10.10.10.10"
+		bypassedCtx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+		require.True(t, IsBypassed(bypassedCtx))
+
+		var result bool
+		WrapWithGLS(bypassedCtx, func() {
+			result = IsBypassed(context.Background())
+		})
+		assert.True(t, result)
+	})
 }
 
 func TestGetContext(t *testing.T) {


### PR DESCRIPTION
`IsBypassed` wasn't falling back to GLS which means if a service was using `http.Get` instead of creating a request with a context (please use a context!), then bypassed IP would not be detected.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated QA tester action to v1.0.14 in workflow

**🐛 Bugfixes**
* Made IsBypassed fallback to GLS when context lacked bypass flag


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107935739?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->