### PR TITLE
Remove trailing dots from hostnames and make normalisation consistent

### DIFF
--- a/instrumentation/sinks/net/http/dial_context.go
+++ b/instrumentation/sinks/net/http/dial_context.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/vulnerabilities"
 	"github.com/AikidoSec/firewall-go/vulnerabilities/ssrf"
@@ -30,6 +31,7 @@ func ssrfDialContext(originalDialContext func(ctx context.Context, network, addr
 		if err != nil {
 			return conn, nil
 		}
+		host = normalize.Hostname(host)
 
 		remoteIP, _, err := net.SplitHostPort(conn.RemoteAddr().String())
 		if err != nil {

--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -3,13 +3,12 @@ package http
 import (
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/hooks"
 	"github.com/AikidoSec/firewall-go/instrumentation/operation"
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
-	"golang.org/x/net/idna"
 )
 
 func Examine(r *http.Request) error {
@@ -23,15 +22,7 @@ func Examine(r *http.Request) error {
 		return nil
 	}
 
-	hostname := r.URL.Hostname()
-	// Normalise to lowercase Unicode so block list entries (stored as Unicode)
-	// match regardless of whether the URL used punycode or Unicode labels
-	// (e.g. "xn--mnchen-3ya.de" and "münchen.de" both become "münchen.de").
-	if normalised, err := idna.Lookup.ToUnicode(hostname); err == nil {
-		hostname = normalised
-	} else {
-		hostname = strings.ToLower(hostname)
-	}
+	hostname := normalize.Hostname(r.URL.Hostname())
 	port := getPort(r)
 
 	// Report any hostnames to the dashboard

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -83,6 +83,29 @@ func TestExamine_IDNANormalisationForBlocking(t *testing.T) {
 	require.ErrorAs(t, Examine(mixedCaseReq), &blockedErr, "mixed case should be blocked")
 }
 
+func TestExamine_TrailingDotDoesNotBypassBlocking(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	defer zen.SetDisabled(originalDisabled)
+
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+	defer agent.SetCloudClient(originalClient)
+
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+		Domains: []aikido_types.OutboundDomain{
+			{Hostname: "blocked.com", Mode: "block"},
+		},
+	}, nil)
+
+	var blockedErr *zen.OutboundConnectionBlocked
+
+	req, _ := http.NewRequest("GET", "http://blocked.com./", http.NoBody)
+	require.ErrorAs(t, Examine(req), &blockedErr, "trailing dot should not bypass block list")
+}
+
 func TestExamine_TracksOperationStats(t *testing.T) {
 	originalDisabled := zen.IsDisabled()
 	defer zen.SetDisabled(originalDisabled)

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 )
@@ -62,9 +63,9 @@ func recordRedirect(source *url.URL, location string, reqCtx *request.Context) {
 	dest = source.ResolveReference(dest)
 
 	reqCtx.AddOutgoingRedirect(request.RedirectEntry{
-		SourceHostname: source.Hostname(),
+		SourceHostname: normalize.Hostname(source.Hostname()),
 		SourcePort:     portFromURL(source),
-		DestHostname:   dest.Hostname(),
+		DestHostname:   normalize.Hostname(dest.Hostname()),
 		DestPort:       portFromURL(dest),
 	})
 }

--- a/internal/agent/config/service_config.go
+++ b/internal/agent/config/service_config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/globals"
 	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
 	"github.com/AikidoSec/firewall-go/internal/log"
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 )
 
 var (
@@ -351,6 +352,8 @@ func IsIPBypassed(ip string) bool {
 func ShouldBlockHostname(hostname string) bool {
 	serviceConfigMutex.RLock()
 	defer serviceConfigMutex.RUnlock()
+
+	hostname = normalize.Hostname(hostname)
 
 	// Check if it's in the known list
 	for _, domain := range serviceConfig.Domains {

--- a/internal/agent/config/service_config_test.go
+++ b/internal/agent/config/service_config_test.go
@@ -903,6 +903,25 @@ func TestShouldBlockHostname(t *testing.T) {
 		assert.False(t, ShouldBlockHostname("allowed.com"))
 	})
 
+	t.Run("normalizes trailing dot before matching", func(t *testing.T) {
+		resetServiceConfig()
+
+		cloudConfig := &aikido_types.CloudConfigData{
+			ConfigUpdatedAt:          time.Now().UnixMilli(),
+			BlockNewOutgoingRequests: true,
+			Domains: []aikido_types.OutboundDomain{
+				{Hostname: "malicious.com", Mode: "block"},
+				{Hostname: "allowed.com", Mode: "allow"},
+			},
+		}
+
+		UpdateServiceConfig(cloudConfig, nil)
+
+		assert.True(t, ShouldBlockHostname("malicious.com."))
+		assert.False(t, ShouldBlockHostname("allowed.com."))
+		assert.True(t, ShouldBlockHostname("unknown.com."))
+	})
+
 	t.Run("blocks hostname when BlockNewOutgoingRequests is true and hostname not in domains", func(t *testing.T) {
 		resetServiceConfig()
 

--- a/internal/agent/state/hostnames.go
+++ b/internal/agent/state/hostnames.go
@@ -1,10 +1,15 @@
 package state
 
-import "github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+import (
+	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
+	"github.com/AikidoSec/firewall-go/internal/normalize"
+)
 
 func (c *Collector) StoreHostname(domain string, port uint32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	domain = normalize.Hostname(domain)
 
 	if _, ok := c.hostnames[domain]; !ok {
 		c.hostnames[domain] = make(map[uint32]uint64)

--- a/internal/agent/state/hostnames_test.go
+++ b/internal/agent/state/hostnames_test.go
@@ -106,3 +106,17 @@ func TestStoreDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestStoreHostnameNormalizesTrailingDot(t *testing.T) {
+	c := NewCollector()
+
+	c.StoreHostname("example.com.", 443)
+	c.StoreHostname("example.com", 443)
+
+	result := c.GetAndClearHostnames()
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "example.com", result[0].URL)
+	assert.Equal(t, uint32(443), result[0].Port)
+	assert.Equal(t, uint64(2), result[0].Hits)
+}

--- a/internal/normalize/normalize.go
+++ b/internal/normalize/normalize.go
@@ -1,0 +1,20 @@
+package normalize
+
+import (
+	"strings"
+
+	"golang.org/x/net/idna"
+	"golang.org/x/text/unicode/norm"
+)
+
+// Hostname canonicalizes a hostname for comparison and storage: it strips a
+// trailing dot, folds Unicode confusables (NFKC), and lowercases to Unicode.
+// This makes "example.com."/"example.com", punycode/Unicode labels, and
+// confusables like "ⓛocalhost"/"localhost" all compare equal.
+func Hostname(hostname string) string {
+	h := norm.NFKC.String(strings.TrimSuffix(hostname, "."))
+	if unicode, err := idna.Lookup.ToUnicode(h); err == nil {
+		return unicode
+	}
+	return strings.ToLower(h)
+}

--- a/internal/normalize/normalize_test.go
+++ b/internal/normalize/normalize_test.go
@@ -1,0 +1,32 @@
+package normalize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostname(t *testing.T) {
+	assert.Equal(t, "example.com", Hostname("example.com."))
+	assert.Equal(t, "sub.example.com", Hostname("sub.example.com."))
+	assert.Equal(t, "localhost", Hostname("localhost."))
+
+	assert.Equal(t, "example.com", Hostname("example.com"))
+	assert.Equal(t, "localhost", Hostname("localhost"))
+	assert.Equal(t, "192.168.1.1", Hostname("192.168.1.1"))
+	assert.Equal(t, "", Hostname(""))
+
+	assert.Equal(t, "example.com.", Hostname("example.com.."))
+
+	// Lowercases and decodes punycode to Unicode
+	assert.Equal(t, "example.com", Hostname("EXAMPLE.COM"))
+	assert.Equal(t, "münchen.de", Hostname("xn--mnchen-3ya.de"))
+	assert.Equal(t, "münchen.de", Hostname("MÜNCHEN.DE."))
+
+	// Folds Unicode confusables
+	assert.Equal(t, "localhost", Hostname("ⓛocalhost"))
+
+	// Falls back to lowercase when IDNA rejects the input, but NFKC still folds
+	assert.Equal(t, "user_input.com", Hostname("User_Input.com"))
+	assert.Equal(t, "localhost_x", Hostname("ⓛocalhost_x"))
+}

--- a/vulnerabilities/ssrf/find_hostname_in_userinput.go
+++ b/vulnerabilities/ssrf/find_hostname_in_userinput.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/text/unicode/norm"
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 )
 
 func findHostnameInUserInput(userInput, hostname string, port uint32) bool {
@@ -37,12 +37,9 @@ func findHostnameInUserInput(userInput, hostname string, port uint32) bool {
 		// http://127.0.0.1:4000:/ where a trailing colon causes
 		// Hostname() to misparse (it splits on the last colon).
 		parsed.Host = strings.TrimRight(parsed.Host, ":")
-		parsedHostname := strings.ToLower(parsed.Hostname())
-		// NFKC-normalize to handle Unicode confusables (e.g. ⓛ → l).
-		// Go's HTTP transport applies IDNA processing (which includes NFKC)
-		// before dialing, so the hostname we receive at DialContext level is
-		// already normalized. We must normalize the user input side to match.
-		parsedHostname = norm.NFKC.String(parsedHostname)
+		// Canonicalize to match the dialed hostname, which Go's HTTP transport
+		// has already IDNA-processed before reaching DialContext.
+		parsedHostname := normalize.Hostname(parsed.Hostname())
 		parsedPort := getPortFromURL(parsed)
 
 		// Skip if both ports are set, in valid range, and don't match
@@ -64,14 +61,14 @@ func getHostnameOptions(hostname string) []string {
 
 	// Try parsing as-is (wrapped in a URL)
 	if parsed, err := url.Parse("http://" + hostname); err == nil && parsed.Hostname() != "" {
-		options = append(options, strings.ToLower(parsed.Hostname()))
+		options = append(options, normalize.Hostname(parsed.Hostname()))
 	}
 
 	// Try wrapping in brackets for IPv6 addresses like ::1
 	if parsed, err := url.Parse("http://[" + hostname + "]"); err == nil && parsed.Hostname() != "" {
-		lower := strings.ToLower(parsed.Hostname())
-		if len(options) == 0 || options[0] != lower {
-			options = append(options, lower)
+		normalized := normalize.Hostname(parsed.Hostname())
+		if len(options) == 0 || options[0] != normalized {
+			options = append(options, normalized)
 		}
 	}
 

--- a/vulnerabilities/ssrf/find_hostname_in_userinput_test.go
+++ b/vulnerabilities/ssrf/find_hostname_in_userinput_test.go
@@ -154,6 +154,20 @@ func TestFindHostnameInUserInput(t *testing.T) {
 	t.Run("returns false for single character user input", func(t *testing.T) {
 		assert.False(t, findHostnameInUserInput("x", "localhost", 0))
 	})
+
+	t.Run("normalizes trailing dot in hostname argument", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://example.com", "example.com.", 0))
+		assert.True(t, findHostnameInUserInput("example.com", "example.com.", 0))
+	})
+
+	t.Run("normalizes trailing dot in user input", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://example.com.", "example.com", 0))
+		assert.True(t, findHostnameInUserInput("example.com.", "example.com", 0))
+	})
+
+	t.Run("normalizes trailing dot on both sides", func(t *testing.T) {
+		assert.True(t, findHostnameInUserInput("http://example.com.", "example.com.", 0))
+	})
 }
 
 func TestGetPortFromURL(t *testing.T) {

--- a/vulnerabilities/ssrf/imds.go
+++ b/vulnerabilities/ssrf/imds.go
@@ -2,6 +2,7 @@ package ssrf
 
 import (
 	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 )
 
 var imdsIPList = ipaddr.BuildMatchList("imds", "IMDS IP addresses", []string{
@@ -27,7 +28,7 @@ func isIMDSIPAddress(ip string) bool {
 // isTrustedHostname checks if the hostname is a trusted cloud metadata hostname
 // that should not be flagged as stored SSRF.
 func isTrustedHostname(hostname string) bool {
-	return trustedHostnames[hostname]
+	return trustedHostnames[normalize.Hostname(hostname)]
 }
 
 // resolvesToIMDSIP checks whether any of the resolved IPs are IMDS addresses.

--- a/vulnerabilities/ssrf/imds_test.go
+++ b/vulnerabilities/ssrf/imds_test.go
@@ -36,6 +36,11 @@ func TestIsTrustedHostname(t *testing.T) {
 	assert.True(t, isTrustedHostname("metadata.goog"))
 	assert.False(t, isTrustedHostname("example.com"))
 	assert.False(t, isTrustedHostname(""))
+
+	// Normalizes trailing dot and case before matching
+	assert.True(t, isTrustedHostname("metadata.google.internal."))
+	assert.True(t, isTrustedHostname("METADATA.GOOGLE.INTERNAL"))
+	assert.False(t, isTrustedHostname("another.hostname"))
 }
 
 func TestResolvesToIMDSIP(t *testing.T) {

--- a/vulnerabilities/ssrf/imds_test.go
+++ b/vulnerabilities/ssrf/imds_test.go
@@ -3,6 +3,7 @@ package ssrf
 import (
 	"testing"
 
+	"github.com/AikidoSec/firewall-go/internal/normalize"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,6 +42,14 @@ func TestIsTrustedHostname(t *testing.T) {
 	assert.True(t, isTrustedHostname("metadata.google.internal."))
 	assert.True(t, isTrustedHostname("METADATA.GOOGLE.INTERNAL"))
 	assert.False(t, isTrustedHostname("another.hostname"))
+}
+
+// isTrustedHostname normalizes its input before looking it up, so the map keys
+// must already be in normalized form or they would never match.
+func TestTrustedHostnamesAreNormalized(t *testing.T) {
+	for h := range trustedHostnames {
+		assert.Equal(t, normalize.Hostname(h), h, "trusted hostname must be stored normalized")
+	}
 }
 
 func TestResolvesToIMDSIP(t *testing.T) {


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added normalize package with Hostname canonicalization handling trailing dots

**🔧 Refactors**
* Replaced ad-hoc hostname normalization calls with normalize.Hostname across codebase


<sup>[More info](https://app.aikido.dev/featurebranch/scan/125235789?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->