### PR TITLE
Count 404 requests with foreign extensions as attack wave scans

### DIFF
--- a/instrumentation/http/on_post_request.go
+++ b/instrumentation/http/on_post_request.go
@@ -18,7 +18,7 @@ func OnPostRequest(ctx context.Context, statusCode int) {
 	}
 
 	// Check wave is run during post request so that we have the user in the context
-	if agent.CheckAttackWave(reqCtx) {
+	if agent.CheckAttackWave(reqCtx, statusCode) {
 		go agent.OnAttackWaveDetected(reqCtx)
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -157,8 +157,8 @@ func OnMiddlewareInstalled() {
 	stateCollector.SetMiddlewareInstalled(true)
 }
 
-func CheckAttackWave(ctx *request.Context) bool {
-	return attackWaveDetector.CheckRequest(ctx)
+func CheckAttackWave(ctx *request.Context, statusCode int) bool {
+	return attackWaveDetector.CheckRequest(ctx, statusCode)
 }
 
 type DetectedAttackWave struct {

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -196,7 +196,7 @@ func TestGetRateLimitingStatus(t *testing.T) {
 
 func TestCheckAttackWave(t *testing.T) {
 	t.Run("returns false for nil context", func(t *testing.T) {
-		result := CheckAttackWave(nil)
+		result := CheckAttackWave(nil, 200)
 		assert.False(t, result)
 	})
 
@@ -205,7 +205,7 @@ func TestCheckAttackWave(t *testing.T) {
 			Method: "GET",
 			URL:    "/clean",
 		}
-		result := CheckAttackWave(ctx)
+		result := CheckAttackWave(ctx, 200)
 		assert.False(t, result)
 	})
 }
@@ -252,7 +252,7 @@ func TestOnAttackWaveDetected(t *testing.T) {
 			Path:          "/.env",
 			URL:           "http://example.com/.env",
 		}
-		attackWaveDetector.CheckRequest(scanCtx)
+		attackWaveDetector.CheckRequest(scanCtx, 404)
 
 		ctx := &request.Context{
 			RemoteAddress: &ip,

--- a/internal/attackwave/detector.go
+++ b/internal/attackwave/detector.go
@@ -78,7 +78,7 @@ func NewDetector(opts *Options) *Detector {
 
 // CheckRequest checks if the request is part of an attack wave
 // Returns true if an attack wave is detected and should be reported
-func (d *Detector) CheckRequest(ctx *request.Context) bool {
+func (d *Detector) CheckRequest(ctx *request.Context, statusCode int) bool {
 	if ctx == nil || ctx.RemoteAddress == nil || *ctx.RemoteAddress == "" {
 		return false
 	}
@@ -90,7 +90,7 @@ func (d *Detector) CheckRequest(ctx *request.Context) bool {
 		return false
 	}
 
-	if !isWebScanner(ctx) {
+	if !isWebScanner(ctx, statusCode) {
 		return false
 	}
 

--- a/internal/attackwave/detector_test.go
+++ b/internal/attackwave/detector_test.go
@@ -16,7 +16,7 @@ func TestDetectorCheck(t *testing.T) {
 			AttackWaveTimeFrame: 60 * time.Second,
 		})
 
-		result := detector.CheckRequest(nil)
+		result := detector.CheckRequest(nil, 404)
 		assert.False(t, result)
 	})
 
@@ -27,7 +27,7 @@ func TestDetectorCheck(t *testing.T) {
 		})
 
 		ctx := &request.Context{}
-		result := detector.CheckRequest(ctx)
+		result := detector.CheckRequest(ctx, 404)
 		assert.False(t, result)
 	})
 
@@ -44,7 +44,7 @@ func TestDetectorCheck(t *testing.T) {
 			Path:          "/api/users",
 		}
 
-		result := detector.CheckRequest(ctx)
+		result := detector.CheckRequest(ctx, 404)
 		assert.False(t, result)
 	})
 
@@ -62,14 +62,14 @@ func TestDetectorCheck(t *testing.T) {
 		}
 
 		// First two checks should return false
-		result := detector.CheckRequest(ctx)
+		result := detector.CheckRequest(ctx, 404)
 		assert.False(t, result, "First suspicious request should not trigger")
 
