### PR TITLE
Add rule to add struct fields

### DIFF
--- a/cmd/zen-go/docs/instrumentation-rules.md
+++ b/cmd/zen-go/docs/instrumentation-rules.md
@@ -12,7 +12,7 @@ meta:
 
 rules:
   - id: unique.rule.id
-    type: wrap | prepend | inject-decl
+    type: wrap | prepend | inject-decl | add-field
     # ... type-specific fields
     imports:
       alias: import/path
@@ -120,6 +120,17 @@ This is often paired with a `prepend` rule in the same file that calls the injec
       return nil, _aikido_block
     }
 ```
+
+### `add-field`
+
+Adds new fields to a named struct type. Used to extend existing data structures without modifying original source code.
+
+| Field | Description |
+|---|---|
+| `package` | The package being compiled (required), e.g. `main` |
+| `struct` | Name of the struct to modify |
+| `fields` | List of fields to add, each with `name` and `type` |
+| `imports` | Imports needed by the new field types |
 
 ## Discovery
 

--- a/cmd/zen-go/internal/instrumentor/instrumentor.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor.go
@@ -15,9 +15,10 @@ import (
 )
 
 type Instrumentor struct {
-	WrapRules       []rules.WrapRule
-	PrependRules    []rules.PrependRule
-	InjectDeclRules []rules.InjectDeclRule
+	WrapRules        []rules.WrapRule
+	PrependRules     []rules.PrependRule
+	InjectDeclRules  []rules.InjectDeclRule
+	StructFieldRules []rules.StructFieldRule
 }
 
 // NewInstrumentor creates a new Instrumentor, loading rules from YAML files.
@@ -38,6 +39,7 @@ func NewInstrumentor(currentVersion string) (*Instrumentor, error) {
 		allRules.WrapRules = append(allRules.WrapRules, rulesData.WrapRules...)
 		allRules.PrependRules = append(allRules.PrependRules, rulesData.PrependRules...)
 		allRules.InjectDeclRules = append(allRules.InjectDeclRules, rulesData.InjectDeclRules...)
+		allRules.StructFieldRules = append(allRules.StructFieldRules, rulesData.StructFieldRules...)
 		allRules.MinVersions = append(allRules.MinVersions, rulesData.MinVersions...)
 	}
 
@@ -52,9 +54,10 @@ func NewInstrumentorWithRules(r *rules.InstrumentationRules, currentVersion stri
 		return nil, err
 	}
 	return &Instrumentor{
-		WrapRules:       r.WrapRules,
-		PrependRules:    r.PrependRules,
-		InjectDeclRules: r.InjectDeclRules,
+		WrapRules:        r.WrapRules,
+		PrependRules:     r.PrependRules,
+		InjectDeclRules:  r.InjectDeclRules,
+		StructFieldRules: r.StructFieldRules,
 	}, nil
 }
 
@@ -131,6 +134,14 @@ func (i *Instrumentor) InstrumentFile(filename string, compilingPkg string) (Ins
 	// Apply prepend rules (for methods and standalone functions)
 	for _, rule := range i.PrependRules {
 		err = transform.TransformDeclsPrepend(file.Decls, compilingPkg, rule, &modified, importsToAdd)
+		if err != nil {
+			return InstrumentFileResult{}, err
+		}
+	}
+
+	// Apply add-field rules (for struct field injection)
+	for _, rule := range i.StructFieldRules {
+		err = transform.TransformDeclsAddField(file.Decls, fset, compilingPkg, rule, &modified, importsToAdd)
 		if err != nil {
 			return InstrumentFileResult{}, err
 		}

--- a/cmd/zen-go/internal/instrumentor/instrumentor_test.go
+++ b/cmd/zen-go/internal/instrumentor/instrumentor_test.go
@@ -728,6 +728,7 @@ rules:
 		allRules.WrapRules = append(allRules.WrapRules, rulesData.WrapRules...)
 		allRules.PrependRules = append(allRules.PrependRules, rulesData.PrependRules...)
 		allRules.InjectDeclRules = append(allRules.InjectDeclRules, rulesData.InjectDeclRules...)
+		allRules.StructFieldRules = append(allRules.StructFieldRules, rulesData.StructFieldRules...)
 	}
 
 	inst, err := NewInstrumentorWithRules(allRules, "0.0.0")
@@ -784,6 +785,124 @@ func TestNewInstrumentorWithRules_MinVersionNotMet(t *testing.T) {
 	_, err := NewInstrumentorWithRules(r, "0.2.0")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "please upgrade")
+}
+
+func TestInstrumentFile_AddFieldRule(t *testing.T) {
+	src := `package main
+
+type MyStruct struct {
+	Name string
+}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	structFieldRules := []rules.StructFieldRule{
+		{
+			ID:         "main.MyStruct.ctx",
+			Package:    "main",
+			StructName: "MyStruct",
+			NewFields:  []rules.StructFieldDef{{Name: "ID", Type: "int"}},
+		},
+	}
+
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{StructFieldRules: structFieldRules}, "0.0.0")
+	require.NoError(t, err)
+	result, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, result.Modified)
+
+	resultStr := string(result.Code)
+	assert.Contains(t, resultStr, "Name")
+	assert.Contains(t, resultStr, "ID")
+	assert.Contains(t, resultStr, "int")
+}
+
+func TestInstrumentFile_AddFieldRule_WithImports(t *testing.T) {
+	src := `package main
+
+type MyStruct struct{}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	structFieldRules := []rules.StructFieldRule{
+		{
+			ID:         "main.MyStruct.ctx",
+			Package:    "main",
+			StructName: "MyStruct",
+			NewFields:  []rules.StructFieldDef{{Name: "Ctx", Type: "context.Context"}},
+			Imports:    map[string]string{"context": "context"},
+		},
+	}
+
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{StructFieldRules: structFieldRules}, "0.0.0")
+	require.NoError(t, err)
+	result, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.True(t, result.Modified)
+	assert.Equal(t, map[string]string{"context": "context"}, result.Imports)
+
+	resultStr := string(result.Code)
+	assert.Contains(t, resultStr, "Ctx")
+	assert.Contains(t, resultStr, "context.Context")
+	assert.Contains(t, resultStr, `"context"`)
+}
+
+func TestInstrumentFile_AddFieldRule_WrongPackage_NoModification(t *testing.T) {
+	src := `package other
+
+type MyStruct struct{}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "other.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	structFieldRules := []rules.StructFieldRule{
+		{
+			ID:         "main.MyStruct.f",
+			Package:    "main",
+			StructName: "MyStruct",
+			NewFields:  []rules.StructFieldDef{{Name: "F", Type: "string"}},
+		},
+	}
+
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{StructFieldRules: structFieldRules}, "0.0.0")
+	require.NoError(t, err)
+	result, err := inst.InstrumentFile(tmpFile, "other")
+
+	require.NoError(t, err)
+	assert.False(t, result.Modified)
+}
+
+func TestInstrumentFile_AddFieldRule_StructNotFound_NoModification(t *testing.T) {
+	src := `package main
+
+type OtherStruct struct{}
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "main.go")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(src), 0o600))
+
+	structFieldRules := []rules.StructFieldRule{
+		{
+			ID:         "main.MyStruct.f",
+			Package:    "main",
+			StructName: "MyStruct",
+			NewFields:  []rules.StructFieldDef{{Name: "F", Type: "string"}},
+		},
+	}
+
+	inst, err := NewInstrumentorWithRules(&rules.InstrumentationRules{StructFieldRules: structFieldRules}, "0.0.0")
+	require.NoError(t, err)
+	result, err := inst.InstrumentFile(tmpFile, "main")
+
+	require.NoError(t, err)
+	assert.False(t, result.Modified)
 }
 
 func TestIsMajorVersion(t *testing.T) {

--- a/cmd/zen-go/internal/rules/rules.go
+++ b/cmd/zen-go/internal/rules/rules.go
@@ -36,15 +36,9 @@ type Rule struct {
 	Anchor    string            `yaml:"anchor"`    // For inject-decl rules: anchor function name
 	Links     []string          `yaml:"links"`     // For inject-decl rules: packages to link
 	Struct    string            `yaml:"struct"`    // For add-field rules: target struct name
-	Fields    []StructFieldSpec `yaml:"fields"`    // For add-field rules: fields to add
+	Fields    []StructFieldDef  `yaml:"fields"`    // For add-field rules: fields to add
 	Imports   map[string]string `yaml:"imports"`
 	Template  string            `yaml:"template"`
-}
-
-// StructFieldSpec is the YAML representation of a field to add to a struct.
-type StructFieldSpec struct {
-	Name string `yaml:"name"`
-	Type string `yaml:"type"`
 }
 
 // MinVersionEntry records a minimum zen-go version requirement from a rules file.
@@ -103,8 +97,8 @@ type StructFieldRule struct {
 
 // StructFieldDef describes a single field to inject into a struct.
 type StructFieldDef struct {
-	Name string
-	Type string
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
 }
 
 // LoadRulesFromDir loads all zen.instrument.yml files from a directory tree.
@@ -209,15 +203,11 @@ func loadRulesFromFile(path string) (*InstrumentationRules, error) {
 			if rule.Package == "" {
 				return nil, fmt.Errorf("rule %s: add-field rules require a package", rule.ID)
 			}
-			fields := make([]StructFieldDef, len(rule.Fields))
-			for i, f := range rule.Fields {
-				fields[i] = StructFieldDef(f)
-			}
 			result.StructFieldRules = append(result.StructFieldRules, StructFieldRule{
 				ID:         rule.ID,
 				Package:    rule.Package,
 				StructName: rule.Struct,
-				NewFields:  fields,
+				NewFields:  rule.Fields,
 				Imports:    rule.Imports,
 			})
 		}

--- a/cmd/zen-go/internal/rules/rules.go
+++ b/cmd/zen-go/internal/rules/rules.go
@@ -30,13 +30,21 @@ type Rule struct {
 	Match     string            `yaml:"match"`     // For wrap rules: "pkg.Func"
 	Exclude   []string          `yaml:"exclude"`   // For wrap rules: packages to exclude from instrumentation
 	Receiver  string            `yaml:"receiver"`  // For prepend rules with receiver: "*pkg.Type"
-	Package   string            `yaml:"package"`   // For prepend/inject-decl rules: target package (e.g., "os")
+	Package   string            `yaml:"package"`   // For prepend/inject-decl/add-field rules: target package (e.g., "os")
 	Function  string            `yaml:"function"`  // For prepend rules: single "MethodName"
 	Functions []string          `yaml:"functions"` // For prepend rules: multiple method names (one-of)
 	Anchor    string            `yaml:"anchor"`    // For inject-decl rules: anchor function name
 	Links     []string          `yaml:"links"`     // For inject-decl rules: packages to link
+	Struct    string            `yaml:"struct"`    // For add-field rules: target struct name
+	Fields    []StructFieldSpec `yaml:"fields"`    // For add-field rules: fields to add
 	Imports   map[string]string `yaml:"imports"`
 	Template  string            `yaml:"template"`
+}
+
+// StructFieldSpec is the YAML representation of a field to add to a struct.
+type StructFieldSpec struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
 }
 
 // MinVersionEntry records a minimum zen-go version requirement from a rules file.
@@ -47,10 +55,11 @@ type MinVersionEntry struct {
 
 // InstrumentationRules holds all loaded rules
 type InstrumentationRules struct {
-	WrapRules       []WrapRule
-	PrependRules    []PrependRule
-	InjectDeclRules []InjectDeclRule
-	MinVersions     []MinVersionEntry
+	WrapRules        []WrapRule
+	PrependRules     []PrependRule
+	InjectDeclRules  []InjectDeclRule
+	StructFieldRules []StructFieldRule
+	MinVersions      []MinVersionEntry
 }
 
 // WrapRule wraps a function call expression
@@ -81,6 +90,21 @@ type InjectDeclRule struct {
 	AnchorFunc   string   // Function to attach declaration to (e.g., "Getpid")
 	Links        []string // Packages needed for linking
 	DeclTemplate string   // The declaration to inject
+}
+
+// StructFieldRule adds new fields to a named struct type.
+type StructFieldRule struct {
+	ID         string
+	Package    string            // Package being compiled, e.g., "main"
+	StructName string            // Name of the struct to modify
+	NewFields  []StructFieldDef  // Fields to add
+	Imports    map[string]string // alias -> import path
+}
+
+// StructFieldDef describes a single field to inject into a struct.
+type StructFieldDef struct {
+	Name string
+	Type string
 }
 
 // LoadRulesFromDir loads all zen.instrument.yml files from a directory tree.
@@ -117,6 +141,7 @@ func LoadRulesFromDir(dir string) (*InstrumentationRules, error) {
 		result.WrapRules = append(result.WrapRules, rules.WrapRules...)
 		result.PrependRules = append(result.PrependRules, rules.PrependRules...)
 		result.InjectDeclRules = append(result.InjectDeclRules, rules.InjectDeclRules...)
+		result.StructFieldRules = append(result.StructFieldRules, rules.StructFieldRules...)
 		result.MinVersions = append(result.MinVersions, rules.MinVersions...)
 		return nil
 	})
@@ -179,6 +204,21 @@ func loadRulesFromFile(path string) (*InstrumentationRules, error) {
 				AnchorFunc:   rule.Anchor,
 				Links:        rule.Links,
 				DeclTemplate: strings.TrimSpace(rule.Template),
+			})
+		case "add-field":
+			if rule.Package == "" {
+				return nil, fmt.Errorf("rule %s: add-field rules require a package", rule.ID)
+			}
+			fields := make([]StructFieldDef, len(rule.Fields))
+			for i, f := range rule.Fields {
+				fields[i] = StructFieldDef(f)
+			}
+			result.StructFieldRules = append(result.StructFieldRules, StructFieldRule{
+				ID:         rule.ID,
+				Package:    rule.Package,
+				StructName: rule.Struct,
+				NewFields:  fields,
+				Imports:    rule.Imports,
 			})
 		}
 	}

--- a/cmd/zen-go/internal/rules/rules_test.go
+++ b/cmd/zen-go/internal/rules/rules_test.go
@@ -435,6 +435,13 @@ rules:
     anchor: Getpid
     links: []
     template: func __test() {}
+  - id: add-field-rule
+    type: add-field
+    package: main
+    struct: MyStruct
+    fields:
+      - name: NewField
+        type: string
 `
 	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600)
 	require.NoError(t, err)
