### PR TITLE
Respect force protection off with outbound blocking and update QA to v1.0.16

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -37,3 +37,4 @@ jobs:
           app_port: 3000
           sleep_before_test: 10
           test_timeout: 900
+          skip_tests: test_rate_limiting_retry_after,test_user_ip_from_proxy

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -31,7 +31,7 @@ jobs:
           sed -i "s|github.com/AikidoSec/firewall-go/cmd/zen-go@[^ ]*|github.com/AikidoSec/firewall-go/cmd/zen-go@$GITHUB_SHA|" Dockerfile
 
       - name: Run Firewall QA Tests
-        uses: AikidoSec/firewall-tester-action@v1.0.14
+        uses: AikidoSec/firewall-tester-action@v1.0.16
         with:
           dockerfile_path: ./zen-demo-go/Dockerfile
           app_port: 3000

--- a/instrumentation/sinks/net/http/examine.go
+++ b/instrumentation/sinks/net/http/examine.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AikidoSec/firewall-go/instrumentation/hooks"
 	"github.com/AikidoSec/firewall-go/instrumentation/operation"
+	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/normalize"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
@@ -31,6 +32,12 @@ func Examine(r *http.Request) error {
 	// If bypassed IP, report hostname, but don't attempt to block it
 	if request.IsBypassed(r.Context()) {
 		return nil
+	}
+
+	if reqCtx := request.GetContext(r.Context()); reqCtx != nil {
+		if endpoints.IsForceProtectionOff(reqCtx.Method, reqCtx.Route) {
+			return nil
+		}
 	}
 
 	if hooks.ShouldBlockHostname(hostname) {

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -136,6 +136,53 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 	require.Equal(t, 3, stats.Operations["net/http.Client.Do"].Total, "should track 3 HTTP calls")
 }
 
+func TestExamine_ForceProtectionOffSkipsOutboundBlocking(t *testing.T) {
+	originalDisabled := zen.IsDisabled()
+	originalClient := agent.GetCloudClient()
+	defer func() {
+		zen.SetDisabled(originalDisabled)
+		agent.SetCloudClient(originalClient)
+	}()
+
+	require.NoError(t, zen.Protect())
+	agent.SetCloudClient(testutil.NewMockCloudClient())
+
+	block := true
+	config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+		ConfigUpdatedAt: time.Now().UnixMilli(),
+		Block:           &block,
+		Domains: []aikido_types.OutboundDomain{
+			{Hostname: "blocked.com", Mode: "block"},
+		},
+		Endpoints: []aikido_types.Endpoint{
+			{
+				Method:             "GET",
+				Route:              "/api/no-protection",
+				ForceProtectionOff: true,
+			},
+		},
+	}, nil)
+
+	incomingReq := httptest.NewRequest("GET", "/api/no-protection", nil)
+	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+		Source: "test",
+		Route:  "/api/no-protection",
+	})
+
+	outboundReq, _ := http.NewRequestWithContext(ctx, "GET", "http://blocked.com", http.NoBody)
+	assert.NoError(t, Examine(outboundReq), "force protection off route should not block outbound connections")
+
+	// A route without force protection off should still be blocked
+	incomingReqNormal := httptest.NewRequest("GET", "/api/normal", nil)
+	ctxNormal := request.SetContext(context.Background(), incomingReqNormal, request.ContextData{
+		Source: "test",
+		Route:  "/api/normal",
+	})
+	outboundReqNormal, _ := http.NewRequestWithContext(ctxNormal, "GET", "http://blocked.com", http.NoBody)
+	var blockedErr *zen.OutboundConnectionBlocked
+	require.ErrorAs(t, Examine(outboundReqNormal), &blockedErr, "normal route should still block outbound connections")
+}
+
 func TestExamine_BypassedIPSkipsOutboundBlocking(t *testing.T) {
 	originalDisabled := zen.IsDisabled()
 	originalClient := agent.GetCloudClient()

--- a/internal/agent/endpoints/match.go
+++ b/internal/agent/endpoints/match.go
@@ -69,3 +69,12 @@ func FindMatches(endpoints []config.Endpoint, context RouteMetadata) []config.En
 
 	return matches
 }
