### PR TITLE
Ignore version drift check when using pseudo versions

### DIFF
--- a/cmd/zen-go/internal/rules/modcheck.go
+++ b/cmd/zen-go/internal/rules/modcheck.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 )
 
 const aikidoMainModule = "github.com/AikidoSec/firewall-go"
@@ -57,6 +58,10 @@ func CheckModuleVersionSync(gomodPath string) error {
 	}
 
 	if mainVersion == "" {
+		return nil
+	}
+
+	if module.IsPseudoVersion(mainVersion) {
 		return nil
 	}
 

--- a/cmd/zen-go/internal/rules/modcheck_test.go
+++ b/cmd/zen-go/internal/rules/modcheck_test.go
@@ -133,6 +133,20 @@ replace github.com/AikidoSec/firewall-go => ../../
 	require.NoError(t, CheckModuleVersionSync(path))
 }
 
+func TestCheckModuleVersionSync_PseudoVersionSkipped(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.22
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.2-0.20260428123005-0cdd21ca0d12
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.2.1-beta.1.0.20260428123005-0cdd21ca0d12
+)
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
 func TestFindGoMod_Found(t *testing.T) {
 	root := t.TempDir()
 	gomodPath := filepath.Join(root, "go.mod")


### PR DESCRIPTION
When using local replaces and manually overridden versions, the version drift check was triggering, instead these cases should be ignored and the check skipped.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Ignored version drift check for pseudo versions in modcheck when present


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109891511?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->