### PR TITLE
Remove unnecessary strings.ToLower in startsWithUnsafePath

### DIFF
--- a/vulnerabilities/pathtraversal/detect_path_traversal.go
+++ b/vulnerabilities/pathtraversal/detect_path_traversal.go
@@ -34,7 +34,7 @@ func detectPathTraversal(filePath, userInput string, checkPathStart bool) bool {
 
 	if checkPathStart {
 		// Check for absolute path traversal
-		return startsWithUnsafePath(filePath, userInput)
+		return startsWithUnsafePath(normalisedFilePath, normalisedUserInput)
 	}
 
 	return false

--- a/vulnerabilities/pathtraversal/starts_with_unsafe_path.go
+++ b/vulnerabilities/pathtraversal/starts_with_unsafe_path.go
@@ -47,8 +47,8 @@ func startsWithUnsafePath(filePath, userInput string) bool {
 		return false
 	}
 
-	normalizedPath := strings.ToLower(filepath.Clean(filePath))
-	normalizedUserInput := strings.ToLower(filepath.Clean(userInput))
+	normalizedPath := filepath.Clean(filePath)
+	normalizedUserInput := filepath.Clean(userInput)
 
 	for _, dangerousStart := range dangerousPathStarts {
 		if strings.HasPrefix(normalizedPath, dangerousStart) &&
@@ -56,8 +56,7 @@ func startsWithUnsafePath(filePath, userInput string) bool {
 			// If the user input is the same as the dangerous start, we don't want to flag it to prevent false positives
 			// e.g. if user input is /etc/ and the path is /etc/passwd, we don't want to flag it, as long as the
 			// user input does not contain a subdirectory or filename
-			lowerUserInput := strings.ToLower(userInput)
-			if lowerUserInput == dangerousStart || lowerUserInput == dangerousStart[:len(dangerousStart)-1] {
+			if userInput == dangerousStart || userInput == dangerousStart[:len(dangerousStart)-1] {
 				return false
 			}
 			return true


### PR DESCRIPTION
We already lower the input and path earlier in the process. 

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed redundant strings.ToLower calls from startsWithUnsafePath to simplify normalization
* Updated detectPathTraversal to pass normalized inputs into startsWithUnsafePath


<sup>[More info](https://app.aikido.dev/featurebranch/scan/126906823?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->