### PR TITLE
 Use typecasting with reflect fallback for extracting user input

### DIFF
--- a/vulnerabilities/extract_strings_from_user_input.go
+++ b/vulnerabilities/extract_strings_from_user_input.go
@@ -56,7 +56,7 @@ func addURLDecodedVariants(results map[string]string, str string, pathToPayload 
 }
 
 // extractStringsFromUserInput recursively extracts strings from user input
-func extractStringsFromUserInput(obj interface{}, pathToPayload []pathPart) map[string]string {
+func extractStringsFromUserInput(obj any, pathToPayload []pathPart) map[string]string {
 	results := make(map[string]string)
 	// Pre-allocate path with extra capacity so recursive appends reuse the
 	// backing array (stack-like) instead of allocating on every level.
@@ -66,9 +66,9 @@ func extractStringsFromUserInput(obj interface{}, pathToPayload []pathPart) map[
 	return results
 }
 
-func extractStringsInto(obj interface{}, path []pathPart, results map[string]string) {
+func extractStringsInto(obj any, path []pathPart, results map[string]string) {
 	switch v := obj.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		currentPath := buildPathToPayload(path)
 		for key, val := range v {
 			results[key] = currentPath
@@ -92,7 +92,7 @@ func extractStringsInto(obj interface{}, path []pathPart, results map[string]str
 			results[key] = currentPath
 			extractStringsInto(val, append(path, pathPart{Type: "object", Key: key}), results)
 		}
-	case []interface{}:
+	case []any:
 		var values []string
 		for i, item := range v {
 			extractStringsInto(item, append(path, pathPart{Type: "array", Index: i}), results)
@@ -136,7 +136,7 @@ func extractStringsInto(obj interface{}, path []pathPart, results map[string]str
 // extractStringsReflect is the fallback for types not covered by the typed
 // cases above (named map/slice types, maps with other key/value types, arrays,
 // named string types), e.g. a custom Body passed via the public SetContext API.
-func extractStringsReflect(obj interface{}, path []pathPart, results map[string]string) {
+func extractStringsReflect(obj any, path []pathPart, results map[string]string) {
 	val := reflect.ValueOf(obj)
 	switch val.Kind() {
 	case reflect.Map:

--- a/vulnerabilities/extract_strings_from_user_input.go
+++ b/vulnerabilities/extract_strings_from_user_input.go
@@ -57,53 +57,105 @@ func addURLDecodedVariants(results map[string]string, str string, pathToPayload 
 // extractStringsFromUserInput recursively extracts strings from user input
 func extractStringsFromUserInput(obj interface{}, pathToPayload []pathPart) map[string]string {
 	results := make(map[string]string)
+	// Pre-allocate path with extra capacity so recursive appends reuse the
+	// backing array (stack-like) instead of allocating on every level.
+	path := make([]pathPart, len(pathToPayload), len(pathToPayload)+8)
+	copy(path, pathToPayload)
+	extractStringsInto(obj, path, results)
+	return results
+}
 
-	val := reflect.ValueOf(obj)
-	switch val.Kind() {
-	case reflect.Map:
-		for _, key := range val.MapKeys() {
-			keyStr := fmt.Sprintf("%v", key.Interface())
-			results[keyStr] = buildPathToPayload(pathToPayload)
-			nestedResults := extractStringsFromUserInput(val.MapIndex(key).Interface(), append(pathToPayload, pathPart{Type: "object", Key: keyStr}))
-			for k, v := range nestedResults {
-				results[k] = v
-			}
+func extractStringsInto(obj interface{}, path []pathPart, results map[string]string) {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		currentPath := buildPathToPayload(path)
+		for key, val := range v {
+			results[key] = currentPath
+			extractStringsInto(val, append(path, pathPart{Type: "object", Key: key}), results)
 		}
-	case reflect.Slice, reflect.Array:
-		for i := 0; i < val.Len(); i++ {
-			nestedResults := extractStringsFromUserInput(val.Index(i).Interface(), append(pathToPayload, pathPart{Type: "array", Index: i}))
-			for k, v := range nestedResults {
-				results[k] = v
-			}
+	case map[string][]string:
+		currentPath := buildPathToPayload(path)
+		for key, vals := range v {
+			results[key] = currentPath
+			extractStringsInto(vals, append(path, pathPart{Type: "object", Key: key}), results)
 		}
-
+	case url.Values:
+		currentPath := buildPathToPayload(path)
+		for key, vals := range v {
+			results[key] = currentPath
+			extractStringsInto(vals, append(path, pathPart{Type: "object", Key: key}), results)
+		}
+	case map[string]string:
+		currentPath := buildPathToPayload(path)
+		for key, val := range v {
+			results[key] = currentPath
+			extractStringsInto(val, append(path, pathPart{Type: "object", Key: key}), results)
+		}
+	case []interface{}:
+		var values []string
+		for i, item := range v {
+			extractStringsInto(item, append(path, pathPart{Type: "array", Index: i}), results)
+			values = append(values, fmt.Sprintf("%v", item))
+		}
 		// Add array as string to results
 		// This prevents bypassing the firewall by HTTP Parameter Pollution
 		// Example: ?param=value1&param=value2 could be treated as an array
 		// If its used inside a string, it will be converted to a comma separated string
-		if val.Len() > 0 {
-			var values []string
-			for i := 0; i < val.Len(); i++ {
-				values = append(values, reflect.ValueOf(val.Index(i).Interface()).String())
-			}
-			results[strings.Join(values, ",")] = buildPathToPayload(pathToPayload)
+		if len(values) > 0 {
+			results[strings.Join(values, ",")] = buildPathToPayload(path)
 		}
-
-	case reflect.String:
-		str := val.String()
-		results[str] = buildPathToPayload(pathToPayload)
-		addURLDecodedVariants(results, str, pathToPayload)
-		jwt := tryDecodeAsJWT(str)
+	case []string:
+		for i, item := range v {
+			extractStringsInto(item, append(path, pathPart{Type: "array", Index: i}), results)
+		}
+		if len(v) > 0 {
+			results[strings.Join(v, ",")] = buildPathToPayload(path)
+		}
+	case string:
+		results[v] = buildPathToPayload(path)
+		addURLDecodedVariants(results, v, path)
+		jwt := tryDecodeAsJWT(v)
 		if jwt.JWT {
-			for k, v := range extractStringsFromUserInput(jwt.Object, append(pathToPayload, pathPart{Type: "jwt"})) {
-				if k == "iss" || strings.HasSuffix(v, "<jwt>.iss") {
+			jwtPath := append(path, pathPart{Type: "jwt"})
+			// JWT needs a temporary map for iss filtering before merging.
+			jwtResults := make(map[string]string)
+			extractStringsInto(jwt.Object, jwtPath, jwtResults)
+			for k, vv := range jwtResults {
+				if k == "iss" || strings.HasSuffix(vv, "<jwt>.iss") {
 					continue
 				}
-				results[k] = v
+				results[k] = vv
 			}
 		}
-
+	default:
+		extractStringsReflect(obj, path, results)
 	}
+}
 
-	return results
+// extractStringsReflect is the fallback for types not covered by the typed
+// cases above (named map/slice types, maps with other key/value types, arrays,
+// named string types), e.g. a custom Body passed via the public SetContext API.
+func extractStringsReflect(obj interface{}, path []pathPart, results map[string]string) {
+	val := reflect.ValueOf(obj)
+	switch val.Kind() {
+	case reflect.Map:
+		currentPath := buildPathToPayload(path)
+		for _, key := range val.MapKeys() {
+			keyStr := fmt.Sprintf("%v", key.Interface())
+			results[keyStr] = currentPath
+			extractStringsInto(val.MapIndex(key).Interface(), append(path, pathPart{Type: "object", Key: keyStr}), results)
+		}
+	case reflect.Slice, reflect.Array:
+		var values []string
+		for i := 0; i < val.Len(); i++ {
+			item := val.Index(i).Interface()
+			extractStringsInto(item, append(path, pathPart{Type: "array", Index: i}), results)
+			values = append(values, fmt.Sprintf("%v", item))
+		}
+		if len(values) > 0 {
+			results[strings.Join(values, ",")] = buildPathToPayload(path)
+		}
+	case reflect.String:
+		extractStringsInto(val.String(), path, results)
+	}
 }

--- a/vulnerabilities/extract_strings_from_user_input.go
+++ b/vulnerabilities/extract_strings_from_user_input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -116,7 +117,7 @@ func extractStringsInto(obj interface{}, path []pathPart, results map[string]str
 		addURLDecodedVariants(results, v, path)
 		jwt := tryDecodeAsJWT(v)
 		if jwt.JWT {
-			jwtPath := append(path, pathPart{Type: "jwt"})
+			jwtPath := append(slices.Clone(path), pathPart{Type: "jwt"})
 			// JWT needs a temporary map for iss filtering before merging.
 			jwtResults := make(map[string]string)
 			extractStringsInto(jwt.Object, jwtPath, jwtResults)

--- a/vulnerabilities/extract_strings_from_user_input_test.go
+++ b/vulnerabilities/extract_strings_from_user_input_test.go
@@ -365,7 +365,7 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 			"arr":  ".",
 			"1":    ".arr.[0]",
 			"test": ".arr.[5].test",
-			"1,<int Value>,<bool Value>,<invalid Value>,<invalid Value>,<map[string]interface {} Value>": ".arr",
+			"1,2,true,<nil>,<nil>,map[test:test]": ".arr",
 		}
 		actual = extractStringsFromUserInput(obj, []pathPart{})
 		if !reflect.DeepEqual(expected, actual) {
@@ -383,7 +383,56 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 			"test123":         ".arr.[5].test.[0]",
 			"test345":         ".arr.[5].test.[1]",
 			"test123,test345": ".arr.[5].test",
-			"1,<int Value>,<bool Value>,<invalid Value>,<invalid Value>,<map[string]interface {} Value>": ".arr",
+			"1,2,true,<nil>,<nil>,map[test:[test123 test345]]": ".arr",
+		}
+		actual = extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it handles unusual types via reflect fallback", func(t *testing.T) {
+		// Named map type (e.g. http.Header) not matched by the typed cases.
+		type customHeader map[string][]string
+		obj := map[string]interface{}{
+			"headers": customHeader{"X-Custom": {"attack"}},
+		}
+		expected := map[string]string{
+			"headers":  ".",
+			"X-Custom": ".headers",
+			"attack":   ".headers.X-Custom",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+
+		// Named string type and a map with a non-string value type.
+		type customString string
+		obj = map[string]interface{}{
+			"name": customString("attack"),
+			"meta": map[string]int{"count": 5},
+		}
+		expected = map[string]string{
+			"name":   ".",
+			"attack": ".name",
+			"meta":   ".",
+			"count":  ".meta",
+		}
+		actual = extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+
+		// Fixed-size array of strings.
+		obj = map[string]interface{}{
+			"arr": [2]string{"a", "b"},
+		}
+		expected = map[string]string{
+			"arr": ".",
+			"a":   ".arr.[0]",
+			"b":   ".arr.[1]",
+			"a,b": ".arr",
 		}
 		actual = extractStringsFromUserInput(obj, []pathPart{})
 		if !reflect.DeepEqual(expected, actual) {

--- a/vulnerabilities/extract_strings_from_user_input_test.go
+++ b/vulnerabilities/extract_strings_from_user_input_test.go
@@ -1,6 +1,7 @@
 package vulnerabilities
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -340,6 +341,24 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 		}
 	})
 
+	t.Run("it adds URL-decoded variants for strings inside arrays", func(t *testing.T) {
+		// The raw encoded form is recorded at the array path (from the join),
+		// while the decoded variants point to the individual element path.
+		obj := map[string]interface{}{
+			"paths": []string{"%252e%252e%252fetc%252fpasswd"},
+		}
+		expected := map[string]string{
+			"paths":                         ".",
+			"%252e%252e%252fetc%252fpasswd": ".paths",
+			"%2e%2e%2fetc%2fpasswd":         ".paths.[0]",
+			"../etc/passwd":                 ".paths.[0]",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
 	t.Run("it concatenates array values", func(t *testing.T) {
 		obj := map[string]interface{}{
 			"arr": []interface{}{"1", "2", "3"},
@@ -435,6 +454,78 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 			"a,b": ".arr",
 		}
 		actual = extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it handles map[string]string directly", func(t *testing.T) {
+		obj := map[string]string{"session": "ABC", "session2": "DEF"}
+		expected := map[string]string{
+			"session":  ".",
+			"session2": ".",
+			"ABC":      ".session",
+			"DEF":      ".session2",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it handles map[string][]string directly", func(t *testing.T) {
+		obj := map[string][]string{"users": {"alice", "bob"}}
+		expected := map[string]string{
+			"users":     ".",
+			"alice":     ".users.[0]",
+			"bob":       ".users.[1]",
+			"alice,bob": ".users",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it handles url.Values directly", func(t *testing.T) {
+		obj := url.Values{"q": {"foo", "bar"}}
+		expected := map[string]string{
+			"q":       ".",
+			"foo":     ".q.[0]",
+			"bar":     ".q.[1]",
+			"foo,bar": ".q",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it handles nil input", func(t *testing.T) {
+		expected := map[string]string{}
+		actual := extractStringsFromUserInput(nil, []pathPart{})
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("it does not corrupt sibling paths when processing a JWT", func(t *testing.T) {
+		obj := map[string]interface{}{
+			"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.QLC0vl-A11a1WcUPD6vQR2PlUvRMsqpegddfQzPajQM",
+			"role":  "admin",
+		}
+		expected := map[string]string{
+			"token": ".",
+			"role":  ".",
+			"admin": ".role",
+			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.QLC0vl-A11a1WcUPD6vQR2PlUvRMsqpegddfQzPajQM": ".token",
+			"sub":        ".token<jwt>",
+			"1234567890": ".token<jwt>.sub",
+			"name":       ".token<jwt>",
+			"John Doe":   ".token<jwt>.name",
+			"iat":        ".token<jwt>",
+		}
+		actual := extractStringsFromUserInput(obj, []pathPart{})
 		if !reflect.DeepEqual(expected, actual) {
 			t.Errorf("Expected %v, got %v", expected, actual)
 		}

--- a/vulnerabilities/extract_strings_from_user_input_test.go
+++ b/vulnerabilities/extract_strings_from_user_input_test.go
@@ -362,9 +362,9 @@ func TestExtractStringsFromUserInput(t *testing.T) {
 		}
 
 		expected = map[string]string{
-			"arr":  ".",
-			"1":    ".arr.[0]",
-			"test": ".arr.[5].test",
+			"arr":                                 ".",
+			"1":                                   ".arr.[0]",
+			"test":                                ".arr.[5].test",
 			"1,2,true,<nil>,<nil>,map[test:test]": ".arr",
 		}
 		actual = extractStringsFromUserInput(obj, []pathPart{})


### PR DESCRIPTION
Removes 14 (42 -> 28) allocs per op with `make bench-os`.  Reflect isn't necessary here, we can use basic typecasting.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 1 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Preallocated path slice to reduce allocations and improve performance.
* Added explicit handling for maps, slices, url.Values, and string arrays.

**🔧 Refactors**
* Rewrote extraction to use type assertions with reflect fallback.
* Adjusted JWT extraction to clone path and filter iss values safely.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/143843381?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->