### PR TITLE
Add support for wrapping anonymous functions

### DIFF
--- a/cmd/zen-go/internal/transform/transform_wrap.go
+++ b/cmd/zen-go/internal/transform/transform_wrap.go
@@ -37,6 +37,29 @@ func TransformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName
 func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
 	for _, stmt := range stmts {
 		switch s := stmt.(type) {
+		case *ast.DeclStmt:
+			genDecl, ok := s.Decl.(*ast.GenDecl)
+			if !ok {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, val := range valueSpec.Values {
+					newExpr, err := tryTransformCall(val, fset, pkgName, funcName, rule, modified, importsToAdd)
+					if err != nil {
+						return err
+					}
+					if newExpr != nil {
+						valueSpec.Values[i] = newExpr
+					}
+					if err := transformFuncLitWrap(val, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+						return err
+					}
+				}
+			}
 		case *ast.AssignStmt:
 			for i, rhs := range s.Rhs {
 				newExpr, err := tryTransformCall(rhs, fset, pkgName, funcName, rule, modified, importsToAdd)

--- a/cmd/zen-go/internal/transform/transform_wrap.go
+++ b/cmd/zen-go/internal/transform/transform_wrap.go
@@ -47,6 +47,10 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 				if newExpr != nil {
 					s.Rhs[i] = newExpr
 				}
+
+				if err := transformFuncLitWrap(rhs, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+					return err
+				}
 			}
 		case *ast.ExprStmt:
 			newExpr, err := tryTransformCall(s.X, fset, pkgName, funcName, rule, modified, importsToAdd)
@@ -57,6 +61,10 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 			if newExpr != nil {
 				s.X = newExpr
 			}
+
+			if err := transformFuncLitWrap(s.X, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+				return err
+			}
 		case *ast.ReturnStmt:
 			for i, result := range s.Results {
 				newExpr, err := tryTransformCall(result, fset, pkgName, funcName, rule, modified, importsToAdd)
@@ -66,6 +74,10 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 
 				if newExpr != nil {
 					s.Results[i] = newExpr
+				}
+
+				if err := transformFuncLitWrap(result, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+					return err
 				}
 			}
 		case *ast.IfStmt:
@@ -127,6 +139,22 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 		}
 	}
 
+	return nil
+}
+
+// transformFuncLitWrap recurses into the body of a function literal so that
+// calls inside anonymous functions are instrumented. It handles two forms:
+//   - *ast.FuncLit: the expression is a plain function literal (e.g. assigned or returned)
+//   - *ast.CallExpr whose Fun is a *ast.FuncLit: an immediately invoked function literal
+func transformFuncLitWrap(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
+	switch e := expr.(type) {
+	case *ast.FuncLit:
+		return transformStmtsWrap(e.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+	case *ast.CallExpr:
+		if lit, ok := e.Fun.(*ast.FuncLit); ok {
+			return transformStmtsWrap(lit.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+		}
+	}
 	return nil
 }
 

--- a/cmd/zen-go/internal/transform/transform_wrap.go
+++ b/cmd/zen-go/internal/transform/transform_wrap.go
@@ -120,6 +120,17 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 					}
 				}
 			}
