### PR TITLE
Prevent blocking/reporting deferred attacks on deferred operations

### DIFF
--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -236,6 +236,104 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 	}
 }
 
+func TestChainedJoinsNoAttackWhenOpenFileNotCalled(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	request.WrapWithGLS(ctx, func() {
+		// First join stores a deferred attack
+		first := filepath.Join("/tmp/", "../test.txt")
+		// Second join should not prematurely report the deferred attack
+		_ = filepath.Join(first, "extra")
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		t.Fatal("attack should not be reported when os.OpenFile is not called")
+	case <-time.After(100 * time.Millisecond):
+		// Success - no attack event should be sent
+	}
+}
+
+func TestChainedJoinsAttackReportedOnceWhenOpenFileCalled(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	attackCount := int64(0)
+	client := newMockClient()
+	originalSend := client.sendAttackDetectedEvent
+	client.sendAttackDetectedEvent = func(agentInfo cloud.AgentInfo, req aikido_types.RequestInfo, attack aikido_types.AttackDetails) {
+		atomic.AddInt64(&attackCount, 1)
+		originalSend(agentInfo, req, attack)
+	}
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	request.WrapWithGLS(ctx, func() {
+		first := filepath.Join("/tmp/", "../test.txt")
+		second := filepath.Join(first, "extra")
+		_, _ = os.OpenFile(second, os.O_RDONLY, 0o600)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "GET", client.capturedRequest.Method)
+		assert.Equal(t, "127.0.0.1", client.capturedRequest.IPAddress)
+		assert.Equal(t, "http://example.com/route?path=../test.txt", client.capturedRequest.URL)
+		assert.Equal(t, "test", client.capturedRequest.Source)
+		assert.Equal(t, "/route", client.capturedRequest.Route)
+
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.False(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../test.txt", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+		assert.Equal(t, ".path", client.capturedAttack.Path)
+		assert.Equal(t, map[string]string{"filename": "/tmp/../test.txt"}, client.capturedAttack.Metadata)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&attackCount), "attack should only be reported once")
+}
+
 func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 	require.NoError(t, zen.Protect())
 

--- a/vulnerabilities/scan.go
+++ b/vulnerabilities/scan.go
@@ -60,12 +60,11 @@ func ScanWithOptions[T any](ctx context.Context, operation string, vulnerability
 
 	deferredAttack := reqCtx.GetDeferredAttack()
 	if deferredAttack != nil && deferredAttack.Kind == string(vulnerability.Kind) {
-		reportDeferredAttack(ctx)
-
-		// If blocking is enabled, there will be an error to return to block the request
-		if deferredAttack.Error != nil {
+		if !opts.DeferReporting {
+			reportDeferredAttack(ctx)
 			return deferredAttack.Error
 		}
+		return nil
 	}
 
 	err := scanSource(ctx, "query", reqCtx.Query, operation, vulnerability, args, opts)

--- a/vulnerabilities/scan_test.go
+++ b/vulnerabilities/scan_test.go
@@ -479,6 +479,69 @@ func TestScanWithOptions_ModuleIsPassedThrough(t *testing.T) {
 	}
 }
 
+func TestScanWithOptions_DeferReportingReturnsNilWhenDeferredAttackExists(t *testing.T) {
+	ip := "127.0.0.1"
+	args := mockScanArgs{Value: "test"}
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+	defer config.SetBlocking(original)
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	reqCtx := request.GetContext(ctx)
+	reqCtx.SetDeferredAttack(&request.DeferredAttack{
+		Kind:  string(KindSQLInjection),
+		Error: &AttackDetectedError{Kind: KindSQLInjection, Operation: "testOp"},
+	})
+
+	err := ScanWithOptions(ctx, "testOp", mockVulnerability, args, ScanOptions{DeferReporting: true})
+	assert.NoError(t, err, "DeferReporting: true should return nil even when a deferred attack with a block error exists")
+}
+
+func TestScanWithOptions_NonDeferredBlocksAndReportsExistingDeferredAttack(t *testing.T) {
+	ip := "127.0.0.1"
+	args := mockScanArgs{Value: "test"}
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+	defer config.SetBlocking(original)
+
+	originalClient := agent.GetCloudClient()
+	client := &mockCloudClient{attackDetectedEventSent: make(chan struct{}, 1)}
+	agent.SetCloudClient(client)
+	t.Cleanup(func() { agent.SetCloudClient(originalClient) })
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/test",
+		RemoteAddress: &ip,
+	})
+
+	blockErr := &AttackDetectedError{Kind: KindSQLInjection, Operation: "testOp"}
+	reqCtx := request.GetContext(ctx)
+	reqCtx.SetDeferredAttack(&request.DeferredAttack{
+		Kind:  string(KindSQLInjection),
+		Error: blockErr,
+	})
+
+	err := ScanWithOptions(ctx, "testOp", mockVulnerability, args, ScanOptions{DeferReporting: false})
+	require.ErrorAs(t, err, new(*AttackDetectedError), "should return the block error from the deferred attack")
+
+	select {
+	case <-client.attackDetectedEventSent:
+		// reported correctly
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
 func TestScan_ShouldProtect(t *testing.T) {
 	ip := "127.0.0.1"
 	args := mockScanArgs{Value: "test"}


### PR DESCRIPTION
It was possible for attacks to be prematurely reported in some cases, for example, if you had multiple `path.Join`, the second `path.Join` would trigger a report of the attack even though no actual attack could have taken place, until a later `os.OpenFile`/etc.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Handled DeferReporting option to suppress immediate reports and errors
* Stored deferred attack instead of reporting when defer reporting enabled

**🐛 Bugfixes**
* Prevented premature reporting and blocking of deferred attacks on deferred operations


<sup>[More info](https://app.aikido.dev/featurebranch/scan/122270086?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->