### PR TITLE
Trim user input before sending to detectSQLInjection

### DIFF
--- a/vulnerabilities/sqlinjection/detect_sql_injection.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection.go
@@ -17,7 +17,7 @@ const (
 func detectSQLInjection(query string, userInput string, dialect int) int {
 	// Lowercase versions of query and user input
 	queryLowercase := strings.ToLower(query)
-	userInputLowercase := strings.ToLower(userInput)
+	userInputLowercase := strings.TrimSpace(strings.ToLower(userInput))
 
 	if shouldReturnEarly(queryLowercase, userInputLowercase) {
 		return sqlInjectionSafe

--- a/vulnerabilities/sqlinjection/detect_sql_injection_test.go
+++ b/vulnerabilities/sqlinjection/detect_sql_injection_test.go
@@ -125,6 +125,12 @@ func TestIsSQLInjection(t *testing.T) {
 				   first_name,
 				   last_name
 			FROM users WHERE email_lowercase = '' or 1=1 -- a',`, "' OR 1=1 -- a"},
+
+		// it detects injection when user input has trailing whitespace (trimmed by DB driver)
+		{
+			"INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+			"x', 'dummy'), ('injected', 'hacker'); --    ",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Trims leading/trailing whitespace from user input before SQL injection detection, matching the fix applied to the Java firewall in AikidoSec/firewall-java#298.

**Problem**: An attacker can pad their payload with trailing whitespace (e.g. `"payload   "`). If the DB driver trims this before execution, the SQL query won't contain the padded input, causing `shouldReturnEarly` to incorrectly return `true` (missed detection).

**Fix**: Apply `strings.TrimSpace` after `strings.ToLower` for the user input before both the early-return check and the zen-internals detection call.

See: https://github.com/AikidoSec/firewall-java/pull/298

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Trimmed user input whitespace before SQL injection detection logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124637442?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->