### PR TITLE
Bump versions to v1.2.7

### DIFF
--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const version = "1.0.4"
+const version = "1.2.7"
 
 func newCommand() *cli.Command {
 	return &cli.Command{

--- a/cmd/zen-go/main_test.go
+++ b/cmd/zen-go/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "1.0.4", version)
+	assert.Equal(t, "1.2.7", version)
 }
 
 func TestCLI(t *testing.T) {
@@ -27,12 +27,12 @@ func TestCLI(t *testing.T) {
 		{
 			name:           "version short flag -v",
 			args:           []string{"zen-go", "-v"},
-			stdoutContains: []string{"zen-go version 1.0.4"},
+			stdoutContains: []string{"zen-go version 1.2.7"},
 		},
 		{
 			name:           "version long flag --version",
 			args:           []string{"zen-go", "--version"},
-			stdoutContains: []string{"zen-go version 1.0.4"},
+			stdoutContains: []string{"zen-go version 1.2.7"},
 		},
 		{
 			name:           "help command",

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -249,7 +249,7 @@ func TestInitWithProvidedEndpoints(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	require.Equal(t, "1.2.6", Version)
+	require.Equal(t, "1.2.7", Version)
 }
 
 func TestInitReturnsErrorForInvalidConfig(t *testing.T) {

--- a/internal/agent/config/globals.go
+++ b/internal/agent/config/globals.go
@@ -1,5 +1,5 @@
 package config
 
 const (
-	Version = "1.2.6"
+	Version = "1.2.7"
 )


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Bumped internal agent package version constant to 1.2.7.
* Updated CLI binary version constant in main to 1.2.7.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147095240?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->