@@ -444,4 +451,66 @@ rules:
 	assert.Len(t, rules.WrapRules, 1)
 	assert.Len(t, rules.PrependRules, 1)
 	assert.Len(t, rules.InjectDeclRules, 1)
+	assert.Len(t, rules.StructFieldRules, 1)
+}
+
+func TestLoadRulesFromFile_AddFieldRule(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "zen.instrument.yml")
+
+	yamlContent := `
+meta:
+  name: test-package
+
+rules:
+  - id: main.MyStruct.add-field
+    type: add-field
+    package: main
+    struct: MyStruct
+    fields:
+      - name: ctx
+        type: context.Context
+      - name: id
+        type: int
+    imports:
+      context: context
+`
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600)
+	require.NoError(t, err)
+
+	rules, err := loadRulesFromFile(yamlPath)
+	require.NoError(t, err)
+	require.Len(t, rules.StructFieldRules, 1)
+	require.Empty(t, rules.WrapRules)
+	require.Empty(t, rules.PrependRules)
+
+	r := rules.StructFieldRules[0]
+	assert.Equal(t, "main.MyStruct.add-field", r.ID)
+	assert.Equal(t, "main", r.Package)
+	assert.Equal(t, "MyStruct", r.StructName)
+	assert.Equal(t, []StructFieldDef{{Name: "ctx", Type: "context.Context"}, {Name: "id", Type: "int"}}, r.NewFields)
+	assert.Equal(t, map[string]string{"context": "context"}, r.Imports)
+}
+
+func TestLoadRulesFromFile_AddFieldRule_MissingPackage_Error(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "zen.instrument.yml")
+
+	yamlContent := `
+meta:
+  name: test-package
+rules:
+  - id: bad-rule
+    type: add-field
+    struct: MyStruct
+    fields:
+      - name: F
+        type: string
+`
+	err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600)
+	require.NoError(t, err)
+
+	_, err = loadRulesFromFile(yamlPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "package")
 }

