### PR TITLE
Add `zen-go` tool directive as part of init and change recommended install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,12 @@ func main() {
 
 Zen needs to instrument your code at build time to intercept and monitor operations like database queries and system calls.
 
-Install the Zen build tool:
+The `zen-go` go tool should have been installed automatically as part of `zen-go init`.
+
+Update your build process to use `zen-go` with:
 
 ```bash
-go install github.com/AikidoSec/firewall-go/cmd/zen-go@latest
-```
-
-Then update your build process to use `zen-go` via `toolexec`:
-
-```bash
-go build -toolexec="zen-go toolexec" -o bin/app
+go tool zen-go go build -o bin/app
 ```
 
 > `zen-go` instruments your application at build time.

--- a/cmd/zen-go/README.md
+++ b/cmd/zen-go/README.md
@@ -7,19 +7,19 @@ CLI build tool for [Aikido Zen for Go](../../README.md). It instruments your Go 
 Install:
 
 ```bash
-go install github.com/AikidoSec/firewall-go/cmd/zen-go@latest
+go get -tool github.com/AikidoSec/firewall-go/cmd/zen-go
 ```
 
 Create initial zen-go configuration for your project (creates `zen.tool.go`):
 
 ```bash
-zen-go init
+go tool zen-go init
 ```
 
 Build with instrumentation:
 
 ```bash
-go build -toolexec="zen-go toolexec" -o bin/app .
+go tool zen-go go build -o bin/app .
 ```
 
 ## How it works

--- a/cmd/zen-go/cmd_init.go
+++ b/cmd/zen-go/cmd_init.go
@@ -226,6 +226,12 @@ func initCommand(stdout io.Writer, force, auto bool, sourcesFlag string, sources
 	fmt.Fprintf(stdout, "✓ Created %s\n", filename)
 	fmt.Fprintf(stdout, "  %s\n\n", absPath)
 
+	if gomodPath, toolErr := addZenGoTool(); toolErr != nil {
+		fmt.Fprintf(stdout, "⚠️  Could not add tool directive to go.mod: %v\n\n", toolErr)
+	} else {
+		fmt.Fprintf(stdout, "✓ Added zen-go tool directive to %s\n\n", gomodPath)
+	}
+
 	if len(selectedSources) > 0 {
 		fmt.Fprintf(stdout, "  Sources: %s\n", strings.Join(selectedSources, ", "))
 	}
@@ -239,9 +245,8 @@ func initCommand(stdout io.Writer, force, auto bool, sourcesFlag string, sources
 
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Next steps:")
-	fmt.Fprintln(stdout, "  1. Run 'go mod tidy' to update your dependencies")
-	fmt.Fprintln(stdout, "  2. Install `zen-go` CLI with 'go install github.com/AikidoSec/firewall-go/cmd/zen-go@latest'")
-	fmt.Fprintln(stdout, "  3. Build with 'go build -toolexec=\"zen-go toolexec\"' to enable instrumentation")
+	fmt.Fprintln(stdout, "  1. Run 'go mod tidy' to download dependencies including zen-go")
+	fmt.Fprintln(stdout, "  2. Build with 'go tool zen-go go build ./...' to enable instrumentation")
 
 	return nil
 }

--- a/cmd/zen-go/cmd_init_detect.go
+++ b/cmd/zen-go/cmd_init_detect.go
@@ -8,6 +8,8 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+const zenGoModulePath = "github.com/AikidoSec/firewall-go/cmd/zen-go"
+
 func loadProjectGoMod() (map[string]struct{}, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -40,6 +42,45 @@ func parseGoModRequires(path string) (map[string]struct{}, error) {
 		requires[r.Mod.Path] = struct{}{}
 	}
 	return requires, nil
+}
+
+func addZenGoTool() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	gomodPath := rules.FindGoMod(cwd)
+	if gomodPath == "" {
+		return "", fmt.Errorf("go.mod not found in %s or any parent directory", cwd)
+	}
+
+	// #nosec G304 - path is derived from the project source directory
+	data, err := os.ReadFile(gomodPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", gomodPath, err)
+	}
+
+	f, err := modfile.Parse(gomodPath, data, nil)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", gomodPath, err)
+	}
+
+	if err = f.AddTool(zenGoModulePath); err != nil {
+		return "", fmt.Errorf("add tool to %s: %w", gomodPath, err)
+	}
+
+	out, err := f.Format()
+	if err != nil {
+		return "", fmt.Errorf("format %s: %w", gomodPath, err)
+	}
+
+	// #nosec G306 - go.mod is a source file readable by all
+	// #nosec G703 - path is derived from the project source directory
+	if err := os.WriteFile(gomodPath, out, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", gomodPath, err)
+	}
+
+	return gomodPath, nil
 }
 
 // detectInstalledOptions returns the names of options whose goModulePath is


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added function to add zen-go tool directive to go.mod

**📚 Documentation**
* Updated init output instructions to recommend building with zen-go tool


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153451240?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->