### PR TITLE
Change early return in path traversal to be case-insensitive

### DIFF
--- a/vulnerabilities/pathtraversal/detect_path_traversal.go
+++ b/vulnerabilities/pathtraversal/detect_path_traversal.go
@@ -17,15 +17,18 @@ func detectPathTraversal(filePath, userInput string, checkPathStart bool) bool {
 		return false
 	}
 
-	if !strings.Contains(strings.ToLower(filePath), strings.ToLower(userInput)) {
+	// Compared case-insensitively so apps that case-normalize the path
+	// before opening it cannot bypass detection on case-insensitive
+	// file systems (macOS APFS, Windows NTFS).
+	normalisedFilePath := strings.ToLower(filePath)
+	normalisedUserInput := strings.ToLower(userInput)
+
+	if !strings.Contains(normalisedFilePath, normalisedUserInput) {
 		// We ignore cases where the user input is not part of the file path.
-		// Compared case-insensitively so apps that case-normalize the path
-		// before opening it cannot bypass detection on case-insensitive
-		// file systems (macOS APFS, Windows NTFS).
 		return false
 	}
 
-	if containsUnsafePathParts(filePath) && containsUnsafePathParts(userInput) {
+	if containsUnsafePathParts(normalisedFilePath) && containsUnsafePathParts(normalisedUserInput) {
 		return true
 	}
 

--- a/vulnerabilities/pathtraversal/detect_path_traversal.go
+++ b/vulnerabilities/pathtraversal/detect_path_traversal.go
@@ -17,8 +17,11 @@ func detectPathTraversal(filePath, userInput string, checkPathStart bool) bool {
 		return false
 	}
 
-	if !strings.Contains(filePath, userInput) {
+	if !strings.Contains(strings.ToLower(filePath), strings.ToLower(userInput)) {
 		// We ignore cases where the user input is not part of the file path.
+		// Compared case-insensitively so apps that case-normalize the path
+		// before opening it cannot bypass detection on case-insensitive
+		// file systems (macOS APFS, Windows NTFS).
 		return false
 	}
 

--- a/vulnerabilities/pathtraversal/detect_path_traversal_test.go
+++ b/vulnerabilities/pathtraversal/detect_path_traversal_test.go
@@ -149,4 +149,20 @@ func TestDetectPathTraversal(t *testing.T) {
 		assert.True(t, detectPathTraversal("/var/a/b", "/var/a", true))
 		assert.True(t, detectPathTraversal("/var/a/b/test.txt", "/var/a", true))
 	})
+
+	t.Run("detects relative traversal when user input case differs from file path", func(t *testing.T) {
+		// App lowercases user input before opening the file: covers the
+		// bypass where filePath and userInput diverge in case.
+		assert.True(t, detectPathTraversal("/data/../etc/passwd", "../ETC/passwd", true))
+		assert.True(t, detectPathTraversal("/data/../etc/passwd", "../ETC/", true))
+		// App uppercases user input before opening the file.
+		assert.True(t, detectPathTraversal("/DATA/../ETC/PASSWD", "../etc/passwd", true))
+	})
+
+	t.Run("detects absolute paths when case differs", func(t *testing.T) {
+		assert.True(t, detectPathTraversal("/etc/passwd", "/ETC/passwd", true))
+		assert.True(t, detectPathTraversal("/ETC/PASSWD", "/etc/passwd", true))
+		assert.True(t, detectPathTraversal("/Users/admin/secret", "/users/admin/secret", true))
+		assert.True(t, detectPathTraversal("/users/admin/secret", "/Users/admin/secret", true))
+	})
 }

--- a/vulnerabilities/pathtraversal/starts_with_unsafe_path.go
+++ b/vulnerabilities/pathtraversal/starts_with_unsafe_path.go
@@ -56,7 +56,8 @@ func startsWithUnsafePath(filePath, userInput string) bool {
 			// If the user input is the same as the dangerous start, we don't want to flag it to prevent false positives
 			// e.g. if user input is /etc/ and the path is /etc/passwd, we don't want to flag it, as long as the
 			// user input does not contain a subdirectory or filename
-			if userInput == dangerousStart || userInput == dangerousStart[:len(dangerousStart)-1] {
+			lowerUserInput := strings.ToLower(userInput)
+			if lowerUserInput == dangerousStart || lowerUserInput == dangerousStart[:len(dangerousStart)-1] {
 				return false
 			}
 			return true


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Made path traversal containment checks case-insensitive by normalizing inputs
* Adjusted absolute-start detection to compare user input case-insensitively


<sup>[More info](https://app.aikido.dev/featurebranch/scan/121830830?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->