### PR TITLE
Add benchmarks for each source with different request paths

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -5,6 +5,7 @@ package gin_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -215,32 +216,197 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	b.Run("plain", func(b *testing.B) {
-		router := gin.New()
-		router.ContextWithFallback = true
-		router.GET("/route", func(c *gin.Context) {})
+	b.Run("simple", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.GET("/route", func(c *gin.Context) {})
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.Use(zengin.GetMiddleware())
+			router.GET("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
 
-	b.Run("zen", func(b *testing.B) {
-		router := gin.New()
-		router.ContextWithFallback = true
-		router.Use(zengin.GetMiddleware())
-		router.GET("/route", func(c *gin.Context) {})
+	b.Run("json-body", func(b *testing.B) {
+		const body = `{"username":"bob","email":"bob@example.com"}`
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.POST("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.Use(zengin.GetMiddleware())
+			router.POST("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("form-body", func(b *testing.B) {
+		const body = "username=bob&password=secret"
+
+		b.Run("plain", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.POST("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.Use(zengin.GetMiddleware())
+			router.POST("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("ip-list", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.GET("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			block := true
+			config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+				Block: &block,
+			}, &aikido_types.ListsConfigData{
+				BlockedIPAddresses: []aikido_types.IPList{
+					{
+						Source:      "benchmark",
+						Description: "benchmark blocked IPs",
+						IPs:         generateIPs(10_000),
+					},
+				},
+			})
+			b.Cleanup(func() {
+				noBlock := false
+				config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+					Block: &noBlock,
+				}, &aikido_types.ListsConfigData{})
+			})
+
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.Use(zengin.GetMiddleware())
+			router.GET("/route", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("route-params", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.GET("/users/:id", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := gin.New()
+			router.ContextWithFallback = true
+			router.Use(zengin.GetMiddleware())
+			router.GET("/users/:id", func(c *gin.Context) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
 }
@@ -450,4 +616,12 @@ func TestMiddlewareNestedRouters(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+}
+
+func generateIPs(n int) []string {
+	ips := make([]string, n)
+	for i := range n {
+		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+	}
+	return ips
 }

--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	gin.SetMode(gin.ReleaseMode)
+
 	original := config.IsZenLoaded()
 	config.SetZenLoaded(true)
 
@@ -213,18 +215,33 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	router := gin.New()
-	router.ContextWithFallback = true
-	router.Use(zengin.GetMiddleware())
+	b.Run("plain", func(b *testing.B) {
+		router := gin.New()
+		router.ContextWithFallback = true
+		router.GET("/route", func(c *gin.Context) {})
 
-	router.GET("/route", func(c *gin.Context) {})
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
+	})
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			r := httptest.NewRequest("GET", "/route", http.NoBody)
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, r)
-		}
+	b.Run("zen", func(b *testing.B) {
+		router := gin.New()
+		router.ContextWithFallback = true
+		router.Use(zengin.GetMiddleware())
+		router.GET("/route", func(c *gin.Context) {})
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
 	})
 }
 

--- a/instrumentation/sources/gin-gonic/gin/middleware_test.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware_test.go
@@ -226,6 +226,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -242,6 +243,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -261,6 +263,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -278,6 +281,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -298,6 +302,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -315,6 +320,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -333,6 +339,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -369,6 +376,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -387,6 +395,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -403,6 +412,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -624,4 +634,13 @@ func generateIPs(n int) []string {
 		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
 	}
 	return ips
+}
+
+func addBrowserHeaders(r *http.Request) {
+	r.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	r.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	r.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Cache-Control", "max-age=0")
 }

--- a/instrumentation/sources/go-chi/chi.v5/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware_test.go
@@ -211,17 +211,31 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	router := chi.NewRouter()
-	router.Use(zenchi.GetMiddleware())
+	b.Run("plain", func(b *testing.B) {
+		router := chi.NewRouter()
+		router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
 
-	router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
+	})
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			r := httptest.NewRequest("GET", "/route", http.NoBody)
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, r)
-		}
+	b.Run("zen", func(b *testing.B) {
+		router := chi.NewRouter()
+		router.Use(zenchi.GetMiddleware())
+		router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
 	})
 }
 

--- a/instrumentation/sources/go-chi/chi.v5/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	zenchi "github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi.v5"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
@@ -211,32 +213,197 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	b.Run("plain", func(b *testing.B) {
-		router := chi.NewRouter()
-		router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+	b.Run("simple", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Use(zenchi.GetMiddleware())
+			router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
 
-	b.Run("zen", func(b *testing.B) {
-		router := chi.NewRouter()
-		router.Use(zenchi.GetMiddleware())
-		router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+	b.Run("json-body", func(b *testing.B) {
+		const body = `{"username":"bob","email":"bob@example.com"}`
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Post("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Use(zenchi.GetMiddleware())
+			router.Post("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
+
+	b.Run("form-body", func(b *testing.B) {
+		const body = "username=bob&password=secret"
+
+		b.Run("plain", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Post("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Use(zenchi.GetMiddleware())
+			router.Post("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("ip-list", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			block := true
+			config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+				Block: &block,
+			}, &aikido_types.ListsConfigData{
+				BlockedIPAddresses: []aikido_types.IPList{
+					{
+						Source:      "benchmark",
+						Description: "benchmark blocked IPs",
+						IPs:         generateIPs(10_000),
+					},
+				},
+			})
+			b.Cleanup(func() {
+				noBlock := false
+				config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+					Block: &noBlock,
+				}, &aikido_types.ListsConfigData{})
+			})
+
+			router := chi.NewRouter()
+			router.Use(zenchi.GetMiddleware())
+			router.Get("/route", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("route-params", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Get("/users/{id}", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := chi.NewRouter()
+			router.Use(zenchi.GetMiddleware())
+			router.Get("/users/{id}", func(w http.ResponseWriter, r *http.Request) {})
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+}
+
+func generateIPs(n int) []string {
+	ips := make([]string, n)
+	for i := range n {
+		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+	}
+	return ips
 }
 
 func TestMiddlewarePreservesBodyForJSON(t *testing.T) {

--- a/instrumentation/sources/go-chi/chi.v5/middleware_test.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware_test.go
@@ -222,6 +222,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -237,6 +238,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -255,6 +257,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -271,6 +274,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -290,6 +294,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -306,6 +311,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -323,6 +329,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -358,6 +365,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -375,6 +383,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -390,6 +399,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -657,4 +667,13 @@ func TestMiddlewareNestedRouters(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+}
+
+func addBrowserHeaders(r *http.Request) {
+	r.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	r.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	r.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Cache-Control", "max-age=0")
 }

--- a/instrumentation/sources/labstack/echo.v4/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	zenecho "github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo.v4"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
@@ -218,32 +220,197 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	b.Run("plain", func(b *testing.B) {
-		router := echo.New()
-		router.GET("/route", func(e echo.Context) error { return nil })
+	b.Run("simple", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/route", func(e echo.Context) error { return nil })
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
 
-	b.Run("zen", func(b *testing.B) {
-		router := echo.New()
-		router.Use(zenecho.GetMiddleware())
-		router.GET("/route", func(e echo.Context) error { return nil })
+	b.Run("json-body", func(b *testing.B) {
+		const body = `{"username":"bob","email":"bob@example.com"}`
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.POST("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.POST("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
+
+	b.Run("form-body", func(b *testing.B) {
+		const body = "username=bob&password=secret"
+
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.POST("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.POST("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("ip-list", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			block := true
+			config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+				Block: &block,
+			}, &aikido_types.ListsConfigData{
+				BlockedIPAddresses: []aikido_types.IPList{
+					{
+						Source:      "benchmark",
+						Description: "benchmark blocked IPs",
+						IPs:         generateIPs(10_000),
+					},
+				},
+			})
+			b.Cleanup(func() {
+				noBlock := false
+				config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+					Block: &noBlock,
+				}, &aikido_types.ListsConfigData{})
+			})
+
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/route", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("route-params", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/users/:id", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/users/:id", func(e echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+}
+
+func generateIPs(n int) []string {
+	ips := make([]string, n)
+	for i := range n {
+		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+	}
+	return ips
 }
 
 func TestMiddlewarePreservesBodyForJSON(t *testing.T) {

--- a/instrumentation/sources/labstack/echo.v4/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware_test.go
@@ -229,6 +229,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -244,6 +245,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -262,6 +264,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -278,6 +281,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -297,6 +301,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -313,6 +318,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -330,6 +336,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -365,6 +372,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -382,6 +390,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -397,6 +406,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -594,4 +604,13 @@ func TestMiddlewareNestedRouters(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+}
+
+func addBrowserHeaders(r *http.Request) {
+	r.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	r.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	r.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Cache-Control", "max-age=0")
 }

--- a/instrumentation/sources/labstack/echo.v4/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware_test.go
@@ -218,17 +218,31 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	router := echo.New()
-	router.Use(zenecho.GetMiddleware())
+	b.Run("plain", func(b *testing.B) {
+		router := echo.New()
+		router.GET("/route", func(e echo.Context) error { return nil })
 
-	router.GET("/route", func(e echo.Context) error { return nil })
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
+	})
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			r := httptest.NewRequest("GET", "/route", http.NoBody)
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, r)
-		}
+	b.Run("zen", func(b *testing.B) {
+		router := echo.New()
+		router.Use(zenecho.GetMiddleware())
+		router.GET("/route", func(e echo.Context) error { return nil })
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
 	})
 }
 

--- a/instrumentation/sources/labstack/echo.v5/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware_test.go
@@ -209,6 +209,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -224,6 +225,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -242,6 +244,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -258,6 +261,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -277,6 +281,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -293,6 +298,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -310,6 +316,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -345,6 +352,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
@@ -362,6 +370,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -377,6 +386,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					router.ServeHTTP(w, r)
 				}
@@ -512,4 +522,13 @@ func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 		stats := agent.Stats().GetAndClear()
 		require.Equal(c, 1, stats.Requests.Total)
 	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func addBrowserHeaders(r *http.Request) {
+	r.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	r.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	r.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Cache-Control", "max-age=0")
 }

--- a/instrumentation/sources/labstack/echo.v5/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware_test.go
@@ -199,17 +199,31 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	router := echo.New()
-	router.Use(zenecho.GetMiddleware())
+	b.Run("plain", func(b *testing.B) {
+		router := echo.New()
+		router.GET("/route", func(e *echo.Context) error { return nil })
 
-	router.GET("/route", func(e *echo.Context) error { return nil })
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
+	})
 
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			r := httptest.NewRequest("GET", "/route", http.NoBody)
-			w := httptest.NewRecorder()
-			router.ServeHTTP(w, r)
-		}
+	b.Run("zen", func(b *testing.B) {
+		router := echo.New()
+		router.Use(zenecho.GetMiddleware())
+		router.GET("/route", func(e *echo.Context) error { return nil })
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+			}
+		})
 	})
 }
 

--- a/instrumentation/sources/labstack/echo.v5/middleware_test.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware_test.go
@@ -5,6 +5,7 @@ package echo_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -199,32 +200,197 @@ func TestMiddlewareBlockingRequests(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	b.Run("plain", func(b *testing.B) {
-		router := echo.New()
-		router.GET("/route", func(e *echo.Context) error { return nil })
+	b.Run("simple", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/route", func(e *echo.Context) error { return nil })
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
 
-	b.Run("zen", func(b *testing.B) {
-		router := echo.New()
-		router.Use(zenecho.GetMiddleware())
-		router.GET("/route", func(e *echo.Context) error { return nil })
+	b.Run("json-body", func(b *testing.B) {
+		const body = `{"username":"bob","email":"bob@example.com"}`
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				router.ServeHTTP(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.POST("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.POST("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
 		})
 	})
+
+	b.Run("form-body", func(b *testing.B) {
+		const body = "username=bob&password=secret"
+
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.POST("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.POST("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("ip-list", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			block := true
+			config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+				Block: &block,
+			}, &aikido_types.ListsConfigData{
+				BlockedIPAddresses: []aikido_types.IPList{
+					{
+						Source:      "benchmark",
+						Description: "benchmark blocked IPs",
+						IPs:         generateIPs(10_000),
+					},
+				},
+			})
+			b.Cleanup(func() {
+				noBlock := false
+				config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+					Block: &noBlock,
+				}, &aikido_types.ListsConfigData{})
+			})
+
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/route", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("route-params", func(b *testing.B) {
+		b.Run("plain", func(b *testing.B) {
+			router := echo.New()
+			router.GET("/users/:id", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			router := echo.New()
+			router.Use(zenecho.GetMiddleware())
+			router.GET("/users/:id", func(e *echo.Context) error { return nil })
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+}
+
+func generateIPs(n int) []string {
+	ips := make([]string, n)
+	for i := range n {
+		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+	}
+	return ips
 }
 
 func TestMiddlewarePreservesBodyForJSON(t *testing.T) {

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -244,6 +244,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					handler(w, r)
 				}
@@ -257,6 +258,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					wrapped(w, r)
 				}
@@ -273,6 +275,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					handler(w, r)
@@ -287,6 +290,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/json")
 					w := httptest.NewRecorder()
 					wrapped(w, r)
@@ -304,6 +308,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					handler(w, r)
@@ -318,6 +323,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					addBrowserHeaders(r)
 					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 					w := httptest.NewRecorder()
 					wrapped(w, r)
@@ -334,6 +340,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					handler(w, r)
@@ -367,6 +374,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					addBrowserHeaders(r)
 					r.RemoteAddr = "192.168.1.1:1234"
 					w := httptest.NewRecorder()
 					wrapped(w, r)
@@ -386,6 +394,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					mux.ServeHTTP(w, r)
 				}
@@ -400,6 +409,7 @@ func BenchmarkMiddleware(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
 					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					addBrowserHeaders(r)
 					w := httptest.NewRecorder()
 					mux.ServeHTTP(w, r)
 				}
@@ -434,4 +444,13 @@ func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 		stats := agent.Stats().GetAndClear()
 		require.Equal(c, 1, stats.Requests.Total)
 	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func addBrowserHeaders(r *http.Request) {
+	r.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+	r.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	r.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	r.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Cache-Control", "max-age=0")
 }

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -15,7 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
+
 	"github.com/AikidoSec/firewall-go/internal/agent"
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/stretchr/testify/assert"
@@ -233,29 +236,184 @@ func TestExtractRouteParams(t *testing.T) {
 }
 
 func BenchmarkMiddleware(b *testing.B) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
+	b.Run("simple", func(b *testing.B) {
+		handler := func(w http.ResponseWriter, r *http.Request) {}
 
-	b.Run("plain", func(b *testing.B) {
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				handler(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					handler(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			wrapped := Middleware(handler)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					w := httptest.NewRecorder()
+					wrapped(w, r)
+				}
+			})
 		})
 	})
 
-	b.Run("zen", func(b *testing.B) {
-		wrapped := Middleware(handler)
+	b.Run("json-body", func(b *testing.B) {
+		const body = `{"username":"bob","email":"bob@example.com"}`
+		handler := func(w http.ResponseWriter, r *http.Request) {}
 
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				r := httptest.NewRequest("GET", "/route", http.NoBody)
-				w := httptest.NewRecorder()
-				wrapped(w, r)
-			}
+		b.Run("plain", func(b *testing.B) {
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					handler(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			wrapped := Middleware(handler)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					wrapped(w, r)
+				}
+			})
 		})
 	})
+
+	b.Run("form-body", func(b *testing.B) {
+		const body = "username=bob&password=secret"
+		handler := func(w http.ResponseWriter, r *http.Request) {}
+
+		b.Run("plain", func(b *testing.B) {
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					handler(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			wrapped := Middleware(handler)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("POST", "/route", strings.NewReader(body))
+					r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+					w := httptest.NewRecorder()
+					wrapped(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("ip-list", func(b *testing.B) {
+		handler := func(w http.ResponseWriter, r *http.Request) {}
+
+		b.Run("plain", func(b *testing.B) {
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					handler(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			block := true
+			config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+				Block: &block,
+			}, &aikido_types.ListsConfigData{
+				BlockedIPAddresses: []aikido_types.IPList{
+					{
+						Source:      "benchmark",
+						Description: "benchmark blocked IPs",
+						IPs:         generateIPs(10_000),
+					},
+				},
+			})
+			b.Cleanup(func() {
+				noBlock := false
+				config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+					Block: &noBlock,
+				}, &aikido_types.ListsConfigData{})
+			})
+
+			wrapped := Middleware(handler)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/route", http.NoBody)
+					r.RemoteAddr = "192.168.1.1:1234"
+					w := httptest.NewRecorder()
+					wrapped(w, r)
+				}
+			})
+		})
+	})
+
+	b.Run("route-params", func(b *testing.B) {
+		handler := func(w http.ResponseWriter, r *http.Request) {}
+
+		b.Run("plain", func(b *testing.B) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/users/{id}", handler)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					mux.ServeHTTP(w, r)
+				}
+			})
+		})
+
+		b.Run("zen", func(b *testing.B) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/users/{id}", Middleware(handler))
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					r := httptest.NewRequest("GET", "/users/123", http.NoBody)
+					w := httptest.NewRecorder()
+					mux.ServeHTTP(w, r)
+				}
+			})
+		})
+	})
+}
+
+func generateIPs(n int) []string {
+	ips := make([]string, n)
+	for i := range n {
+		ips[i] = fmt.Sprintf("10.%d.%d.%d", (i/65536)%256, (i/256)%256, i%256)
+	}
+	return ips
 }
 
 func TestMiddlewareCallsOnPostRequest(t *testing.T) {

--- a/instrumentation/sources/net/http/middleware_test.go
+++ b/instrumentation/sources/net/http/middleware_test.go
@@ -232,6 +232,32 @@ func TestExtractRouteParams(t *testing.T) {
 	}
 }
 
+func BenchmarkMiddleware(b *testing.B) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	b.Run("plain", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				handler(w, r)
+			}
+		})
+	})
+
+	b.Run("zen", func(b *testing.B) {
+		wrapped := Middleware(handler)
+
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				r := httptest.NewRequest("GET", "/route", http.NoBody)
+				w := httptest.NewRecorder()
+				wrapped(w, r)
+			}
+		})
+	})
+}
+
 func TestMiddlewareCallsOnPostRequest(t *testing.T) {
 	agent.Stats().GetAndClear()
 


### PR DESCRIPTION
Add benchmarks to cover various parts of the middlewares for each source.