### PR TITLE
Add instrumentation for filepath.Glob/Walk/WalkDir

### DIFF
--- a/instrumentation/sinks/path/filepath/examine.go
+++ b/instrumentation/sinks/path/filepath/examine.go
@@ -11,24 +11,39 @@ import (
 	"github.com/AikidoSec/firewall-go/zen"
 )
 
-func Examine(args []string) error {
+// Examine is the hook entry point for functions that directly open the filesystem (e.g. Walk, WalkDir, Glob).
+func Examine(operationName, path string) error {
 	if zen.IsDisabled() {
 		return nil
 	}
 
-	hooks.OnOperationCall("path/filepath.Join", operation.KindFileSystem)
+	hooks.OnOperationCall(operationName, operation.KindFileSystem)
 
-	path := strings.Join(args, "")
+	return vulnerabilities.ScanWithOptions(context.Background(), operationName, pathtraversal.PathTraversalVulnerability, &pathtraversal.ScanArgs{
+		FilePath:       path,
+		CheckPathStart: true,
+	}, vulnerabilities.ScanOptions{
+		DeferReporting: false,
+		Module:         "path/filepath",
+	})
+}
 
-	// The error that the vulnerability scan returns is deferred with filepath.Join
-	// We delay blocking and reporting until the result is used in os.OpenFile
-	err := vulnerabilities.ScanWithOptions(context.Background(), "filepath.Join", pathtraversal.PathTraversalVulnerability, &pathtraversal.ScanArgs{
+// ExamineDeferred is the hook entry point for path-building functions that cannot return an error (e.g. Join).
+// Blocking is deferred until the result is used in a filesystem operation.
+func ExamineDeferred(operationName string, elems []string) error {
+	if zen.IsDisabled() {
+		return nil
+	}
+
+	hooks.OnOperationCall(operationName, operation.KindFileSystem)
+
+	path := strings.Join(elems, "")
+
+	return vulnerabilities.ScanWithOptions(context.Background(), operationName, pathtraversal.PathTraversalVulnerability, &pathtraversal.ScanArgs{
 		FilePath:       path,
 		CheckPathStart: true,
 	}, vulnerabilities.ScanOptions{
 		DeferReporting: true,
 		Module:         "path/filepath",
 	})
-
-	return err
 }

--- a/instrumentation/sinks/path/filepath/examine_test.go
+++ b/instrumentation/sinks/path/filepath/examine_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExamineDeferred_ReturnsEarlyWhenDisabled(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	zen.SetDisabled(true)
+	require.True(t, zen.IsDisabled())
+
+	err := filepath.ExamineDeferred("filepath.Join", []string{"..", "etc", "passwd"})
+	require.NoError(t, err)
+}
+
 func TestExamine_ReturnsEarlyWhenDisabled(t *testing.T) {
 	originalDisabled := zen.IsDisabled()
 	defer zen.SetDisabled(originalDisabled)
@@ -19,8 +30,31 @@ func TestExamine_ReturnsEarlyWhenDisabled(t *testing.T) {
 	zen.SetDisabled(true)
 	require.True(t, zen.IsDisabled())
 
-	err := filepath.Examine([]string{"..", "etc", "passwd"})
+	err := filepath.Examine("filepath.Walk", "/tmp/safe")
 	require.NoError(t, err)
+}
+
+func TestExamineDeferred_TracksJoinOperationStats(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+
+	mockClient := testutil.NewMockCloudClient()
+	agent.SetCloudClient(mockClient)
+
+	agent.Stats().GetAndClear()
+
+	_ = filepath.ExamineDeferred("filepath.Join", []string{"tmp", "file1.txt"})
+	_ = filepath.ExamineDeferred("filepath.Join", []string{"var", "log", "test.log"})
+	_ = filepath.ExamineDeferred("filepath.Join", []string{"home", "user", "data"})
+
+	stats := agent.Stats().GetAndClear()
+	require.Contains(t, stats.Operations, "filepath.Join")
+	require.Equal(t, 3, stats.Operations["filepath.Join"].Total, "should track 3 filepath.Join operations")
 }
 
 func TestExamine_TracksOperationStats(t *testing.T) {
@@ -35,16 +69,17 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 	mockClient := testutil.NewMockCloudClient()
 	agent.SetCloudClient(mockClient)
 
-	// Clear stats before test
 	agent.Stats().GetAndClear()
 
-	// Join multiple paths
-	_ = filepath.Examine([]string{"tmp", "file1.txt"})
-	_ = filepath.Examine([]string{"var", "log", "test.log"})
-	_ = filepath.Examine([]string{"home", "user", "data"})
+	_ = filepath.Examine("filepath.Walk", "/tmp/a")
+	_ = filepath.Examine("filepath.WalkDir", "/tmp/b")
+	_ = filepath.Examine("filepath.Glob", "/tmp/*.txt")
 
-	// Get stats and verify operations were tracked
 	stats := agent.Stats().GetAndClear()
-	require.Contains(t, stats.Operations, "path/filepath.Join")
-	require.Equal(t, 3, stats.Operations["path/filepath.Join"].Total, "should track 3 filepath.Join operations")
+	require.Contains(t, stats.Operations, "filepath.Walk")
+	require.Equal(t, 1, stats.Operations["filepath.Walk"].Total)
+	require.Contains(t, stats.Operations, "filepath.WalkDir")
+	require.Equal(t, 1, stats.Operations["filepath.WalkDir"].Total)
+	require.Contains(t, stats.Operations, "filepath.Glob")
+	require.Equal(t, 1, stats.Operations["filepath.Glob"].Total)
 }

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -334,6 +334,251 @@ func TestChainedJoinsAttackReportedOnceWhenOpenFileCalled(t *testing.T) {
 	assert.Equal(t, int64(1), atomic.LoadInt64(&attackCount), "attack should only be reported once")
 }
 
+func TestGlobPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	request.WrapWithGLS(ctx, func() {
+		target := filepath.Join(sub, "../sub")
+		_, _ = filepath.Glob(target + "/*")
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.False(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../sub", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestWalkPathInjectionBlockIsDeferred(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	request.WrapWithGLS(ctx, func() {
+		target := filepath.Join(sub, "../sub")
+
+		err := filepath.Walk(target, func(path string, info fs.FileInfo, err error) error {
+			return err
+		})
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.True(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../sub", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestWalkPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	request.WrapWithGLS(ctx, func() {
+		target := filepath.Join(sub, "../sub")
+
+		err := filepath.Walk(target, func(path string, info fs.FileInfo, err error) error {
+			return err
+		})
+		require.NoError(t, err)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.False(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../sub", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestWalkDirPathInjectionBlockIsDeferred(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	request.WrapWithGLS(ctx, func() {
+		target := filepath.Join(sub, "../sub")
+
+		err := filepath.WalkDir(target, func(path string, d fs.DirEntry, err error) error {
+			return err
+		})
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.True(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../sub", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
+func TestWalkDirPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(false)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	require.NoError(t, os.Mkdir(sub, 0o755))
+
+	request.WrapWithGLS(ctx, func() {
+		target := filepath.Join(sub, "../sub")
+
+		err := filepath.WalkDir(target, func(path string, d fs.DirEntry, err error) error {
+			return err
+		})
+		require.NoError(t, err)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.False(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "../sub", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
 func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 	require.NoError(t, zen.Protect())
 

--- a/instrumentation/sinks/path/filepath/zen.instrument.yml
+++ b/instrumentation/sinks/path/filepath/zen.instrument.yml
@@ -3,7 +3,6 @@ meta:
   description: Protection from Local File Inclusion (LFI) Attacks.
 
 rules:
-  # Inject go:linkname declaration for Examine
   - id: filepath.Examine.linkname
     type: inject-decl
     package: path/filepath
@@ -12,11 +11,43 @@ rules:
       - github.com/AikidoSec/firewall-go/instrumentation/sinks/path/filepath
     template: |
       //go:linkname __aikido_filepath_Examine github.com/AikidoSec/firewall-go/instrumentation/sinks/path/filepath.Examine
-      func __aikido_filepath_Examine([]string) error
+      func __aikido_filepath_Examine(string, string) error
+      //go:linkname __aikido_filepath_ExamineDeferred github.com/AikidoSec/firewall-go/instrumentation/sinks/path/filepath.ExamineDeferred
+      func __aikido_filepath_ExamineDeferred(string, []string) error
 
   - id: filepath.Join
     type: prepend
     package: path/filepath
     function: Join
     template: |
-      __aikido_filepath_Examine({{ .Function.Argument 0 }})
+      __aikido_filepath_ExamineDeferred("filepath.Join", {{ .Function.Argument 0 }})
+
+  - id: filepath.Walk
+    type: prepend
+    package: path/filepath
+    function: Walk
+    template: |
+      _aikido_block := __aikido_filepath_Examine("filepath.Walk", {{ .Function.Argument 0 }})
+      if _aikido_block != nil {
+        return _aikido_block
+      }
+
+  - id: filepath.WalkDir
+    type: prepend
+    package: path/filepath
+    function: WalkDir
+    template: |
+      _aikido_block := __aikido_filepath_Examine("filepath.WalkDir", {{ .Function.Argument 0 }})
+      if _aikido_block != nil {
+        return _aikido_block
+      }
+
+  - id: filepath.Glob
+    type: prepend
+    package: path/filepath
+    function: Glob
+    template: |
+      _aikido_block := __aikido_filepath_Examine("filepath.Glob", {{ .Function.Argument 0 }})
+      if _aikido_block != nil {
+        return nil, _aikido_block
+      }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added instrumentation rules for filepath.Walk, WalkDir, and Glob.
* Modified filepath.Join instrumentation to defer examination via ExamineDeferred.
* Introduced ExamineDeferred to perform deferred vulnerability scanning for joins.

**🔧 Refactors**
* Changed Examine signature to accept operation name and single path.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/122895237?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->