### PR TITLE
Add auto mode for zen-go

### DIFF
--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -151,11 +151,15 @@ func initCommand(stdout io.Writer, force, auto bool, sourcesFlag string, sources
 		}
 	}
 
-	// Best-effort detection from go.mod. Failure to read/parse is non-fatal:
-	// we proceed with an empty detection set so init still works.
+	// Detect installed instrumentation targets from go.mod.
+	// Under --auto, any go.mod failure is fatal — the user explicitly delegated
+	// selection to go.mod. Otherwise we log and fall back to empty detection.
 	requires, modErr := parseGoModRequires("go.mod")
-	if modErr != nil && auto {
-		fmt.Fprintf(stdout, "⚠️  Could not read go.mod for auto-detection: %v\n", modErr)
+	if modErr != nil {
+		if auto {
+			return fmt.Errorf("--auto requires a readable go.mod: %w", modErr)
+		}
+		fmt.Fprintf(stdout, "⚠️  Skipping go.mod detection: %v\n", modErr)
 	}
 	detectedSources := detectInstalledOptions(sourceOptions, requires)
 	detectedSinks := detectInstalledOptions(sinkOptions, requires)

--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -12,22 +12,23 @@ import (
 )
 
 type instrumentOption struct {
-	name        string
-	description string
-	importPath  string // empty for locked/stdlib items
-	locked      bool
+	name         string
+	description  string
+	importPath   string // empty for locked/stdlib items
+	goModulePath string // upstream module path used for go.mod detection; empty for locked items
+	locked       bool
 }
 
 var (
 	sourceOptions = []instrumentOption{
-		{name: "gin", description: "Gin web framework", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin"},
-		{name: "chi", description: "Chi router", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi.v5"},
-		{name: "echo/v4", description: "Echo v4 web framework", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo.v4"},
+		{name: "gin", description: "Gin web framework", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin", goModulePath: "github.com/gin-gonic/gin"},
+		{name: "chi", description: "Chi router", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi.v5", goModulePath: "github.com/go-chi/chi/v5"},
+		{name: "echo/v4", description: "Echo v4 web framework", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sources/labstack/echo.v4", goModulePath: "github.com/labstack/echo/v4"},
 		{name: "net/http", description: "Standard library (always included)", locked: true},
 	}
 
 	sinkOptions = []instrumentOption{
-		{name: "pgx", description: "PostgreSQL via pgx/v5", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5"},
+		{name: "pgx", description: "PostgreSQL via pgx/v5", importPath: "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5", goModulePath: "github.com/jackc/pgx/v5"},
 		{name: "os", description: "File system operations (always included)", locked: true},
 		{name: "os/exec", description: "Command execution (always included)", locked: true},
 		{name: "path", description: "Path traversal protection (always included)", locked: true},
@@ -138,7 +139,7 @@ func parseAndValidateList(flagValue string, available map[string]string, itemTyp
 	return result, nil
 }
 
-func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bool, sinksFlag string, sinksSet bool) error {
+func initCommand(stdout io.Writer, force, auto bool, sourcesFlag string, sourcesSet bool, sinksFlag string, sinksSet bool) error {
 	filename := "zen.tool.go"
 
 	// Check if file already exists
@@ -150,11 +151,21 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 		}
 	}
 
+	// Best-effort detection from go.mod. Failure to read/parse is non-fatal:
+	// we proceed with an empty detection set so init still works.
+	requires, modErr := parseGoModRequires("go.mod")
+	if modErr != nil && auto {
+		fmt.Fprintf(stdout, "⚠️  Could not read go.mod for auto-detection: %v\n", modErr)
+	}
+	detectedSources := detectInstalledOptions(sourceOptions, requires)
+	detectedSinks := detectInstalledOptions(sinkOptions, requires)
+
 	var selectedSources, selectedSinks []string
 	var err error
 
-	// Handle sources: use flag if explicitly set, otherwise prompt
-	if sourcesSet {
+	// Handle sources: explicit flag > auto > interactive prompt
+	switch {
+	case sourcesSet:
 		selectedSources, err = parseAndValidateList(sourcesFlag, availableSources, "source")
 		if err != nil {
 			return err
@@ -162,15 +173,18 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 		if len(selectedSources) == 0 && sourcesFlag == "" {
 			fmt.Fprintln(stdout, "No sources selected (empty argument provided)")
 		}
-	} else {
-		selectedSources, err = promptForSources()
+	case auto:
+		selectedSources = detectedSources
+	default:
+		selectedSources, err = promptForSources(detectedSources)
 		if err != nil {
 			return fmt.Errorf("source selection cancelled or failed: %w", err)
 		}
 	}
 
-	// Handle sinks: use flag if explicitly set, otherwise prompt
-	if sinksSet {
+	// Handle sinks: explicit flag > auto > interactive prompt
+	switch {
+	case sinksSet:
 		selectedSinks, err = parseAndValidateList(sinksFlag, availableSinks, "sink")
 		if err != nil {
 			return err
@@ -178,8 +192,10 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 		if len(selectedSinks) == 0 && sinksFlag == "" {
 			fmt.Fprintln(stdout, "No sinks selected (empty argument provided)")
 		}
-	} else {
-		selectedSinks, err = promptForSinks()
+	case auto:
+		selectedSinks = detectedSinks
+	default:
+		selectedSinks, err = promptForSinks(detectedSinks)
 		if err != nil {
 			return fmt.Errorf("sink selection cancelled or failed: %w", err)
 		}
@@ -226,30 +242,37 @@ func initCommand(stdout io.Writer, force bool, sourcesFlag string, sourcesSet bo
 	return nil
 }
 
-func toSelectItems(options []instrumentOption) []tui.SelectItem {
+func toSelectItems(options []instrumentOption, preselected []string) []tui.SelectItem {
+	preset := make(map[string]struct{}, len(preselected))
+	for _, name := range preselected {
+		preset[name] = struct{}{}
+	}
 	items := make([]tui.SelectItem, len(options))
 	for i, opt := range options {
+		_, detected := preset[opt.name]
 		items[i] = tui.SelectItem{
 			Name:        opt.name,
 			Description: opt.description,
 			Locked:      opt.locked,
+			Selected:    detected,
+			Detected:    detected,
 		}
 	}
 	return items
 }
 
-func promptForSources() ([]string, error) {
+func promptForSources(preselected []string) ([]string, error) {
 	return tui.RunMultiSelect(
 		"Sources",
 		"Entry points for incoming requests (web frameworks)",
-		toSelectItems(sourceOptions),
+		toSelectItems(sourceOptions, preselected),
 	)
 }
 
-func promptForSinks() ([]string, error) {
+func promptForSinks(preselected []string) ([]string, error) {
 	return tui.RunMultiSelect(
 		"Sinks",
 		"Operations that need protection & monitoring (database, file system, etc.)",
-		toSelectItems(sinkOptions),
+		toSelectItems(sinkOptions, preselected),
 	)
 }

--- a/cmd/zen-go/cmd_init_detect.go
+++ b/cmd/zen-go/cmd_init_detect.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/mod/modfile"
+)
+
+// parseGoModRequires reads a go.mod file and returns the set of required
+// module paths (both direct and indirect). Returns an error if the file
+// cannot be read or parsed.
+func parseGoModRequires(path string) (map[string]struct{}, error) {
+	// #nosec G304 - path is a fixed, well-known filename in the user's project
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	f, err := modfile.Parse(path, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	requires := make(map[string]struct{}, len(f.Require))
+	for _, r := range f.Require {
+		requires[r.Mod.Path] = struct{}{}
+	}
+	return requires, nil
+}
+
+// detectInstalledOptions returns the names of options whose goModulePath is
+// present in requires. Locked items and items without a goModulePath are skipped.
+func detectInstalledOptions(options []instrumentOption, requires map[string]struct{}) []string {
+	var detected []string
+	for _, opt := range options {
+		if opt.locked || opt.goModulePath == "" {
+			continue
+		}
+		if _, ok := requires[opt.goModulePath]; ok {
+			detected = append(detected, opt.name)
+		}
+	}
+	return detected
+}

--- a/cmd/zen-go/cmd_init_detect_test.go
+++ b/cmd/zen-go/cmd_init_detect_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleGoMod = `module example.com/app
+
+go 1.25
+
+require (
+	github.com/gin-gonic/gin v1.10.0
+	github.com/jackc/pgx/v5 v5.5.0
+)
+
+require (
+	github.com/some/indirect v1.0.0 // indirect
+)
+`
+
+func writeGoMod(t *testing.T, dir, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, "go.mod")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}
+
+func TestParseGoModRequires_ReturnsAllRequires(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, sampleGoMod)
+
+	requires, err := parseGoModRequires(path)
+	require.NoError(t, err)
+
+	assert.Contains(t, requires, "github.com/gin-gonic/gin")
+	assert.Contains(t, requires, "github.com/jackc/pgx/v5")
+	assert.Contains(t, requires, "github.com/some/indirect")
+}
+
+func TestParseGoModRequires_MissingFile(t *testing.T) {
+	_, err := parseGoModRequires(filepath.Join(t.TempDir(), "missing.mod"))
+	assert.Error(t, err)
+}
+
+func TestParseGoModRequires_InvalidContent(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, "this is not a valid go.mod\n")
+
+	_, err := parseGoModRequires(path)
+	assert.Error(t, err)
+}
+
+func TestDetectInstalledOptions_MatchesByModulePath(t *testing.T) {
+	requires := map[string]struct{}{
+		"github.com/gin-gonic/gin": {},
+		"github.com/jackc/pgx/v5":  {},
+	}
+
+	gotSources := detectInstalledOptions(sourceOptions, requires)
+	assert.ElementsMatch(t, []string{"gin"}, gotSources)
+
+	gotSinks := detectInstalledOptions(sinkOptions, requires)
+	assert.ElementsMatch(t, []string{"pgx"}, gotSinks)
+}
+
+func TestDetectInstalledOptions_SkipsLocked(t *testing.T) {
+	// net/http is locked in sourceOptions; it should never appear in detection.
+	requires := map[string]struct{}{
+		"net/http": {},
+	}
+	got := detectInstalledOptions(sourceOptions, requires)
+	assert.Empty(t, got)
+}
+
+func TestDetectInstalledOptions_NoMatches(t *testing.T) {
+	requires := map[string]struct{}{
+		"github.com/unrelated/lib": {},
+	}
+	assert.Empty(t, detectInstalledOptions(sourceOptions, requires))
+	assert.Empty(t, detectInstalledOptions(sinkOptions, requires))
+}
+
+func TestDetectInstalledOptions_NilRequires(t *testing.T) {
+	assert.Empty(t, detectInstalledOptions(sourceOptions, nil))
+}

--- a/cmd/zen-go/cmd_init_test.go
+++ b/cmd/zen-go/cmd_init_test.go
@@ -24,7 +24,7 @@ func TestInitCommand_DoesNotOverwriteExistingFile(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false, "", false, "", false)
+	err = initCommand(&buf, false, false, "", false, "", false)
 	require.NoError(t, err)
 
 	// Verify file content was not overwritten
@@ -143,7 +143,7 @@ func TestInitCommand_WithSourcesAndSinksFlags(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false, "gin", true, "pgx", true)
+	err = initCommand(&buf, false, false, "gin", true, "pgx", true)
 	require.NoError(t, err)
 
 	// Verify file was created
@@ -173,7 +173,7 @@ func TestInitCommand_WithInvalidSource(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false, "invalid", true, "", false)
+	err = initCommand(&buf, false, false, "invalid", true, "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid source(s): invalid")
 }
@@ -188,7 +188,7 @@ func TestInitCommand_WithEmptySourcesFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false, "", true, "pgx", true)
+	err = initCommand(&buf, false, false, "", true, "pgx", true)
 	require.NoError(t, err)
 
 	// Verify file was created
@@ -221,7 +221,7 @@ func TestInitCommand_WithEmptySinksFlag(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = initCommand(&buf, false, "gin", true, "", true)
+	err = initCommand(&buf, false, false, "gin", true, "", true)
 	require.NoError(t, err)
 
 	// Verify file was created
@@ -242,4 +242,102 @@ func TestInitCommand_WithEmptySinksFlag(t *testing.T) {
 	assert.Contains(t, output, "Created zen.tool.go")
 	assert.Contains(t, output, "Sources: gin")
 	assert.NotContains(t, output, "Sinks:")
+}
+
+func TestInitCommand_AutoSelectsFromGoMod(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	require.NoError(t, os.Chdir(tmpDir))
+	require.NoError(t, os.WriteFile("go.mod", []byte(sampleGoMod), 0o600))
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, true, "", false, "", false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile("zen.tool.go")
+	require.NoError(t, err)
+
+	contentStr := string(content)
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin")
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5")
+	assert.NotContains(t, contentStr, "labstack/echo")
+	assert.NotContains(t, contentStr, "go-chi/chi")
+
+	output := buf.String()
+	assert.Contains(t, output, "Sources: gin")
+	assert.Contains(t, output, "Sinks: pgx")
+}
+
+func TestInitCommand_AutoWithExplicitSourcesOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	require.NoError(t, os.Chdir(tmpDir))
+	require.NoError(t, os.WriteFile("go.mod", []byte(sampleGoMod), 0o600))
+
+	var buf bytes.Buffer
+	// --auto plus an explicit --sources=chi: chi should win for sources,
+	// while sinks come from go.mod detection (pgx).
+	err = initCommand(&buf, false, true, "chi", true, "", false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile("zen.tool.go")
+	require.NoError(t, err)
+	contentStr := string(content)
+
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sources/go-chi/chi.v5")
+	assert.NotContains(t, contentStr, "gin-gonic/gin")
+	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5")
+}
+
+func TestInitCommand_AutoWithMissingGoMod(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	require.NoError(t, os.Chdir(tmpDir))
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, true, "", false, "", false)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile("zen.tool.go")
+	require.NoError(t, err)
+	contentStr := string(content)
+
+	// Locked sinks/sources are still included via the base import, but no
+	// optional sections should be emitted.
+	assert.NotContains(t, contentStr, "// Aikido Zen: Sources")
+	assert.NotContains(t, contentStr, "// Aikido Zen: Sinks")
+
+	output := buf.String()
+	assert.Contains(t, output, "Could not read go.mod for auto-detection")
+}
+
+func TestToSelectItems_MarksPreselectedAsDetected(t *testing.T) {
+	items := toSelectItems(sourceOptions, []string{"gin"})
+
+	var ginItem, chiItem *struct{ selected, detected bool }
+	for _, it := range items {
+		switch it.Name {
+		case "gin":
+			ginItem = &struct{ selected, detected bool }{it.Selected, it.Detected}
+		case "chi":
+			chiItem = &struct{ selected, detected bool }{it.Selected, it.Detected}
+		}
+	}
+
+	require.NotNil(t, ginItem)
+	assert.True(t, ginItem.selected, "gin should be preselected")
+	assert.True(t, ginItem.detected, "gin should be marked detected")
+
+	require.NotNil(t, chiItem)
+	assert.False(t, chiItem.selected, "chi should not be preselected")
+	assert.False(t, chiItem.detected, "chi should not be marked detected")
 }

--- a/cmd/zen-go/cmd_init_test.go
+++ b/cmd/zen-go/cmd_init_test.go
@@ -295,7 +295,7 @@ func TestInitCommand_AutoWithExplicitSourcesOverride(t *testing.T) {
 	assert.Contains(t, contentStr, "github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5")
 }
 
-func TestInitCommand_AutoWithMissingGoMod(t *testing.T) {
+func TestInitCommand_AutoWithMissingGoModFails(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldDir, err := os.Getwd()
 	require.NoError(t, err)
@@ -305,19 +305,45 @@ func TestInitCommand_AutoWithMissingGoMod(t *testing.T) {
 
 	var buf bytes.Buffer
 	err = initCommand(&buf, false, true, "", false, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--auto requires a readable go.mod")
+
+	// File should not be created when --auto can't honor the user's intent.
+	_, statErr := os.Stat("zen.tool.go")
+	assert.True(t, os.IsNotExist(statErr), "zen.tool.go should not be written on --auto failure")
+}
+
+func TestInitCommand_AutoWithMalformedGoModFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	require.NoError(t, os.Chdir(tmpDir))
+	require.NoError(t, os.WriteFile("go.mod", []byte("this is not a valid go.mod\n"), 0o600))
+
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, true, "", false, "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--auto requires a readable go.mod")
+}
+
+func TestInitCommand_MalformedGoModWarnsWithFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	require.NoError(t, os.Chdir(tmpDir))
+	require.NoError(t, os.WriteFile("go.mod", []byte("this is not a valid go.mod\n"), 0o600))
+
+	// Use --sources/--sinks so we don't enter the interactive TUI. The warning
+	// path should fire regardless of --auto.
+	var buf bytes.Buffer
+	err = initCommand(&buf, false, false, "", true, "", true)
 	require.NoError(t, err)
 
-	content, err := os.ReadFile("zen.tool.go")
-	require.NoError(t, err)
-	contentStr := string(content)
-
-	// Locked sinks/sources are still included via the base import, but no
-	// optional sections should be emitted.
-	assert.NotContains(t, contentStr, "// Aikido Zen: Sources")
-	assert.NotContains(t, contentStr, "// Aikido Zen: Sinks")
-
-	output := buf.String()
-	assert.Contains(t, output, "Could not read go.mod for auto-detection")
+	assert.Contains(t, buf.String(), "Skipping go.mod detection")
 }
 
 func TestToSelectItems_MarksPreselectedAsDetected(t *testing.T) {

--- a/cmd/zen-go/internal/tui/multiselect.go
+++ b/cmd/zen-go/internal/tui/multiselect.go
@@ -11,8 +11,9 @@ import (
 type SelectItem struct {
 	Name        string
 	Description string
-	selected    bool
+	Selected    bool
 	Locked      bool
+	Detected    bool
 }
 
 type multiSelectModel struct {
@@ -62,7 +63,7 @@ func (m *multiSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case " ":
 			if m.cursor < len(m.items) {
-				m.items[m.cursor].selected = !m.items[m.cursor].selected
+				m.items[m.cursor].Selected = !m.items[m.cursor].Selected
 			}
 		case "enter":
 			m.done = true
@@ -144,7 +145,7 @@ func (m *multiSelectModel) renderItem(index int) string {
 	}
 
 	checkbox := "[ ]"
-	if item.selected || item.Locked {
+	if item.Selected || item.Locked {
 		checkbox = checkboxStyle.Render("[x]")
 	}
 
@@ -152,6 +153,9 @@ func (m *multiSelectModel) renderItem(index int) string {
 	desc := ""
 	if item.Description != "" {
 		desc = "  " + descStyle.Render(item.Description)
+	}
+	if item.Detected && !item.Locked {
+		desc += "  " + descStyle.Render("(detected in go.mod)")
 	}
 
 	if item.Locked {
@@ -182,7 +186,7 @@ func newMultiSelectModel(title, subtitle string, items []SelectItem) *multiSelec
 func (m *multiSelectModel) selectedItems() []string {
 	var selected []string
 	for _, item := range m.items {
-		if item.selected && !item.Locked {
+		if item.Selected && !item.Locked {
 			selected = append(selected, item.Name)
 		}
 	}

--- a/cmd/zen-go/internal/tui/multiselect_test.go
+++ b/cmd/zen-go/internal/tui/multiselect_test.go
@@ -13,9 +13,9 @@ func newTestModel() *multiSelectModel {
 		title:    "Test",
 		subtitle: "Test subtitle",
 		items: []SelectItem{
-			{Name: "a", Description: "Option A", selected: false, Locked: false},
-			{Name: "b", Description: "Option B", selected: false, Locked: false},
-			{Name: "c", Description: "Always included", selected: false, Locked: true},
+			{Name: "a", Description: "Option A", Selected: false, Locked: false},
+			{Name: "b", Description: "Option B", Selected: false, Locked: false},
+			{Name: "c", Description: "Always included", Selected: false, Locked: true},
 		},
 	}
 }
@@ -32,10 +32,10 @@ func TestMultiSelect_ToggleOptionalItem(t *testing.T) {
 	m := newTestModel()
 
 	m.Update(key(" "))
-	assert.True(t, m.items[0].selected)
+	assert.True(t, m.items[0].Selected)
 
 	m.Update(key(" "))
-	assert.False(t, m.items[0].selected)
+	assert.False(t, m.items[0].Selected)
 }
 
 func TestMultiSelect_CursorSkipsLockedItems(t *testing.T) {
@@ -120,7 +120,7 @@ func TestMultiSelect_SelectedItems(t *testing.T) {
 	// Collect selected non-locked items
 	var selected []string
 	for _, item := range m.items {
-		if item.selected && !item.Locked {
+		if item.Selected && !item.Locked {
 			selected = append(selected, item.Name)
 		}
 	}
@@ -184,9 +184,9 @@ func TestNewMultiSelectModel_CursorSkipsLeadingLockedItems(t *testing.T) {
 func TestMultiSelectModel_SelectedNames(t *testing.T) {
 	m := &multiSelectModel{
 		items: []SelectItem{
-			{Name: "a", selected: true},
-			{Name: "b", selected: false},
-			{Name: "c", selected: true, Locked: true},
+			{Name: "a", Selected: true},
+			{Name: "b", Selected: false},
+			{Name: "c", Selected: true, Locked: true},
 		},
 	}
 	assert.Equal(t, []string{"a"}, m.selectedItems())

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -31,6 +31,10 @@ func newCommand() *cli.Command {
 						Aliases: []string{"f"},
 						Usage:   "Force overwrite existing zen.tool.go file",
 					},
+					&cli.BoolFlag{
+						Name:  "auto",
+						Usage: "Auto-select sources/sinks from go.mod without interactive prompts. Combine with --sources/--sinks to override specific categories.",
+					},
 					&cli.StringFlag{
 						Name:  "sources",
 						Usage: "Comma-separated list of sources to instrument (e.g., 'gin,chi,echo/v4'). Skips interactive prompt.",
@@ -44,6 +48,7 @@ func newCommand() *cli.Command {
 					return initCommand(
 						cmd.Root().Writer,
 						cmd.Bool("force"),
+						cmd.Bool("auto"),
 						cmd.String("sources"),
 						cmd.IsSet("sources"),
 						cmd.String("sinks"),


### PR DESCRIPTION
Add flag to detect and create the zen.tool.go file automatically.
It will now also automatically select detected dependencies in normal init mode.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added --auto flag to init command to enable automatic selection.
* Implemented go.mod parsing and detection to auto-select instrumentation options.

**⚡ Enhancements**
* Changed init flow to prefer flags, auto, then interactive prompts.

**🔧 Refactors**
* Refactored TUI multiselect fields and rendering to show detected packages.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/121790692?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->