-		result = detector.CheckRequest(ctx)
+		result = detector.CheckRequest(ctx, 404)
 		assert.False(t, result, "Second suspicious request should not trigger")
 
 		// Third check should return true (threshold reached)
-		result = detector.CheckRequest(ctx)
+		result = detector.CheckRequest(ctx, 404)
 		assert.True(t, result, "Third suspicious request should trigger attack wave")
 	})
 
@@ -93,18 +93,18 @@ func TestDetectorCheck(t *testing.T) {
 		}
 
 		// IP1: 2 requests
-		detector.CheckRequest(ctx1)
-		detector.CheckRequest(ctx1)
+		detector.CheckRequest(ctx1, 404)
+		detector.CheckRequest(ctx1, 404)
 
 		// IP2: 2 requests
-		detector.CheckRequest(ctx2)
-		detector.CheckRequest(ctx2)
+		detector.CheckRequest(ctx2, 404)
+		detector.CheckRequest(ctx2, 404)
 
 		// Neither should trigger yet
-		result1 := detector.CheckRequest(ctx1)
+		result1 := detector.CheckRequest(ctx1, 404)
 		assert.True(t, result1, "IP1 should trigger on third request")
 
-		result2 := detector.CheckRequest(ctx2)
+		result2 := detector.CheckRequest(ctx2, 404)
 		assert.True(t, result2, "IP2 should trigger on third request")
 	})
 
@@ -122,13 +122,13 @@ func TestDetectorCheck(t *testing.T) {
 		}
 
 		// Trigger attack wave
-		detector.CheckRequest(ctx)
-		result := detector.CheckRequest(ctx)
+		detector.CheckRequest(ctx, 404)
+		result := detector.CheckRequest(ctx, 404)
 		assert.True(t, result, "Should trigger attack wave")
 
 		// Immediate subsequent check should return false (even with more suspicious requests)
 		for i := 0; i < 3; i++ {
-			result = detector.CheckRequest(ctx)
+			result = detector.CheckRequest(ctx, 404)
 			assert.False(t, result, "Should not trigger again immediately (attempt %d)", i+1)
 		}
 
@@ -137,7 +137,7 @@ func TestDetectorCheck(t *testing.T) {
 
 		// After waiting, the next suspicious request should trigger again
 		// Since the counter is still incrementing during the waiting period
-		result = detector.CheckRequest(ctx)
+		result = detector.CheckRequest(ctx, 404)
 		assert.True(t, result, "Should trigger again after waiting")
 	})
 
@@ -155,9 +155,9 @@ func TestDetectorCheck(t *testing.T) {
 			URL:           "http://example.com/.env",
 		}
 
-		detector.CheckRequest(ctx)
-		detector.CheckRequest(ctx)
-		detector.CheckRequest(ctx)
+		detector.CheckRequest(ctx, 404)
+		detector.CheckRequest(ctx, 404)
+		detector.CheckRequest(ctx, 404)
 
 		samples := detector.GetSamplesForIP(ip)
 		assert.Len(t, samples, 1, "Should have 1 unique sample")
@@ -180,8 +180,8 @@ func TestDetectorCheck(t *testing.T) {
 			Path:          "/.env",
 			URL:           "http://example.com/.env",
 		}
-		detector.CheckRequest(ctx1)
-		detector.CheckRequest(ctx1)
+		detector.CheckRequest(ctx1, 404)
+		detector.CheckRequest(ctx1, 404)
 
 		// Different request
 		ctx2 := &request.Context{
@@ -190,7 +190,7 @@ func TestDetectorCheck(t *testing.T) {
 			Path:          "/.git/config",
 			URL:           "http://example.com/.git/config",
 		}
-		detector.CheckRequest(ctx2)
+		detector.CheckRequest(ctx2, 404)
 
 		samples := detector.GetSamplesForIP(ip)
 		assert.Len(t, samples, 2, "Should have 2 unique samples")
@@ -213,7 +213,7 @@ func TestDetectorCheck(t *testing.T) {
 				Path:          path,
 				URL:           "http://example.com" + path,
 			}
-			detector.CheckRequest(ctx)
+			detector.CheckRequest(ctx, 404)
 		}
 
 		samples := detector.GetSamplesForIP(ip)