+		case *ast.TypeSwitchStmt:
+			if s.Body != nil {
+				for _, clause := range s.Body.List {
+					if cc, ok := clause.(*ast.CaseClause); ok {
+						err := transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
 		case *ast.SelectStmt:
 			if s.Body != nil {
 				for _, clause := range s.Body.List {
@@ -134,6 +145,27 @@ func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName
 		case *ast.BlockStmt:
 			err := transformStmtsWrap(s.List, fset, pkgName, funcName, rule, modified, importsToAdd)
 			if err != nil {
+				return err
+			}
+		case *ast.SendStmt:
+			newExpr, err := tryTransformCall(s.Value, fset, pkgName, funcName, rule, modified, importsToAdd)
+			if err != nil {
+				return err
+			}
+
+			if newExpr != nil {
+				s.Value = newExpr
+			}
+
+			if err := transformFuncLitWrap(s.Value, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+				return err
+			}
+		case *ast.GoStmt:
+			if err := transformFuncLitWrap(s.Call, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+				return err
+			}
+		case *ast.DeferStmt:
+			if err := transformFuncLitWrap(s.Call, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
 				return err
 			}
 		}
@@ -153,6 +185,13 @@ func transformFuncLitWrap(expr ast.Expr, fset *token.FileSet, pkgName, funcName 
 	case *ast.CallExpr:
 		if lit, ok := e.Fun.(*ast.FuncLit); ok {
 			return transformStmtsWrap(lit.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
+		}
+		for _, arg := range e.Args {
+			if lit, ok := arg.(*ast.FuncLit); ok {
+				if err := transformStmtsWrap(lit.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/cmd/zen-go/internal/transform/transform_wrap_test.go
+++ b/cmd/zen-go/internal/transform/transform_wrap_test.go
@@ -179,6 +179,48 @@ func main() {
 				return cc.Body[0].(*ast.AssignStmt).Rhs[0]
 			},
 		},
+		{
+			name: "anonymous function assigned to variable",
+			src: `package p
+func main() {
+	f := func() {
+		r := gin.Default()
+		_ = r
+	}
+	f()
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "immediately invoked anonymous function",
+			src: `package p
+func main() {
+	r := func() interface{} { return gin.Default() }()
+	_ = r
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				iife := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CallExpr)
+				lit := iife.Fun.(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.ReturnStmt).Results[0]
+			},
+		},
+		{
+			name: "anonymous function returned from outer function",
+			src: `package p
+func main() interface{} {
+	return func() interface{} {
+		r := gin.Default()
+		return r
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.ReturnStmt).Results[0].(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/zen-go/internal/transform/transform_wrap_test.go
+++ b/cmd/zen-go/internal/transform/transform_wrap_test.go
@@ -52,6 +52,22 @@ func main() { r := gin.Default(); _ = r }`
 	assert.Equal(t, "Default", origSel.Sel.Name)
 }
 
+func TestTransformDeclsWrap_InAssignment_Reassign(t *testing.T) {
+	src := `package p
+func main() { var r interface{}; r = gin.Default(); _ = r }`
+	f, fset := parseFile(t, src)
+	rule := rules.WrapRule{WrapTmpl: `mw.Wrap({{.}})`}
+
+	modified := false
+	err := TransformDeclsWrap(f.Decls, fset, "gin", "Default", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	fn := findFunc(t, f.Decls, "main")
+	assign := fn.Body.List[1].(*ast.AssignStmt)
+	requireWrappedCall(t, assign.Rhs[0], "mw", "Wrap")
+}
+
 func TestTransformDeclsWrap_InExprStmt(t *testing.T) {
 	src := `package p
 func main() { gin.Default() }`
@@ -177,6 +193,18 @@ func main() {
 			getExpr: func(fn *ast.FuncDecl) ast.Expr {
 				cc := fn.Body.List[1].(*ast.SelectStmt).Body.List[0].(*ast.CommClause)
 				return cc.Body[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "var declaration",
+			src: `package p
+func main() {
+	var r = gin.Default()
+	_ = r
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				decl := fn.Body.List[0].(*ast.DeclStmt).Decl.(*ast.GenDecl)
+				return decl.Specs[0].(*ast.ValueSpec).Values[0]
 			},
 		},
 		{

--- a/cmd/zen-go/internal/transform/transform_wrap_test.go
+++ b/cmd/zen-go/internal/transform/transform_wrap_test.go
@@ -180,6 +180,33 @@ func main() {
 			},
 		},
 		{
+			name: "type switch case",
+			src: `package p
+func main() {
+	var x interface{}
+	switch x.(type) {
+	case int:
+		r := gin.Default()
+		_ = r
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				cc := fn.Body.List[1].(*ast.TypeSwitchStmt).Body.List[0].(*ast.CaseClause)
+				return cc.Body[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "send statement",
+			src: `package p
+func main() {
+	ch := make(chan interface{})
+	ch <- gin.Default()
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[1].(*ast.SendStmt).Value
+			},
+		},
+		{
 			name: "anonymous function assigned to variable",
 			src: `package p
 func main() {
@@ -205,6 +232,49 @@ func main() {
 				iife := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CallExpr)
 				lit := iife.Fun.(*ast.FuncLit)
 				return lit.Body.List[0].(*ast.ReturnStmt).Results[0]
+			},
+		},
+		{
+			name: "anonymous function passed as argument",
+			src: `package p
+func main() {
+	doTransaction(ctx, func() {
+		r := gin.Default()
+		_ = r
+	})
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				call := fn.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
+				lit := call.Args[1].(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "goroutine anonymous function",
+			src: `package p
+func main() {
+	go func() {
+		r := gin.Default()
+		_ = r
+	}()
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.GoStmt).Call.Fun.(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "deferred anonymous function",
+			src: `package p
+func main() {
+	defer func() {
+		r := gin.Default()
+		_ = r
+	}()
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.DeferStmt).Call.Fun.(*ast.FuncLit)
+				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
 			},
 		},
 		{


### PR DESCRIPTION
Adding support for anonymous function wrapping, so that targets within anonymous functions are wrapped, for example:

```go
func main() {
  r := func() {
    return gin.Default()
  }
  // ...
}
```

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 4 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added support for wrapping calls inside anonymous function literals.
* Handled additional statement forms: var assigns, send, go, defer, type-switch.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110845090?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->