### PR TITLE
Use strings.Builder for buildPathToPayload

### DIFF
--- a/vulnerabilities/extract_strings_from_user_input.go
+++ b/vulnerabilities/extract_strings_from_user_input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -19,19 +20,21 @@ func buildPathToPayload(pathToPayload []pathPart) string {
 	if len(pathToPayload) == 0 {
 		return "."
 	}
-
-	path := ""
+	var b strings.Builder
 	for _, part := range pathToPayload {
 		switch part.Type {
 		case "jwt":
-			path += "<jwt>"
+			b.WriteString("<jwt>")
 		case "object":
-			path += "." + part.Key
+			b.WriteByte('.')
+			b.WriteString(part.Key)
 		case "array":
-			path += fmt.Sprintf(".[%d]", part.Index)
+			b.WriteString(".[")
+			b.WriteString(strconv.Itoa(part.Index))
+			b.WriteByte(']')
 		}
 	}
-	return path
+	return b.String()
 }
 
 // addURLDecodedVariants adds further URL-decoded forms of str, so apps that

--- a/vulnerabilities/extract_strings_from_user_input_test.go
+++ b/vulnerabilities/extract_strings_from_user_input_test.go
@@ -5,6 +5,89 @@ import (
 	"testing"
 )
 
+func TestBuildPathToPayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		parts    []pathPart
+		expected string
+	}{
+		{
+			name:     "empty path returns dot",
+			parts:    []pathPart{},
+			expected: ".",
+		},
+		{
+			name:     "single object part",
+			parts:    []pathPart{{Type: "object", Key: "username"}},
+			expected: ".username",
+		},
+		{
+			name:     "single array part index zero",
+			parts:    []pathPart{{Type: "array", Index: 0}},
+			expected: ".[0]",
+		},
+		{
+			name:     "single array part large index",
+			parts:    []pathPart{{Type: "array", Index: 99}},
+			expected: ".[99]",
+		},
+		{
+			name:     "single jwt part",
+			parts:    []pathPart{{Type: "jwt"}},
+			expected: "<jwt>",
+		},
+		{
+			name: "nested object path",
+			parts: []pathPart{
+				{Type: "object", Key: "a"},
+				{Type: "object", Key: "b"},
+				{Type: "object", Key: "c"},
+			},
+			expected: ".a.b.c",
+		},
+		{
+			name: "object then array",
+			parts: []pathPart{
+				{Type: "object", Key: "arr"},
+				{Type: "array", Index: 2},
+			},
+			expected: ".arr.[2]",
+		},
+		{
+			name: "jwt then object",
+			parts: []pathPart{
+				{Type: "jwt"},
+				{Type: "object", Key: "sub"},
+			},
+			expected: "<jwt>.sub",
+		},
+		{
+			name: "complex mixed path",
+			parts: []pathPart{
+				{Type: "object", Key: "token"},
+				{Type: "jwt"},
+				{Type: "object", Key: "username"},
+				{Type: "object", Key: "$ne"},
+			},
+			expected: ".token<jwt>.username.$ne",
+		},
+		{
+			name:     "unknown type is skipped",
+			parts:    []pathPart{{Type: "unknown", Key: "x"}},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := buildPathToPayload(tt.parts)
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
 func TestExtractStringsFromUserInput(t *testing.T) {
 	t.Run("empty object returns empty array", func(t *testing.T) {
 		obj := map[string]interface{}{}


### PR DESCRIPTION
For `make bench-os`, removes 3 allocs per op.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Rewrote buildPathToPayload to use strings.Builder, reducing allocations per operation


<sup>[More info](https://app.aikido.dev/featurebranch/scan/126907751?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->