### PR TITLE
Use FindGoMod to locate go.mod for dependency detection

### DIFF
--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -154,7 +154,7 @@ func initCommand(stdout io.Writer, force, auto bool, sourcesFlag string, sources
 	// Detect installed instrumentation targets from go.mod.
 	// Under --auto, any go.mod failure is fatal — the user explicitly delegated
 	// selection to go.mod. Otherwise we log and fall back to empty detection.
-	requires, modErr := parseGoModRequires("go.mod")
+	requires, modErr := loadProjectGoMod()
 	if modErr != nil {
 		if auto {
 			return fmt.Errorf("--auto requires a readable go.mod: %w", modErr)

--- a/cmd/zen-go/cmd_init_detect.go
+++ b/cmd/zen-go/cmd_init_detect.go
@@ -4,8 +4,21 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
 	"golang.org/x/mod/modfile"
 )
+
+func loadProjectGoMod() (map[string]struct{}, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("get working directory: %w", err)
+	}
+	gomodPath := rules.FindGoMod(cwd)
+	if gomodPath == "" {
+		return nil, fmt.Errorf("go.mod not found in %s or any parent directory", cwd)
+	}
+	return parseGoModRequires(gomodPath)
+}
 
 // parseGoModRequires reads a go.mod file and returns the set of required
 // module paths (both direct and indirect). Returns an error if the file


### PR DESCRIPTION
Ensures you can run `zen-go --auto` from a child directory. This is important when you have `package main` not in the root.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Made go.mod detection search parent directories using rules.FindGoMod

**🔧 Refactors**
* Introduced loadProjectGoMod wrapper and replaced direct parseGoModRequires call


<sup>[More info](https://app.aikido.dev/featurebranch/scan/122890285?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->