### PR TITLE
Add 'go' command to zen-go CLI for 'go tool' support

### DIFF
--- a/cmd/zen-go/cmd_go.go
+++ b/cmd/zen-go/cmd_go.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+var toolexecSubcommands = map[string]bool{
+	"build":   true,
+	"install": true,
+	"run":     true,
+	"test":    true,
+	"vet":     true,
+}
+
+func buildGoArgs(self string, args []string) []string {
+	if !toolexecSubcommands[args[0]] {
+		return args
+	}
+
+	toolexec := fmt.Sprintf("-toolexec=%s toolexec", self)
+
+	goArgs := make([]string, 0, len(args)+1)
+	goArgs = append(goArgs, args[0], toolexec)
+	goArgs = append(goArgs, args[1:]...)
+	return goArgs
+}
+
+func goCommand(stdout io.Writer, stderr io.Writer, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("no go command specified")
+	}
+
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		return fmt.Errorf("could not find go binary: %w", err)
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine zen-go path: %w", err)
+	}
+
+	// #nosec G204 - goBin is the Go toolchain resolved from PATH
+	cmd := exec.Command(goBin, buildGoArgs(self, args)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	return cmd.Run()
+}

--- a/cmd/zen-go/cmd_go.go
+++ b/cmd/zen-go/cmd_go.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 var toolexecSubcommands = map[string]bool{
@@ -15,17 +16,34 @@ var toolexecSubcommands = map[string]bool{
 	"vet":     true,
 }
 
-func buildGoArgs(self string, args []string) []string {
+func quoteToolexecArg(arg string) (string, error) {
+	switch {
+	case !strings.ContainsAny(arg, " \t'\""):
+		return arg, nil
+	case !strings.Contains(arg, "'"):
+		return "'" + arg + "'", nil
+	case !strings.Contains(arg, `"`):
+		return `"` + arg + `"`, nil
+	default:
+		return "", fmt.Errorf("zen-go path %q contains both single and double quotes and cannot be passed to -toolexec", arg)
+	}
+}
+
+func buildGoArgs(self string, args []string) ([]string, error) {
 	if !toolexecSubcommands[args[0]] {
-		return args
+		return args, nil
 	}
 
-	toolexec := fmt.Sprintf("-toolexec=%s toolexec", self)
+	quoted, err := quoteToolexecArg(self)
+	if err != nil {
+		return nil, err
+	}
+	toolexec := fmt.Sprintf("-toolexec=%s toolexec", quoted)
 
 	goArgs := make([]string, 0, len(args)+1)
 	goArgs = append(goArgs, args[0], toolexec)
 	goArgs = append(goArgs, args[1:]...)
-	return goArgs
+	return goArgs, nil
 }
 
 func goCommand(stdout io.Writer, stderr io.Writer, args []string) error {
@@ -43,8 +61,13 @@ func goCommand(stdout io.Writer, stderr io.Writer, args []string) error {
 		return fmt.Errorf("could not determine zen-go path: %w", err)
 	}
 
+	goArgs, err := buildGoArgs(self, args)
+	if err != nil {
+		return err
+	}
+
 	// #nosec G204 - goBin is the Go toolchain resolved from PATH
-	cmd := exec.Command(goBin, buildGoArgs(self, args)...)
+	cmd := exec.Command(goBin, goArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/cmd/zen-go/cmd_go_test.go
+++ b/cmd/zen-go/cmd_go_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildGoArgs(t *testing.T) {
+	t.Run("injects toolexec after subcommand", func(t *testing.T) {
+		got := buildGoArgs("/abs/zen-go", []string{"build", "./..."})
+		assert.Equal(t, []string{"build", "-toolexec=/abs/zen-go toolexec", "./..."}, got)
+	})
+
+	t.Run("subcommand only", func(t *testing.T) {
+		got := buildGoArgs("/abs/zen-go", []string{"build"})
+		assert.Equal(t, []string{"build", "-toolexec=/abs/zen-go toolexec"}, got)
+	})
+
+	t.Run("preserves trailing flags", func(t *testing.T) {
+		got := buildGoArgs("/abs/zen-go", []string{"test", "-race", "-tags=integration", "./..."})
+		assert.Equal(t, []string{"test", "-toolexec=/abs/zen-go toolexec", "-race", "-tags=integration", "./..."}, got)
+	})
+
+	t.Run("passes through non-compiling subcommands untouched", func(t *testing.T) {
+		args := []string{"help", "build"}
+		assert.Equal(t, args, buildGoArgs("/abs/zen-go", args))
+
+		args = []string{"mod", "tidy"}
+		assert.Equal(t, args, buildGoArgs("/abs/zen-go", args))
+	})
+}
+
+func TestGoCommandNoArgs(t *testing.T) {
+	err := goCommand(nil, nil, nil)
+	assert.ErrorContains(t, err, "no go command specified")
+}

--- a/cmd/zen-go/cmd_go_test.go
+++ b/cmd/zen-go/cmd_go_test.go
@@ -8,26 +8,44 @@ import (
 
 func TestBuildGoArgs(t *testing.T) {
 	t.Run("injects toolexec after subcommand", func(t *testing.T) {
-		got := buildGoArgs("/abs/zen-go", []string{"build", "./..."})
+		got, err := buildGoArgs("/abs/zen-go", []string{"build", "./..."})
+		assert.NoError(t, err)
 		assert.Equal(t, []string{"build", "-toolexec=/abs/zen-go toolexec", "./..."}, got)
 	})
 
 	t.Run("subcommand only", func(t *testing.T) {
-		got := buildGoArgs("/abs/zen-go", []string{"build"})
+		got, err := buildGoArgs("/abs/zen-go", []string{"build"})
+		assert.NoError(t, err)
 		assert.Equal(t, []string{"build", "-toolexec=/abs/zen-go toolexec"}, got)
 	})
 
 	t.Run("preserves trailing flags", func(t *testing.T) {
-		got := buildGoArgs("/abs/zen-go", []string{"test", "-race", "-tags=integration", "./..."})
+		got, err := buildGoArgs("/abs/zen-go", []string{"test", "-race", "-tags=integration", "./..."})
+		assert.NoError(t, err)
 		assert.Equal(t, []string{"test", "-toolexec=/abs/zen-go toolexec", "-race", "-tags=integration", "./..."}, got)
+	})
+
+	t.Run("quotes path containing spaces", func(t *testing.T) {
+		got, err := buildGoArgs("/abs/My Tools/zen-go", []string{"build", "./..."})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"build", "-toolexec='/abs/My Tools/zen-go' toolexec", "./..."}, got)
+	})
+
+	t.Run("errors when path contains both quote styles", func(t *testing.T) {
+		_, err := buildGoArgs(`/abs/it's "weird"/zen-go`, []string{"build", "./..."})
+		assert.ErrorContains(t, err, "cannot be passed to -toolexec")
 	})
 
 	t.Run("passes through non-compiling subcommands untouched", func(t *testing.T) {
 		args := []string{"help", "build"}
-		assert.Equal(t, args, buildGoArgs("/abs/zen-go", args))
+		got, err := buildGoArgs("/abs/zen-go", args)
+		assert.NoError(t, err)
+		assert.Equal(t, args, got)
 
 		args = []string{"mod", "tidy"}
-		assert.Equal(t, args, buildGoArgs("/abs/zen-go", args))
+		got, err = buildGoArgs("/abs/zen-go", args)
+		assert.NoError(t, err)
+		assert.Equal(t, args, got)
 	})
 }
 

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -57,6 +57,14 @@ func newCommand() *cli.Command {
 				},
 			},
 			{
+				Name:            "go",
+				Usage:           "Run a go command with Zen instrumentation enabled (e.g. zen-go go build ./...)",
+				SkipFlagParsing: true,
+				Action: func(ctx context.Context, cmd *cli.Command) error {
+					return goCommand(os.Stdout, os.Stderr, cmd.Args().Slice())
+				},
+			},
+			{
 				Name:            "toolexec",
 				SkipFlagParsing: true,
 				Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/sample-apps/common.mk
+++ b/sample-apps/common.mk
@@ -10,13 +10,13 @@ export AIKIDO_DEBUG ?= true
 
 build: check-zen-go
 	@mkdir -p bin
-	@go build -toolexec="$(ZENGO) toolexec" -o $(BINARY) .
+	@$(ZENGO) go build -o $(BINARY) .
 
 run: build
 	@PORT=$(PORT) ./$(BINARY)
 
 dev: check-zen-go
-	@PORT=$(PORT) go run -toolexec="$(ZENGO) toolexec" .
+	@PORT=$(PORT) $(ZENGO) go run .
 
 start-database:
 	@cd ../databases/ && docker compose up $(DB_SERVICE) -d --wait


### PR DESCRIPTION
Allows for running `zen-go` with `go tool zen-go go build .` instead of having to add the toolexec, and allows us to pin the tool version in go.mod.

I've updated the sample apps to already use the `zen-go go build .` approach.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added 'go' command to run go tool with Zen instrumentation

**⚡ Enhancements**
* Enhanced quoting logic to handle single and double quotes in paths


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137268800?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->