### PR TITLE
Add benchmark for os.OpenFile with/without zen-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ internal/vulnerabilities/zen_internals/lib/*
 
 sample-apps/*/bin
 tools/bin
+
+# Benchmark artefacts from scripts/bench-toolexec.sh
+/bench-results/
+*.prof

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ benchmark:
 	@echo "Running benchmarks..."
 	@GIN_MODE=release ./scripts/benchmark.sh
 
+# Compare a toolexec-instrumented package vanilla vs. zen-go (benchstat).
+.PHONY: bench-os
+bench-os:
+	@TAGS=sink_bench ./scripts/bench-toolexec.sh ./benchmarks/sinks/os $(COUNT)
+
 .PHONY: test-main
 test-main:
 	@echo "Running main module tests with gotestsum"

--- a/benchmarks/sinks/os/bench_test.go
+++ b/benchmarks/sinks/os/bench_test.go
@@ -1,0 +1,77 @@
+//go:build sink_bench
+
+// Benchmarks for the os sink (path-traversal scan injected into os.OpenFile).
+// Run via scripts/bench-toolexec.sh for the vanilla vs. zen-go comparison.
+
+package osbench
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/request"
+)
+
+// TestCompiledWithZenGo is the liveness gate: passes only under zen-go toolexec.
+func TestCompiledWithZenGo(t *testing.T) {
+	if !config.IsCompiledWithZenGo() {
+		t.Fatal("binary was not compiled with zen-go; re-run with " +
+			`-toolexec="$(pwd)/tools/bin/zen-go toolexec"`)
+	}
+}
+
+func benchFile(b *testing.B) string {
+	b.Helper()
+	path := filepath.Join(b.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte("zen"), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	return path
+}
+
+func openClose(b *testing.B, path string) {
+	b.Helper()
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = f.Close()
+}
+
+func BenchmarkOpenFile(b *testing.B) {
+	// Enable the scan path without starting the agent (zen.Protect spawns
+	// network goroutines).
+	config.SetZenLoaded(true)
+	b.Cleanup(func() { config.SetZenLoaded(false) })
+
+	path := benchFile(b)
+
+	b.Run("no_context", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			openClose(b, path)
+		}
+	})
+
+	b.Run("with_context", func(b *testing.B) {
+		req := httptest.NewRequest(http.MethodGet, "/files?name=report&id=42", http.NoBody)
+		ip := "127.0.0.1"
+		ctx := request.SetContext(context.Background(), req, request.ContextData{
+			Source:        "bench",
+			Route:         "/files",
+			RemoteAddress: &ip,
+		})
+
+		b.ResetTimer()
+		request.WrapWithGLS(ctx, func() {
+			for i := 0; i < b.N; i++ {
+				openClose(b, path)
+			}
+		})
+	})
+}

--- a/benchmarks/sinks/os/zen.tool.go
+++ b/benchmarks/sinks/os/zen.tool.go
@@ -1,0 +1,5 @@
+package osbench
+
+import (
+	_ "github.com/AikidoSec/firewall-go/instrumentation"
+)