--- a/internal/attackwave/is_web_scanner.go
+++ b/internal/attackwave/is_web_scanner.go
@@ -3,7 +3,7 @@ package attackwave
 import "github.com/AikidoSec/firewall-go/internal/request"
 
 // isWebScanner checks if the request looks like a web scanner or attack tool
-func isWebScanner(ctx *request.Context) bool {
+func isWebScanner(ctx *request.Context, statusCode int) bool {
 	if ctx == nil {
 		return false
 	}
@@ -12,7 +12,7 @@ func isWebScanner(ctx *request.Context) bool {
 		return true
 	}
 
-	if ctx.Path != "" && isSuspiciousPath(ctx.Path) {
+	if ctx.Path != "" && isSuspiciousPath(ctx.Path, statusCode) {
 		return true
 	}
 

--- a/internal/attackwave/is_web_scanner_test.go
+++ b/internal/attackwave/is_web_scanner_test.go
@@ -9,14 +9,16 @@ import (
 
 func TestIsWebScanner(t *testing.T) {
 	tests := []struct {
-		name     string
-		ctx      *request.Context
-		expected bool
+		name       string
+		ctx        *request.Context
+		statusCode int
+		expected   bool
 	}{
 		{
-			name:     "nil context",
-			ctx:      nil,
-			expected: false,
+			name:       "nil context",
+			ctx:        nil,
+			statusCode: 200,
+			expected:   false,
 		},
 		{
 			name: "normal request",
@@ -24,7 +26,8 @@ func TestIsWebScanner(t *testing.T) {
 				Method: "GET",
 				Path:   "/api/users",
 			},
-			expected: false,
+			statusCode: 200,
+			expected:   false,
 		},
 		{
 			name: "suspicious method",
@@ -32,7 +35,8 @@ func TestIsWebScanner(t *testing.T) {
 				Method: "BADMETHOD",
 				Path:   "/api/users",
 			},
-			expected: true,
+			statusCode: 200,
+			expected:   true,
 		},
 		{
 			name: "suspicious path - .env",
@@ -40,7 +44,8 @@ func TestIsWebScanner(t *testing.T) {
 				Method: "GET",
 				Path:   "/.env",
 			},
-			expected: true,
+			statusCode: 404,
+			expected:   true,
 		},
 		{
 			name: "suspicious path - .git",
@@ -48,7 +53,8 @@ func TestIsWebScanner(t *testing.T) {
 				Method: "GET",
 				Path:   "/.git/config",
 			},
-			expected: true,
+			statusCode: 404,
+			expected:   true,
 		},
 		{
 			name: "suspicious path - wp-config.php",
@@ -56,7 +62,8 @@ func TestIsWebScanner(t *testing.T) {
 				Method: "GET",
 				Path:   "/wp-config.php",
 			},
-			expected: true,
+			statusCode: 404,
+			expected:   true,
 		},
 		{
 			name: "suspicious query - SQL injection",
@@ -67,7 +74,8 @@ func TestIsWebScanner(t *testing.T) {
 					"q": {"SELECT * FROM users"},
 				},
 			},
-			expected: true,
+			statusCode: 200,
+			expected:   true,
 		},
 		{
 			name: "suspicious query - path traversal",
@@ -78,7 +86,8 @@ func TestIsWebScanner(t *testing.T) {
 					"path": {"../../etc/passwd"},
 				},
 			},
-			expected: true,
+			statusCode: 200,
+			expected:   true,
 		},
 		{
 			name: "normal query parameters",
@@ -90,13 +99,14 @@ func TestIsWebScanner(t *testing.T) {
 					"page": {"1"},
 				},
 			},
-			expected: false,
+			statusCode: 200,
+			expected:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isWebScanner(tt.ctx)
+			result := isWebScanner(tt.ctx, tt.statusCode)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/attackwave/suspicious_paths.go
+++ b/internal/attackwave/suspicious_paths.go
@@ -4,8 +4,25 @@ import (
 	"strings"
 )
 
-// isSuspiciousPath checks if the path contains patterns commonly targeted by scanners
-func isSuspiciousPath(path string) bool {
+// foreignExtensions are extensions that a Go app wouldn't natively serve.
+// Requests to these extensions are only counted as scan hits when the response
+// is 404 — a 200 may indicate the app proxies to another backend.
+var foreignExtensions = map[string]bool{
+	"php":   true,
+	"php3":  true,
+	"php4":  true,
+	"php5":  true,
+	"phtml": true,
+	"java":  true,
+	"jsp":   true,
+	"jspx":  true,
+}
+
+// isSuspiciousPath checks if the path contains patterns commonly targeted by scanners.
+// statusCode is required to disambiguate foreign-extension paths: they are only
+// suspicious when the server returns 404 (a 200 might mean the app proxies to a
+// PHP/Java backend).
+func isSuspiciousPath(path string, statusCode int) bool {
 	normalized := strings.ToLower(path)
 	segments := strings.Split(normalized, "/")
 
@@ -26,6 +43,9 @@ func isSuspiciousPath(path string) bool {
 		if len(parts) > 1 {
 			ext := parts[len(parts)-1]
 			if suspiciousExtensions[ext] {
+				return true
+			}
+			if foreignExtensions[ext] && statusCode == 404 {
 				return true
 			}
 		}

--- a/internal/attackwave/suspicious_paths_test.go
+++ b/internal/attackwave/suspicious_paths_test.go
@@ -8,162 +8,216 @@ import (
 
 func TestIsSuspiciousPath(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		expected bool
+		name       string
+		path       string
+		statusCode int
+		expected   bool
 	}{
 		// Normal paths
 		{
-			name:     "normal API path",
-			path:     "/api/users",
-			expected: false,
+			name:       "normal API path",
+			path:       "/api/users",
+			statusCode: 200,
+			expected:   false,
 		},
 		{
-			name:     "normal file path",
-			path:     "/images/logo.png",
-			expected: false,
+			name:       "normal file path",
+			path:       "/images/logo.png",
+			statusCode: 200,
+			expected:   false,
 		},
 
 		// Suspicious filenames
 		{
-			name:     ".env file",
-			path:     "/.env",
-			expected: true,
+			name:       ".env file",
+			path:       "/.env",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".env in subdirectory",
-			path:     "/app/.env",
-			expected: true,
+			name:       ".env in subdirectory",
+			path:       "/app/.env",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".gitignore",
-			path:     "/.gitignore",
-			expected: true,
+			name:       ".gitignore",
+			path:       "/.gitignore",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "wp-config.php",
-			path:     "/wp-config.php",
-			expected: true,
+			name:       "wp-config.php",
+			path:       "/wp-config.php",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "config.json",
-			path:     "/config.json",
-			expected: true,
+			name:       "config.json",
+			path:       "/config.json",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "docker-compose.yml",
-			path:     "/docker-compose.yml",
-			expected: true,
+			name:       "docker-compose.yml",
+			path:       "/docker-compose.yml",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".htaccess",
-			path:     "/.htaccess",
-			expected: true,
+			name:       ".htaccess",
+			path:       "/.htaccess",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "passwd",
-			path:     "/etc/passwd",
-			expected: true,
+			name:       "passwd",
+			path:       "/etc/passwd",
+			statusCode: 404,
+			expected:   true,
 		},
 
 		// Suspicious extensions
 		{
-			name:     ".bak extension",
-			path:     "/backup.bak",
-			expected: true,
+			name:       ".bak extension",
+			path:       "/backup.bak",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".sql extension",
-			path:     "/dump.sql",
-			expected: true,
+			name:       ".sql extension",
+			path:       "/dump.sql",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".db extension",
-			path:     "/data.db",
-			expected: true,
+			name:       ".db extension",
+			path:       "/data.db",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".old extension",
-			path:     "/config.old",
-			expected: true,
+			name:       ".old extension",
+			path:       "/config.old",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".sqlite extension",
-			path:     "/database.sqlite",
-			expected: true,
+			name:       ".sqlite extension",
+			path:       "/database.sqlite",
+			statusCode: 404,
+			expected:   true,
 		},
 
 		// Suspicious directories
 		{
-			name:     ".git directory",
-			path:     "/.git/config",
-			expected: true,
+			name:       ".git directory",
+			path:       "/.git/config",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".ssh directory",
-			path:     "/.ssh/id_rsa",
-			expected: true,
+			name:       ".ssh directory",
+			path:       "/.ssh/id_rsa",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".docker directory",
-			path:     "/.docker/config.json",
-			expected: true,
+			name:       ".docker directory",
+			path:       "/.docker/config.json",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".aws directory",
-			path:     "/.aws/credentials",
-			expected: true,
+			name:       ".aws directory",
+			path:       "/.aws/credentials",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     ".kube directory",
-			path:     "/.kube/config",
-			expected: true,
+			name:       ".kube directory",
+			path:       "/.kube/config",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "tmp directory",
-			path:     "/tmp/shell.php",
-			expected: true,
+			name:       "tmp directory",
+			path:       "/tmp/shell.php",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "apache directory",
-			path:     "/apache/httpd.conf",
-			expected: true,
+			name:       "apache directory",
+			path:       "/apache/httpd.conf",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "system32 directory",
-			path:     "C:/System32",
-			expected: true,
+			name:       "system32 directory",
+			path:       "C:/System32",
+			statusCode: 404,
+			expected:   true,
 		},
 
 		// Case insensitivity
 		{
-			name:     "uppercase .ENV",
-			path:     "/.ENV",
-			expected: true,
+			name:       "uppercase .ENV",
+			path:       "/.ENV",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "mixed case .Git",
-			path:     "/.Git/config",
-			expected: true,
+			name:       "mixed case .Git",
+			path:       "/.Git/config",
+			statusCode: 404,
+			expected:   true,
 		},
 
 		// Path traversal patterns
 		{
-			name:     "parent directory access",
-			path:     "/../../etc/passwd",
-			expected: true,
+			name:       "parent directory access",
+			path:       "/../../etc/passwd",
+			statusCode: 404,
+			expected:   true,
 		},
 		{
-			name:     "current directory",
-			path:     "/./etc/passwd",
-			expected: true,
+			name:       "current directory",
+			path:       "/./etc/passwd",
+			statusCode: 404,
+			expected:   true,
+		},
+
+		// Foreign extensions — only suspicious on 404
+		{
+			name:       "php extension with 404",
+			path:       "/admin.php",
+			statusCode: 404,
+			expected:   true,
+		},
+		{
+			name:       "php extension with 200 (may be proxied)",
+			path:       "/admin.php",
+			statusCode: 200,
+			expected:   false,
+		},
+		{
+			name:       "jsp extension with 404",
+			path:       "/app.jsp",
+			statusCode: 404,
+			expected:   true,
+		},
+		{
+			name:       "jsp extension with 200 (may be proxied)",
+			path:       "/app.jsp",
+			statusCode: 200,
+			expected:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isSuspiciousPath(tt.path)
-			assert.Equal(t, tt.expected, result, "Path %s should be %v", tt.path, tt.expected)
+			result := isSuspiciousPath(tt.path, tt.statusCode)
+			assert.Equal(t, tt.expected, result, "Path %s (status %d) should be %v", tt.path, tt.statusCode, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Ports AikidoSec/firewall-node#1041 to Go
- Requests to foreign-platform extensions (`php`, `php3`, `php4`, `php5`, `phtml`, `java`, `jsp`, `jspx`) are only counted as attack-wave scan hits when the HTTP response status is **404** — a 200 may indicate the Go app is proxying to a PHP/Java backend
- Adds a `foreignExtensions` map in `suspicious_paths.go` and threads `statusCode` through the detection chain: `isSuspiciousPath` → `isWebScanner` → `Detector.CheckRequest` → `agent.CheckAttackWave` → `OnPostRequest`

## Test plan

- [ ] `isSuspiciousPath("/admin.php", 404)` → true
- [ ] `isSuspiciousPath("/admin.php", 200)` → false (new: was not tested before)
- [ ] `isSuspiciousPath("/app.jsp", 404)` → true
- [ ] `isSuspiciousPath("/app.jsp", 200)` → false (new: was not tested before)
- [ ] All pre-existing tests updated to pass an explicit status code and still pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Counted foreign-extension requests as scans only when response was 404

**🔧 Refactors**
* Threaded statusCode through detection chain and updated related function signatures

**📚 Documentation**
* Added foreignExtensions map and explanatory comments for behavior


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124657692?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->