### PR TITLE
Detect shell injection when using combined short options

### DIFF
--- a/instrumentation/sinks/os/exec/integration_test.go
+++ b/instrumentation/sinks/os/exec/integration_test.go
@@ -122,6 +122,19 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 				command:     []string{"echo", "hello"},
 				shouldBlock: false,
 			},
+			// Combined short options: shells honor -c regardless of its position
+			{
+				name:        "combined short options -ec (c last)",
+				queryParam:  "cmd=cat%20/etc/passwd",
+				command:     []string{"bash", "-ec", "cat /etc/passwd"},
+				shouldBlock: true,
+			},
+			{
+				name:        "combined short options -cx (c not last)",
+				queryParam:  "cmd=cat%20/etc/passwd",
+				command:     []string{"bash", "-cx", "cat /etc/passwd"},
+				shouldBlock: true,
+			},
 		}
 
 		for _, tc := range testCases {

--- a/vulnerabilities/shellinjection/parse_shell_command.go
+++ b/vulnerabilities/shellinjection/parse_shell_command.go
@@ -19,13 +19,11 @@ func IsShellCommand(program string) bool {
 }
 
 // ExtractShellCommandString extracts the command string from shell invocation arguments.
-// It looks for the -c flag and returns everything after it as the command string
-// to be interpreted by the shell.
+// It looks for a -c flag (including combined short options like -ec or -cx) and
+// returns everything after it as the command string to be interpreted by the shell.
 func ExtractShellCommandString(args []string) []string {
 	for i := 1; i < len(args); i++ {
-		flag := args[i]
-		if flag == "-c" {
-			// Return everything after the flag
+		if isCommandFlag(args[i]) {
 			if i+1 < len(args) {
 				return args[i+1:]
 			}
@@ -34,4 +32,15 @@ func ExtractShellCommandString(args []string) []string {
 	}
 
 	return nil
+}
+
+// isCommandFlag matches -c anywhere in the flag, since shells parse combined short options as an unordered set.
+func isCommandFlag(flag string) bool {
+	if len(flag) < 2 || flag[0] != '-' || flag[1] == '-' {
+		return false
+	}
+	if strings.Contains(flag, "=") {
+		return false
+	}
+	return strings.ContainsRune(flag[1:], 'c')
 }

--- a/vulnerabilities/shellinjection/parse_shell_command_test.go
+++ b/vulnerabilities/shellinjection/parse_shell_command_test.go
@@ -220,6 +220,99 @@ func TestExtractShellCommandString(t *testing.T) {
 			args:     []string{"bash", "-c", "cat $(whoami).txt"},
 			expected: []string{"cat $(whoami).txt"},
 		},
+		// Combined short options, 'c' last
+		{
+			name:     "bash -ec with command",
+			args:     []string{"bash", "-ec", "cat /etc/passwd"},
+			expected: []string{"cat /etc/passwd"},
+		},
+		{
+			name:     "sh -xc with command",
+			args:     []string{"sh", "-xc", "cat /etc/passwd"},
+			expected: []string{"cat /etc/passwd"},
+		},
+		{
+			name:     "bash -euc with command",
+			args:     []string{"bash", "-euc", "whoami"},
+			expected: []string{"whoami"},
+		},
+		{
+			name:     "sh -euxc with command",
+			args:     []string{"sh", "-euxc", "ls -la"},
+			expected: []string{"ls -la"},
+		},
+		// Combined short options, 'c' not last (shells honor -c regardless of position)
+		{
+			name:     "bash -cx with command (c first)",
+			args:     []string{"bash", "-cx", "cat /etc/passwd"},
+			expected: []string{"cat /etc/passwd"},
+		},
+		{
+			name:     "sh -ce with command (c first)",
+			args:     []string{"sh", "-ce", "cat /etc/passwd"},
+			expected: []string{"cat /etc/passwd"},
+		},
+		{
+			name:     "bash -cu with command (c first)",
+			args:     []string{"bash", "-cu", "whoami"},
+			expected: []string{"whoami"},
+		},
+		{
+			name:     "sh -xce with command (c in the middle)",
+			args:     []string{"sh", "-xce", "ls -la"},
+			expected: []string{"ls -la"},
+		},
+		{
+			name:     "bash -ecux with command (c not last, four flags)",
+			args:     []string{"bash", "-ecux", "cat /etc/passwd"},
+			expected: []string{"cat /etc/passwd"},
+		},
+		{
+			name:     "combined options (c not last) with injection payload",
+			args:     []string{"sh", "-cx", "ping 8.8.8.8;cat /etc/passwd"},
+			expected: []string{"ping 8.8.8.8;cat /etc/passwd"},
+		},
+		{
+			name:     "combined options (c not last) with multiple args",
+			args:     []string{"bash", "-cx", "echo", "hello"},
+			expected: []string{"echo", "hello"},
+		},
+		// Negative cases for combined options
+		{
+			name:     "single char option not c",
+			args:     []string{"sh", "-e", "script.sh"},
+			expected: nil,
+		},
+		{
+			name:     "combined options without c",
+			args:     []string{"bash", "-ex", "script.sh"},
+			expected: nil,
+		},
+		{
+			name:     "long option with c",
+			args:     []string{"bash", "--command", "ls"},
+			expected: nil,
+		},
+		{
+			name:     "option with equals",
+			args:     []string{"bash", "-c=ls", "test"},
+			expected: nil,
+		},
+		{
+			name:     "combined option at end with no command",
+			args:     []string{"sh", "-cx"},
+			expected: nil,
+		},
+		{
+			name:     "lone dash",
+			args:     []string{"sh", "-", "script.sh"},
+			expected: nil,
+		},
+		{
+			name:     "double dash only",
+			args:     []string{"sh", "--", "script.sh"},
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adjusted version of: 
- https://github.com/AikidoSec/firewall-go/pull/498

Fixes bypass when using combined short options. The autofix PR was missing that the `c` can be in any position in the combined options.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added isCommandFlag helper to recognize -c anywhere in flags

**🐛 Bugfixes**
* Fixed detection of -c within combined short options to prevent bypass

**📚 Documentation**
* Updated ExtractShellCommandString comment to document combined short option behavior


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152732976?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->