### PR TITLE
Switch to strings.SplitSeq for extracting route params

### DIFF
--- a/vulnerabilities/extract_route_params.go
+++ b/vulnerabilities/extract_route_params.go
@@ -28,10 +28,9 @@ func extractRouteParams(urlPath string) []string {
 		return nil
 	}
 
-	segments := strings.Split(urlPath, "/")
 	var results []string
 
-	for _, segment := range segments {
+	for segment := range strings.SplitSeq(urlPath, "/") {
 		if segment == "" {
 			continue
 		}


### PR DESCRIPTION
Removes one alloc per route segment per vuln scan.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched to strings.SplitSeq for route parameter extraction, reducing allocations


<sup>[More info](https://app.aikido.dev/featurebranch/scan/126905879?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->