### PR TITLE
Bump zen-go CLI to v1.0.4

### DIFF
--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const version = "1.0.3"
+const version = "1.0.4"
 
 func newCommand() *cli.Command {
 	return &cli.Command{

--- a/cmd/zen-go/main_test.go
+++ b/cmd/zen-go/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "1.0.3", version)
+	assert.Equal(t, "1.0.4", version)
 }
 
 func TestCLI(t *testing.T) {
@@ -27,12 +27,12 @@ func TestCLI(t *testing.T) {
 		{
 			name:           "version short flag -v",
 			args:           []string{"zen-go", "-v"},
-			stdoutContains: []string{"zen-go version 1.0.3"},
+			stdoutContains: []string{"zen-go version 1.0.4"},
 		},
 		{
 			name:           "version long flag --version",
 			args:           []string{"zen-go", "--version"},
-			stdoutContains: []string{"zen-go version 1.0.3"},
+			stdoutContains: []string{"zen-go version 1.0.4"},
 		},
 		{
 			name:           "help command",


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped zen-go CLI version constant to v1.0.4 in main.go


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137320733?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->