--- a/cmd/zen-go/internal/transform/transform_add_field.go
+++ b/cmd/zen-go/internal/transform/transform_add_field.go
@@ -1,0 +1,81 @@
+package transform
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
+)
+
+// TransformDeclsAddField finds struct type declarations matching the rule and appends new fields.
+func TransformDeclsAddField(decls []ast.Decl, fset *token.FileSet, compilingPkg string, rule rules.StructFieldRule, modified *bool, importsToAdd map[string]string) error {
+	if rule.Package != "" && rule.Package != compilingPkg {
+		return nil
+	}
+
+	for _, decl := range decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != rule.StructName {
+				continue
+			}
+
+			structType, ok := typeSpec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+
+			for _, fd := range rule.NewFields {
+				field, err := parseStructField(fset, fd.Name, fd.Type)
+				if err != nil {
+					return fmt.Errorf("rule %s: parsing field %q %q: %w", rule.ID, fd.Name, fd.Type, err)
+				}
+				structType.Fields.List = append(structType.Fields.List, field)
+			}
+
+			*modified = true
+			for alias, path := range rule.Imports {
+				importsToAdd[alias] = path
+			}
+		}
+	}
+
+	return nil
+}
+
+func parseStructField(fset *token.FileSet, name, typeExpr string) (*ast.Field, error) {
+	src := fmt.Sprintf("package p\ntype _s struct { %s %s }", name, typeExpr)
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			if len(st.Fields.List) > 0 {
+				return st.Fields.List[0], nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to extract field from parsed source")
+}

--- a/cmd/zen-go/internal/transform/transform_add_field_test.go
+++ b/cmd/zen-go/internal/transform/transform_add_field_test.go
@@ -1,0 +1,188 @@
+package transform
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
+)
+
+// getStructFields returns the fields of the named struct, or nil if not found.
+func getStructFields(t *testing.T, f *ast.File, name string) []*ast.Field {
+	t.Helper()
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok || ts.Name.Name != name {
+				continue
+			}
+			if st, ok := ts.Type.(*ast.StructType); ok {
+				return st.Fields.List
+			}
+		}
+	}
+	return nil
+}
+
+func TestTransformDeclsAddField_AddsField(t *testing.T) {
+	src := `package main
+type MyStruct struct {
+	Existing string
+}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.add.field",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields:  []rules.StructFieldDef{{Name: "NewField", Type: "string"}},
+	}
+
+	modified := false
+	err := TransformDeclsAddField(f.Decls, fset, "main", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	fields := getStructFields(t, f, "MyStruct")
+	require.Len(t, fields, 2)
+	assert.Equal(t, "Existing", fields[0].Names[0].Name)
+	assert.Equal(t, "NewField", fields[1].Names[0].Name)
+}
+
+func TestTransformDeclsAddField_AddsMultipleFields(t *testing.T) {
+	src := `package main
+type MyStruct struct{}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.add.fields",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields: []rules.StructFieldDef{
+			{Name: "FieldA", Type: "int"},
+			{Name: "FieldB", Type: "bool"},
+		},
+	}
+
+	modified := false
+	err := TransformDeclsAddField(f.Decls, fset, "main", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	fields := getStructFields(t, f, "MyStruct")
+	require.Len(t, fields, 2)
+	assert.Equal(t, "FieldA", fields[0].Names[0].Name)
+	assert.Equal(t, "FieldB", fields[1].Names[0].Name)
+}
+
+func TestTransformDeclsAddField_WrongPackage_NoModification(t *testing.T) {
+	src := `package other
+type MyStruct struct{}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.wrong.pkg",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields:  []rules.StructFieldDef{{Name: "F", Type: "string"}},
+	}
+
+	modified := false
+	err := TransformDeclsAddField(f.Decls, fset, "other", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.False(t, modified)
+	assert.Empty(t, getStructFields(t, f, "MyStruct"))
+}
+
+func TestTransformDeclsAddField_StructNotFound_NoModification(t *testing.T) {
+	src := `package main
+type OtherStruct struct{}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.not.found",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields:  []rules.StructFieldDef{{Name: "F", Type: "string"}},
+	}
+
+	modified := false
+	err := TransformDeclsAddField(f.Decls, fset, "main", rule, &modified, map[string]string{})
+	require.NoError(t, err)
+	assert.False(t, modified)
+}
+
+func TestTransformDeclsAddField_AddsImports(t *testing.T) {
+	src := `package main
+type MyStruct struct{}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.imports",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields:  []rules.StructFieldDef{{Name: "Ctx", Type: "context.Context"}},
+		Imports:    map[string]string{"context": "context"},
+	}
+
+	importsToAdd := map[string]string{}
+	err := TransformDeclsAddField(f.Decls, fset, "main", rule, new(bool), importsToAdd)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"context": "context"}, importsToAdd)
+}
+
+func TestTransformDeclsAddField_InvalidFieldType_Error(t *testing.T) {
+	src := `package main
+type MyStruct struct{}
+`
+	f, fset := parseFile(t, src)
+	rule := rules.StructFieldRule{
+		ID:         "test.invalid",
+		Package:    "main",
+		StructName: "MyStruct",
+		NewFields:  []rules.StructFieldDef{{Name: "F", Type: "not a valid type!!!"}},
+	}
+
+	err := TransformDeclsAddField(f.Decls, fset, "main", rule, new(bool), map[string]string{})
+	require.Error(t, err)
+}
+
+func TestParseStructField(t *testing.T) {
+	t.Run("SimpleType", func(t *testing.T) {
+		fset := token.NewFileSet()
+		field, err := parseStructField(fset, "Name", "string")
+		require.NoError(t, err)
+		require.Len(t, field.Names, 1)
+		assert.Equal(t, "Name", field.Names[0].Name)
+	})
+
+	t.Run("QualifiedType", func(t *testing.T) {
+		fset := token.NewFileSet()
+		field, err := parseStructField(fset, "Ctx", "context.Context")
+		require.NoError(t, err)
+		require.Len(t, field.Names, 1)
+		assert.Equal(t, "Ctx", field.Names[0].Name)
+	})
+
+	t.Run("PointerType", func(t *testing.T) {
+		fset := token.NewFileSet()
+		field, err := parseStructField(fset, "Next", "*http.Request")
+		require.NoError(t, err)
+		require.Len(t, field.Names, 1)
+		assert.Equal(t, "Next", field.Names[0].Name)
+	})
+
+	t.Run("InvalidType_Error", func(t *testing.T) {
+		fset := token.NewFileSet()
+		_, err := parseStructField(fset, "F", "not valid!!!")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added 'add-field' rule types and YAML parsing support
* Injected struct fields at compile time via AST transformer


<sup>[More info](https://app.aikido.dev/featurebranch/scan/115466105?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->