### PR TITLE
Add agent platform and version headers to SSE

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,6 +62,8 @@ func Init(environmentConfig *aikido_types.EnvironmentConfigData, aikidoConfig *a
 		Token:            aikidoConfig.Token,
 		APIEndpoint:      globals.EnvironmentConfig.Endpoint,
 		RealtimeEndpoint: globals.EnvironmentConfig.RealtimeEndpoint,
+		Platform:         globals.EnvironmentConfig.PlatformName,
+		Version:          globals.EnvironmentConfig.Version,
 	})
 	SetCloudClient(client)
 

--- a/internal/agent/cloud/client.go
+++ b/internal/agent/cloud/client.go
@@ -9,6 +9,8 @@ type ClientConfig struct {
 	APIEndpoint      string
 	RealtimeEndpoint string
 	Token            string
+	Platform         string
+	Version          string
 }
 
 type Client struct {
@@ -16,6 +18,8 @@ type Client struct {
 	apiEndpoint      string
 	realtimeEndpoint string
 	token            string
+	platform         string
+	version          string
 }
 
 func NewClient(cfg *ClientConfig) *Client {
@@ -26,5 +30,7 @@ func NewClient(cfg *ClientConfig) *Client {
 		apiEndpoint:      cfg.APIEndpoint,
 		realtimeEndpoint: cfg.RealtimeEndpoint,
 		token:            cfg.Token,
+		platform:         cfg.Platform,
+		version:          cfg.Version,
 	}
 }

--- a/internal/agent/cloud/client_test.go
+++ b/internal/agent/cloud/client_test.go
@@ -20,11 +20,15 @@ func TestNewClient(t *testing.T) {
 				APIEndpoint:      "https://localhost:8080",
 				RealtimeEndpoint: "https://localhost:8081",
 				Token:            "test-token-123",
+				Platform:         "golang",
+				Version:          "1.2.7",
 			},
 			want: &Client{
 				apiEndpoint:      "https://localhost:8080",
 				realtimeEndpoint: "https://localhost:8081",
 				token:            "test-token-123",
+				platform:         "golang",
+				version:          "1.2.7",
 			},
 		},
 		{
@@ -50,6 +54,8 @@ func TestNewClient(t *testing.T) {
 			assert.Equal(t, tt.want.apiEndpoint, got.apiEndpoint, "apiEndpoint mismatch")
 			assert.Equal(t, tt.want.realtimeEndpoint, got.realtimeEndpoint, "realtimeEndpoint mismatch")
 			assert.Equal(t, tt.want.token, got.token, "token mismatch")
+			assert.Equal(t, tt.want.platform, got.platform, "platform mismatch")
+			assert.Equal(t, tt.want.version, got.version, "version mismatch")
 			assert.NotNil(t, got.httpClient, "httpClient should not be nil")
 		})
 	}

--- a/internal/agent/cloud/sse.go
+++ b/internal/agent/cloud/sse.go
@@ -42,6 +42,8 @@ func (c *Client) SubscribeToConfigUpdates(ctx context.Context, onUpdate func(con
 	req.Header.Set("Authorization", c.token)
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("X-Agent-Platform", c.platform)
+	req.Header.Set("X-Agent-Version", c.version)
 
 	resp, err := (&http.Client{}).Do(req)
 	if err != nil {

--- a/internal/agent/cloud/sse_test.go
+++ b/internal/agent/cloud/sse_test.go
@@ -87,11 +87,11 @@ func TestSSEParserFeedLine(t *testing.T) {
 
 func TestSubscribeToConfigUpdates(t *testing.T) {
 	t.Run("connects with auth header and receives events, ignoring pings", func(t *testing.T) {
-		var receivedAuth string
+		var receivedHeaders http.Header
 		release := make(chan struct{})
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			receivedAuth = r.Header.Get("Authorization")
+			receivedHeaders = r.Header
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
 			flusher := w.(http.Flusher)
@@ -106,7 +106,7 @@ func TestSubscribeToConfigUpdates(t *testing.T) {
 		}))
 		defer server.Close()
 
-		client := &Client{realtimeEndpoint: server.URL, token: "my-secret-token"}
+		client := &Client{realtimeEndpoint: server.URL, token: "my-secret-token", platform: "golang", version: "1.2.7"}
 
 		updates := make(chan int64, 1)
 		done := make(chan error, 1)
@@ -123,7 +123,11 @@ func TestSubscribeToConfigUpdates(t *testing.T) {
 			t.Fatal("timed out waiting for config update")
 		}
 
-		assert.Equal(t, "my-secret-token", receivedAuth)
+		assert.Equal(t, "my-secret-token", receivedHeaders.Get("Authorization"))
+		assert.Equal(t, "text/event-stream", receivedHeaders.Get("Accept"))
+		assert.Equal(t, "no-cache", receivedHeaders.Get("Cache-Control"))
+		assert.Equal(t, "golang", receivedHeaders.Get("X-Agent-Platform"))
+		assert.Equal(t, "1.2.7", receivedHeaders.Get("X-Agent-Version"))
 
 		close(release)
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added platform and version fields to cloud client config
* Sent X-Agent-Platform and X-Agent-Version headers on SSE subscribe


<sup>[More info](https://app.aikido.dev/featurebranch/scan/149815189?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->