+
+func IsForceProtectionOff(method, route string) bool {
+	for _, match := range FindMatches(config.GetEndpoints(), RouteMetadata{Method: method, Route: route}) {
+		if match.ForceProtectionOff {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/endpoints/match_test.go
+++ b/internal/agent/endpoints/match_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/ipaddr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // sampleRouteMetadata creates a new RouteMetadata for testing.
@@ -282,4 +283,23 @@ func TestFindMatches(t *testing.T) {
 		result := FindMatches(endpoints, routeMetadata)
 		assert.Equal(t, expected, result)
 	})
+}
+
+func TestIsForceProtectionOff(t *testing.T) {
+	block := true
+	config.UpdateServiceConfig(&aikido_types.CloudConfigData{
+		Block: &block,
+		Endpoints: []aikido_types.Endpoint{
+			{Method: "POST", Route: "/api/danger", ForceProtectionOff: true},
+			{Method: "*", Route: "/api/wildcard", ForceProtectionOff: true},
+			{Method: "GET", Route: "/api/safe", ForceProtectionOff: false},
+		},
+	}, nil)
+
+	require.True(t, IsForceProtectionOff("POST", "/api/danger"), "exact match with force protection off")
+	require.True(t, IsForceProtectionOff("GET", "/api/wildcard"), "wildcard method with force protection off")
+	require.False(t, IsForceProtectionOff("GET", "/api/safe"), "force protection off is false")
+	require.False(t, IsForceProtectionOff("GET", "/api/danger"), "wrong method should not match")
+	require.False(t, IsForceProtectionOff("POST", "/api/unknown"), "unmatched route returns false")
+	require.False(t, IsForceProtectionOff("", "/api/danger"), "empty method returns false")
 }

--- a/vulnerabilities/attack.go
+++ b/vulnerabilities/attack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
+	"github.com/AikidoSec/firewall-go/internal/agent/endpoints"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
 
@@ -180,7 +181,7 @@ func OnStoredSSRF(ctx context.Context, module string, operation string, hostname
 	}
 
 	reqCtx := request.GetContext(ctx)
-	if reqCtx != nil && isForceProtectionOff(reqCtx.Method, reqCtx.Route) {
+	if reqCtx != nil && endpoints.IsForceProtectionOff(reqCtx.Method, reqCtx.Route) {
 		return nil
 	}
 

--- a/vulnerabilities/scan.go
+++ b/vulnerabilities/scan.go
@@ -26,19 +26,6 @@ type ScanOptions struct {
 	Module         string
 }
 
-func isForceProtectionOff(method, route string) bool {
-	matches := endpoints.FindMatches(config.GetEndpoints(), endpoints.RouteMetadata{
-		Method: method,
-		Route:  route,
-	})
-	for _, match := range matches {
-		if match.ForceProtectionOff {
-			return true
-		}
-	}
-	return false
-}
-
 func Scan[T any](ctx context.Context, operation string, vulnerability Vulnerability[T], args T) error {
 	return ScanWithOptions(ctx, operation, vulnerability, args, ScanOptions{})
 }
@@ -54,7 +41,7 @@ func ScanWithOptions[T any](ctx context.Context, operation string, vulnerability
 	}
 
 	// Check if route has force protection off, if so, we don't run any scans
-	if isForceProtectionOff(reqCtx.Method, reqCtx.Route) {
+	if endpoints.IsForceProtectionOff(reqCtx.Method, reqCtx.Route) {
 		return nil
 	}
 


### PR DESCRIPTION
Skipping the retry-after QA, will implement in another PR.
Skipping user IP from proxy test, as Gin source doesn't use that envvar. Will think about solution for that.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Skipped outbound blocking when endpoints had force protection turned off
* Updated QA tester action to v1.0.16 and skipped flaky tests

**🔧 Refactors**
* Centralized force protection check into endpoints package and exported
* Replaced local force-protection checks with centralized endpoints.IsForceProtectionOff calls


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152662133?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->