### PR TITLE
Switch to astutil.Apply for wrapping funcs

### DIFF
--- a/cmd/zen-go/internal/transform/transform_wrap.go
+++ b/cmd/zen-go/internal/transform/transform_wrap.go
@@ -8,275 +8,61 @@ import (
 	"go/token"
 	"strings"
 
+	"golang.org/x/tools/go/ast/astutil"
+
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 )
 
-// TransformDeclsWrap walks through all declarations in a file looking for function
-// declarations, then recursively transforms any matching function calls within them.
+// TransformDeclsWrap walks all function declarations in a file and wraps any
+// call matching pkgName.funcName with the given rule's template.
 func TransformDeclsWrap(decls []ast.Decl, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
 	for _, decl := range decls {
-		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
-			err := transformStmtsWrap(fn.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-			if err != nil {
-				return err
-			}
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
 		}
-	}
 
-	return nil
-}
-
-// transformStmtsWrap recursively walks the statement tree, finding all expressions
-// that might contain function calls and attempting to transform them.
-//
-// It handles:
-// - Assignments (x := pkg.Func())
-// - Expression statements (pkg.Func())
-// - Return statements (return pkg.Func())
-// - Control flow blocks (if/for/switch/select bodies)
-func transformStmtsWrap(stmts []ast.Stmt, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
-	for _, stmt := range stmts {
-		switch s := stmt.(type) {
-		case *ast.DeclStmt:
-			genDecl, ok := s.Decl.(*ast.GenDecl)
+		var applyErr error
+		astutil.Apply(fn.Body, func(c *astutil.Cursor) bool {
+			call, ok := c.Node().(*ast.CallExpr)
 			if !ok {
-				continue
+				return true
 			}
-			for _, spec := range genDecl.Specs {
-				valueSpec, ok := spec.(*ast.ValueSpec)
-				if !ok {
-					continue
-				}
-				for i, val := range valueSpec.Values {
-					newExpr, err := tryTransformCall(val, fset, pkgName, funcName, rule, modified, importsToAdd)
-					if err != nil {
-						return err
-					}
-					if newExpr != nil {
-						valueSpec.Values[i] = newExpr
-					}
-					if err := transformFuncLitWrap(val, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-						return err
-					}
-				}
-			}
-		case *ast.AssignStmt:
-			for i, rhs := range s.Rhs {
-				newExpr, err := tryTransformCall(rhs, fset, pkgName, funcName, rule, modified, importsToAdd)
-				if err != nil {
-					return err
-				}
 
-				if newExpr != nil {
-					s.Rhs[i] = newExpr
-				}
-
-				if err := transformFuncLitWrap(rhs, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-					return err
-				}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
 			}
-		case *ast.ExprStmt:
-			newExpr, err := tryTransformCall(s.X, fset, pkgName, funcName, rule, modified, importsToAdd)
+
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok || ident.Name != pkgName || sel.Sel.Name != funcName {
+				return true
+			}
+
+			var origBuf bytes.Buffer
+			_ = printer.Fprint(&origBuf, fset, call)
+
+			wrapped := strings.Replace(rule.WrapTmpl, "{{.}}", origBuf.String(), 1)
+
+			wrappedExpr, err := parser.ParseExpr(wrapped)
 			if err != nil {
-				return err
+				applyErr = err
+				return false
 			}
 
-			if newExpr != nil {
-				s.X = newExpr
+			c.Replace(wrappedExpr)
+			*modified = true
+			for alias, path := range rule.Imports {
+				importsToAdd[alias] = path
 			}
 
-			if err := transformFuncLitWrap(s.X, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-				return err
-			}
-		case *ast.ReturnStmt:
-			for i, result := range s.Results {
-				newExpr, err := tryTransformCall(result, fset, pkgName, funcName, rule, modified, importsToAdd)
-				if err != nil {
-					return err
-				}
+			return false
+		}, nil)
 
-				if newExpr != nil {
-					s.Results[i] = newExpr
-				}
-
-				if err := transformFuncLitWrap(result, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-					return err
-				}
-			}
-		case *ast.IfStmt:
-			if s.Body != nil {
-				err := transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-				if err != nil {
-					return err
-				}
-			}
-			if s.Else != nil {
-				if block, ok := s.Else.(*ast.BlockStmt); ok {
-					err := transformStmtsWrap(block.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		case *ast.ForStmt:
-			if s.Body != nil {
-				err := transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-				if err != nil {
-					return err
-				}
-			}
-		case *ast.RangeStmt:
-			if s.Body != nil {
-				err := transformStmtsWrap(s.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-				if err != nil {
-					return err
-				}
-			}
-		case *ast.SwitchStmt:
-			if s.Body != nil {
-				for _, clause := range s.Body.List {
-					if cc, ok := clause.(*ast.CaseClause); ok {
-						err := transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
-						if err != nil {
-							return err
-						}
-					}
-				}
-			}
-		case *ast.TypeSwitchStmt:
-			if s.Body != nil {
-				for _, clause := range s.Body.List {
-					if cc, ok := clause.(*ast.CaseClause); ok {
-						err := transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
-						if err != nil {
-							return err
-						}
-					}
-				}
-			}
-		case *ast.SelectStmt:
-			if s.Body != nil {
-				for _, clause := range s.Body.List {
-					if cc, ok := clause.(*ast.CommClause); ok {
-						err := transformStmtsWrap(cc.Body, fset, pkgName, funcName, rule, modified, importsToAdd)
-						if err != nil {
-							return err
-						}
-					}
-				}
-			}
-		case *ast.BlockStmt:
-			err := transformStmtsWrap(s.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-			if err != nil {
-				return err
-			}
-		case *ast.SendStmt:
-			newExpr, err := tryTransformCall(s.Value, fset, pkgName, funcName, rule, modified, importsToAdd)
-			if err != nil {
-				return err
-			}
-
-			if newExpr != nil {
-				s.Value = newExpr
-			}
-
-			if err := transformFuncLitWrap(s.Value, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-				return err
-			}
-		case *ast.GoStmt:
-			if err := transformFuncLitWrap(s.Call, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-				return err
-			}
-		case *ast.DeferStmt:
-			if err := transformFuncLitWrap(s.Call, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-				return err
-			}
+		if applyErr != nil {
+			return applyErr
 		}
 	}
 
 	return nil
-}
-
-// transformFuncLitWrap recurses into the body of a function literal so that
-// calls inside anonymous functions are instrumented. It handles two forms:
-//   - *ast.FuncLit: the expression is a plain function literal (e.g. assigned or returned)
-//   - *ast.CallExpr whose Fun is a *ast.FuncLit: an immediately invoked function literal
-func transformFuncLitWrap(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) error {
-	switch e := expr.(type) {
-	case *ast.FuncLit:
-		return transformStmtsWrap(e.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-	case *ast.CallExpr:
-		if lit, ok := e.Fun.(*ast.FuncLit); ok {
-			return transformStmtsWrap(lit.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd)
-		}
-		for _, arg := range e.Args {
-			if lit, ok := arg.(*ast.FuncLit); ok {
-				if err := transformStmtsWrap(lit.Body.List, fset, pkgName, funcName, rule, modified, importsToAdd); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// tryTransformCall attempts to transform a function call expression that matches
-// the target package and function name by wrapping it according to the rule.
-//
-// AST Navigation:
-//   - We're looking for expressions like: pkgName.funcName(args...)
-//   - In Go's AST, this is represented as:
-//     CallExpr { Fun: SelectorExpr { X: Ident(pkgName), Sel: Ident(funcName) } }
-//
-// Process:
-// 1. Check if expr is a CallExpr (a function call)
-// 2. Check if the function being called is a SelectorExpr (e.g., pkg.Func)
-// 3. Verify the selector's receiver is an Ident matching our target package
-// 4. Verify the selector's field matches our target function
-// 5. If all match, wrap the call using the rule's template
-//
-// Returns the wrapped expression if transformation occurred, nil otherwise.
-func tryTransformCall(expr ast.Expr, fset *token.FileSet, pkgName, funcName string, rule rules.WrapRule, modified *bool, importsToAdd map[string]string) (ast.Expr, error) {
-	// Step 1: Check if this is a function call at all
-	call, ok := expr.(*ast.CallExpr)
-	if !ok {
-		return nil, nil
-	}
-
-	// Step 2: Check if the call is in the form "something.method()"
-	// (as opposed to just "function()")
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return nil, nil
-	}
-
-	// Step 3: Check package and func name match
-	ident, ok := sel.X.(*ast.Ident)
-	if !ok || ident.Name != pkgName || sel.Sel.Name != funcName {
-		return nil, nil
-	}
-
-	// Step 4: Serialize the original call expression back to source code
-	// e.g., AST for "http.Get(url)" becomes the string "http.Get(url)"
-	var origBuf bytes.Buffer
-	_ = printer.Fprint(&origBuf, fset, call)
-	origCode := origBuf.String()
-
-	// Step 5: Apply the wrapping template
-	// e.g., if template is "instrument.Wrap({{.}})", we get "instrument.Wrap(http.Get(url))"
-	wrapped := strings.Replace(rule.WrapTmpl, "{{.}}", origCode, 1)
-
-	// Step 6: Parse the wrapped string back into an AST expression
-	wrappedExpr, err := parser.ParseExpr(wrapped)
-	if err != nil {
-		return nil, err
-	}
-
-	// Step 7: Mark that we modified the file and register any new imports needed
-	*modified = true
-	for alias, path := range rule.Imports {
-		importsToAdd[alias] = path
-	}
-
-	return wrappedExpr, nil
 }

--- a/cmd/zen-go/internal/transform/transform_wrap_test.go
+++ b/cmd/zen-go/internal/transform/transform_wrap_test.go
@@ -196,6 +196,82 @@ func main() {
 			},
 		},
 		{
+			name: "type switch init statement",
+			src: `package p
+func main() {
+	var x interface{}
+	switch r := gin.Default(); x.(type) {
+	case int:
+		_ = r
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[1].(*ast.TypeSwitchStmt).Init.(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "for init statement",
+			src: `package p
+func main() {
+	for r := gin.Default(); r != nil; {
+		_ = r
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[0].(*ast.ForStmt).Init.(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "switch init statement",
+			src: `package p
+func main() {
+	switch r := gin.Default(); {
+	case r != nil:
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[0].(*ast.SwitchStmt).Init.(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "composite literal field value",
+			src: `package p
+func main() {
+	cfg := MyStruct{Field: gin.Default()}
+	_ = cfg
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CompositeLit)
+				return lit.Elts[0].(*ast.KeyValueExpr).Value
+			},
+		},
+		{
+			name: "if init statement",
+			src: `package p
+func main() {
+	if r := gin.Default(); r != nil {
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[0].(*ast.IfStmt).Init.(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "else if body",
+			src: `package p
+func main() {
+	if false {
+	} else if true {
+		r := gin.Default()
+		_ = r
+	}
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				elseIf := fn.Body.List[0].(*ast.IfStmt).Else.(*ast.IfStmt)
+				return elseIf.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
 			name: "var declaration",
 			src: `package p
 func main() {
@@ -303,6 +379,73 @@ func main() {
 			getExpr: func(fn *ast.FuncDecl) ast.Expr {
 				lit := fn.Body.List[0].(*ast.DeferStmt).Call.Fun.(*ast.FuncLit)
 				return lit.Body.List[0].(*ast.AssignStmt).Rhs[0]
+			},
+		},
+		{
+			name: "multiple return values",
+			src: `package p
+func main() (interface{}, error) { return gin.Default(), nil }`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[0].(*ast.ReturnStmt).Results[0]
+			},
+		},
+		{
+			name: "unkeyed composite literal element",
+			src: `package p
+func main() {
+	s := []interface{}{gin.Default()}
+	_ = s
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				lit := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CompositeLit)
+				return lit.Elts[0]
+			},
+		},
+		{
+			name: "nested composite literal field value",
+			src: `package p
+func main() {
+	cfg := Outer{Inner: Inner{Field: gin.Default()}}
+	_ = cfg
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				outer := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CompositeLit)
+				inner := outer.Elts[0].(*ast.KeyValueExpr).Value.(*ast.CompositeLit)
+				return inner.Elts[0].(*ast.KeyValueExpr).Value
+			},
+		},
+		{
+			name: "regular function call argument",
+			src: `package p
+func main() {
+	r := setup(gin.Default())
+	_ = r
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				call := fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.CallExpr)
+				return call.Args[0]
+			},
+		},
+		{
+			name: "type assertion on result",
+			src: `package p
+func main() {
+	_, ok := gin.Default().(interface{})
+	_ = ok
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				return fn.Body.List[0].(*ast.AssignStmt).Rhs[0].(*ast.TypeAssertExpr).X
+			},
+		},
+		{
+			name: "method call on result",
+			src: `package p
+func main() {
+	gin.Default().Run()
+}`,
+			getExpr: func(fn *ast.FuncDecl) ast.Expr {
+				outer := fn.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
+				return outer.Fun.(*ast.SelectorExpr).X
 			},
 		},
 		{


### PR DESCRIPTION
Instead of having to check for very node and traverse it manually, switching to the `golang.org/x/tools/go/ast/astutil` module which does it for us!

I've also added more tests to ensure we're covering as many of the weird scenarios that I can think of, but otherwise the minimal changes in tests show that we're still covering all the cases we were wrapping before.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Consolidated call-wrapping logic and updated import tracking, simplified mutation

**🔧 Refactors**
* Replaced manual AST traversal with astutil.Apply to wrap calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112386099?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->