--- a/scripts/bench-toolexec.sh
+++ b/scripts/bench-toolexec.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Compare a package's benchmarks built vanilla vs. under zen-go toolexec.
+# Samples are interleaved (alternating binaries) so machine drift affects both
+# equally rather than biasing one run; results are compared with benchstat.
+#
+# Usage: scripts/bench-toolexec.sh <package> [count]
+#   package   Go package to benchmark, e.g. ./benchmarks/sinks/os
+#   count     benchstat samples per binary (default 10)
+#
+# Env:
+#   TAGS       build tag for the benchmark file (e.g. sink_bench); omitted if empty
+#   BENCH      -test.bench pattern (default '.')
+#   BENCHTIME  -test.benchtime (default 1s)
+#   VERIFY_RUN test run under toolexec to prove instrumentation is live
+#              (default '^TestCompiledWithZenGo$'); set empty to skip
+#   OUT_DIR    output dir (default: <repo>/bench-results/<derived-from-package>)
+#
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PKG="${1:?usage: bench-toolexec.sh <package> [count]}"
+COUNT="${2:-10}"
+TAGS="${TAGS:-}"
+BENCH="${BENCH:-.}"
+BENCHTIME="${BENCHTIME:-1s}"
+VERIFY_RUN="${VERIFY_RUN:-^TestCompiledWithZenGo$}"
+
+label=$(echo "$PKG" | sed -e 's#^\./##' -e 's#[/.]#_#g')
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/bench-results/$label}"
+
+# Assemble the optional -tags flag once.
+tagflag=()
+if [[ -n "$TAGS" ]]; then
+	tagflag=(-tags="$TAGS")
+fi
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/vanilla.* "$OUT_DIR"/zen.* "$OUT_DIR"/benchstat.txt
+
+echo ">>> Building zen-go..."
+make build-zen-go >/dev/null
+ZEN_GO="$ROOT_DIR/tools/bin/zen-go"
+
+if [[ -n "$VERIFY_RUN" ]]; then
+	echo ">>> Verifying instrumentation is active under -toolexec ($VERIFY_RUN)..."
+	go test "${tagflag[@]}" -run="$VERIFY_RUN" -count=1 -v \
+		-toolexec="$ZEN_GO toolexec" "$PKG"
+fi
+
+VANILLA_BIN="$OUT_DIR/vanilla.test"
+ZEN_BIN="$OUT_DIR/zen.test"
+
+echo ">>> Building test binaries..."
+go test "${tagflag[@]}" -c -o "$VANILLA_BIN" "$PKG"
+go test "${tagflag[@]}" -c -o "$ZEN_BIN" -toolexec="$ZEN_GO toolexec" "$PKG"
+
+run_sample() {
+	local bin="$1" out="$2"
+	"$bin" \
+		-test.run='^$' \
+		-test.bench="$BENCH" \
+		-test.benchmem \
+		-test.benchtime="$BENCHTIME" \
+		-test.count=1 \
+		>>"$out"
+}
+
+# benchstat reads the goos/goarch/pkg/cpu header to label results, so emit it
+# once at the top of each file before the interleaved sample lines.
+"$VANILLA_BIN" -test.run='^$' -test.bench='^$' >"$OUT_DIR/vanilla.txt"
+"$ZEN_BIN" -test.run='^$' -test.bench='^$' >"$OUT_DIR/zen.txt"
+
+echo ">>> Interleaving $COUNT samples per binary (benchtime=$BENCHTIME)..."
+for ((i = 1; i <= COUNT; i++)); do
+	printf '\r  sample %d/%d' "$i" "$COUNT"
+	run_sample "$VANILLA_BIN" "$OUT_DIR/vanilla.txt"
+	run_sample "$ZEN_BIN" "$OUT_DIR/zen.txt"
+done
+printf '\n'
+
+echo ">>> Capturing profiles (single dedicated run each)..."
+"$VANILLA_BIN" -test.run='^$' -test.bench="$BENCH" -test.benchtime="$BENCHTIME" \
+	-test.cpuprofile="$OUT_DIR/vanilla.cpu.prof" \
+	-test.memprofile="$OUT_DIR/vanilla.mem.prof" >/dev/null
+"$ZEN_BIN" -test.run='^$' -test.bench="$BENCH" -test.benchtime="$BENCHTIME" \
+	-test.cpuprofile="$OUT_DIR/zen.cpu.prof" \
+	-test.memprofile="$OUT_DIR/zen.mem.prof" >/dev/null
+
+echo
+if command -v benchstat >/dev/null 2>&1; then
+	benchstat "$OUT_DIR/vanilla.txt" "$OUT_DIR/zen.txt" | tee "$OUT_DIR/benchstat.txt"
+else
+	echo "benchstat not installed. To install:"
+	echo "  go install golang.org/x/perf/cmd/benchstat@latest"
+fi
+
+cat <<EOF
+
+Artefacts:    $OUT_DIR
+CPU diff:     go tool pprof -diff_base $OUT_DIR/vanilla.cpu.prof $OUT_DIR/zen.cpu.prof
+Mem diff:     go tool pprof -diff_base $OUT_DIR/vanilla.mem.prof $OUT_DIR/zen.mem.prof
+
+EOF


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added script to compare benchmarks built with and without zen-go


<sup>[More info](https://app.aikido.dev/featurebranch/scan/125837426?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->