### PR TITLE
fix: Preserve empty properties in API schema

### DIFF
--- a/internal/agent/aikido_types/api_spec.go
+++ b/internal/agent/aikido_types/api_spec.go
@@ -10,9 +10,9 @@ type APIAuthType struct {
 
 type DataSchema struct {
 	Type       []string               `json:"type"`
-	Properties map[string]*DataSchema `json:"properties,omitempty"`
-	Items      *DataSchema            `json:"items,omitempty"`
-	Optional   bool                   `json:"optional,omitempty"`
+	Properties map[string]*DataSchema `json:"properties"`
+	Items      *DataSchema            `json:"items"`
+	Optional   bool                   `json:"optional"`
 }
 
 type APIBodyInfo struct {

--- a/internal/agent/apidiscovery/merge_data_schemas_test.go
+++ b/internal/agent/apidiscovery/merge_data_schemas_test.go
@@ -1,11 +1,13 @@
 package apidiscovery
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsSameType(t *testing.T) {
@@ -215,4 +217,33 @@ func TestMergeTypes(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected5, MergeDataSchemas(schema5, MergeDataSchemas(GetDataSchema(map[string]any{"test": 123}, 0), GetDataSchema(map[string]any{"test": true}, 0))))
+}
+
+func TestObjectPropertiesJSONRoundtrip(t *testing.T) {
+	t.Run("empty object preserves non-nil properties after JSON round-trip", func(t *testing.T) {
+		schema := GetDataSchema(map[string]any{}, 0)
+		assert.NotNil(t, schema.Properties)
+
+		data, err := json.Marshal(schema)
+		require.NoError(t, err)
+
+		var restored aikido_types.DataSchema
+		require.NoError(t, json.Unmarshal(data, &restored))
+
+		assert.NotNil(t, restored.Properties, "properties must survive JSON round-trip as non-nil")
+	})
+
+	t.Run("merging after round-trip does not drop existing properties", func(t *testing.T) {
+		withProps := GetDataSchema(map[string]any{"key": "value"}, 0)
+		empty := GetDataSchema(map[string]any{}, 0)
+
+		data, err := json.Marshal(empty)
+		require.NoError(t, err)
+		var restoredEmpty aikido_types.DataSchema
+		require.NoError(t, json.Unmarshal(data, &restoredEmpty))
+
+		result := MergeDataSchemas(withProps, &restoredEmpty)
+		assert.NotNil(t, result.Properties)
+		assert.Contains(t, result.Properties, "key")
+	})
 }

--- a/internal/agent/apidiscovery/merge_data_schemas_test.go
+++ b/internal/agent/apidiscovery/merge_data_schemas_test.go
@@ -220,7 +220,7 @@ func TestMergeTypes(t *testing.T) {
 }
 
 func TestObjectPropertiesJSONRoundtrip(t *testing.T) {
-	t.Run("empty object preserves non-nil properties after JSON round-trip", func(t *testing.T) {
+	t.Run("it preserves empty properties after JSON round-trip", func(t *testing.T) {
 		schema := GetDataSchema(map[string]any{}, 0)
 		assert.NotNil(t, schema.Properties)
 
@@ -233,17 +233,16 @@ func TestObjectPropertiesJSONRoundtrip(t *testing.T) {
 		assert.NotNil(t, restored.Properties, "properties must survive JSON round-trip as non-nil")
 	})
 
-	t.Run("merging after round-trip does not drop existing properties", func(t *testing.T) {
-		withProps := GetDataSchema(map[string]any{"key": "value"}, 0)
-		empty := GetDataSchema(map[string]any{}, 0)
+	t.Run("it preserves nil properties after JSON round-trip", func(t *testing.T) {
+		schema := GetDataSchema([]any{}, 0)
+		assert.Nil(t, schema.Items)
 
-		data, err := json.Marshal(empty)
+		data, err := json.Marshal(schema)
 		require.NoError(t, err)
-		var restoredEmpty aikido_types.DataSchema
-		require.NoError(t, json.Unmarshal(data, &restoredEmpty))
 
-		result := MergeDataSchemas(withProps, &restoredEmpty)
-		assert.NotNil(t, result.Properties)
-		assert.Contains(t, result.Properties, "key")
+		var restored aikido_types.DataSchema
+		require.NoError(t, json.Unmarshal(data, &restored))
+
+		assert.Nil(t, restored.Properties)
 	})
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Preserved empty schema fields by removing omitempty from DataSchema


<sup>[More info](https://app.aikido.dev/featurebranch/scan/126909162?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->