### PR TITLE
Exclude zen-go CLI from version mismatch check

### DIFF
--- a/cmd/zen-go/internal/rules/modcheck.go
+++ b/cmd/zen-go/internal/rules/modcheck.go
@@ -77,7 +77,11 @@ func CheckModuleVersionSync(gomodPath string) error {
 	type mismatch struct{ path, version string }
 	var mismatches []mismatch
 
+	const zenGoModule = aikidoMainModule + "/cmd/zen-go"
 	for _, req := range f.Require {
+		if req.Mod.Path == zenGoModule {
+			continue
+		}
 		if strings.HasPrefix(req.Mod.Path, aikidoMainModule+"/") && !replaced[req.Mod.Path] && req.Mod.Version != mainVersion {
 			mismatches = append(mismatches, mismatch{req.Mod.Path, req.Mod.Version})
 		}

--- a/cmd/zen-go/internal/rules/modcheck_test.go
+++ b/cmd/zen-go/internal/rules/modcheck_test.go
@@ -147,6 +147,27 @@ require (
 	require.NoError(t, CheckModuleVersionSync(path))
 }
 
+func TestCheckModuleVersionSync_ZenGoToolIgnored(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGoMod(t, dir, `module example.com/app
+
+go 1.25.0
+
+require (
+	github.com/AikidoSec/firewall-go v1.2.5
+	github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin v1.2.5
+	github.com/gin-gonic/gin v1.12.0
+)
+
+require (
+	github.com/AikidoSec/firewall-go/cmd/zen-go v1.0.4 // indirect
+)
+
+tool github.com/AikidoSec/firewall-go/cmd/zen-go
+`)
+	require.NoError(t, CheckModuleVersionSync(path))
+}
+
 func TestFindGoMod_Found(t *testing.T) {
 	root := t.TempDir()
 	gomodPath := filepath.Join(root, "go.mod")


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Excluded zen-go CLI from instrumentation version mismatch checks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137295186?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->