### PR TITLE
Ignore invalid JSON after a valid prefix

### DIFF
--- a/instrumentation/http/body_test.go
+++ b/instrumentation/http/body_test.go
@@ -152,8 +152,12 @@ func TestTryExtractBodyBypassVectors(t *testing.T) {
 		parser := &mockParser{req: req}
 		result := TryExtractBody(req, parser)
 
-		formValues, ok := result.(url.Values)
-		require.True(t, ok, "expected url.Values for multipart/form-data request, got %T: %v", result, result)
+		combined, ok := result.([]any)
+		require.True(t, ok, "got %T: %v", result, result)
+		require.Len(t, combined, 2)
+		assert.Equal(t, map[string]interface{}{}, combined[0])
+		formValues, ok := combined[1].(url.Values)
+		require.True(t, ok)
 		assert.Equal(t, "injected", formValues.Get("name"))
 	})
 
@@ -169,8 +173,14 @@ func TestTryExtractBodyBypassVectors(t *testing.T) {
 		parser := &mockParser{req: req}
 		result := TryExtractBody(req, parser)
 
-		formValues, ok := result.(url.Values)
-		require.True(t, ok, "expected url.Values for multipart/form-data request, got %T: %v", result, result)
+		combined, ok := result.([]any)
+		require.True(t, ok, "got %T: %v", result, result)
+		require.Len(t, combined, 2)
+		jsonMap, ok := combined[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "val", jsonMap["key"])
+		formValues, ok := combined[1].(url.Values)
+		require.True(t, ok)
 		assert.Equal(t, "injected", formValues.Get("name"))
 	})
 
@@ -186,8 +196,12 @@ func TestTryExtractBodyBypassVectors(t *testing.T) {
 		parser := &mockParser{req: req}
 		result := TryExtractBody(req, parser)
 
-		formValues, ok := result.(url.Values)
-		require.True(t, ok, "expected url.Values for multipart/form-data request, got %T: %v", result, result)
+		combined, ok := result.([]any)
+		require.True(t, ok, "got %T: %v", result, result)
+		require.Len(t, combined, 2)
+		assert.Equal(t, []interface{}{}, combined[0])
+		formValues, ok := combined[1].(url.Values)
+		require.True(t, ok)
 		assert.Equal(t, "injected", formValues.Get("name"))
 	})
 

--- a/instrumentation/http/json.go
+++ b/instrumentation/http/json.go
@@ -21,9 +21,7 @@ func tryExtractJSON(r *http.Request) any {
 			break
 		}
 		if err != nil {
-			_, _ = io.Copy(io.Discard, tee)
-			r.Body = io.NopCloser(&buf)
-			return nil
+			break
 		}
 		results = append(results, data)
 	}

--- a/instrumentation/http/json_test.go
+++ b/instrumentation/http/json_test.go
@@ -10,6 +10,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// json.Decoder reads one value and ignores trailing bytes, so we must
+// extract that prefix or attackers bypass inspection by appending garbage.
+func TestTryExtractJSONBypassResistance(t *testing.T) {
+	t.Run("valid object followed by invalid object", func(t *testing.T) {
+		body := `{"name":"Doggo"}{"invalid"}`
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+
+		got := tryExtractJSON(r)
+
+		m, ok := got.(map[string]interface{})
+		require.True(t, ok, "got %T: %v", got, got)
+		assert.Equal(t, "Doggo", m["name"])
+	})
+
+	t.Run("valid object followed by unclosed object", func(t *testing.T) {
+		body := `{"valid":true}{"invalid":{"this is valid":true}`
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+
+		got := tryExtractJSON(r)
+
+		m, ok := got.(map[string]interface{})
+		require.True(t, ok, "got %T: %v", got, got)
+		assert.Equal(t, true, m["valid"])
+	})
+
+	t.Run("no valid JSON prefix", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(`garbage{"a":1}`))
+
+		assert.Nil(t, tryExtractJSON(r))
+	})
+
+	t.Run("body is restored after partial extraction", func(t *testing.T) {
+		body := `{"name":"Doggo"}{"invalid"}`
+		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
+
+		_ = tryExtractJSON(r)
+
+		restored, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Equal(t, body, string(restored))
+	})
+}
+
 func TestTryExtractJSONStreamingBehavior(t *testing.T) {
 	t.Run("returns all objects when body contains multiple JSON objects", func(t *testing.T) {
 		body := `{"first":true}` + "\n" + `{"second":true}`
@@ -27,24 +70,24 @@ func TestTryExtractJSONStreamingBehavior(t *testing.T) {
 		assert.Equal(t, body, string(restoredBody))
 	})
 
-	t.Run("returns nil when valid JSON is followed by non-JSON content", func(t *testing.T) {
+	t.Run("returns parsed prefix when valid JSON object is followed by non-JSON content", func(t *testing.T) {
 		multipartTrailer := "\n------boundary\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n------boundary--"
 		body := "{}" + multipartTrailer
 		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
 
 		got := tryExtractJSON(r)
 
-		assert.Nil(t, got)
+		assert.Equal(t, map[string]interface{}{}, got)
 	})
 
-	t.Run("returns nil when valid JSON array is followed by non-JSON content", func(t *testing.T) {
+	t.Run("returns parsed prefix when valid JSON array is followed by non-JSON content", func(t *testing.T) {
 		multipartTrailer := "\n------boundary\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nvalue\r\n------boundary--"
 		body := "[]" + multipartTrailer
 		r := httptest.NewRequest("POST", "/test", strings.NewReader(body))
 
 		got := tryExtractJSON(r)
 
-		assert.Nil(t, got)
+		assert.Equal(t, []interface{}{}, got)
 	})
 }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Stopped aborting on trailing parse error; returned parsed prefix instead


<sup>[More info](https://app.aikido.dev/featurebranch/scan/114841266?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->