### PR TITLE
Fix shell injection bypass via nested quoting in isSafelyEncapsulated

### DIFF
--- a/vulnerabilities/shellinjection/is_safely_encapsulated.go
+++ b/vulnerabilities/shellinjection/is_safely_encapsulated.go
@@ -1,73 +1,108 @@
 package shellinjection
 
 import (
-	"slices"
 	"strings"
 )
 
-var (
-	escapeChars                      = []string{`"`, `'`}
-	dangerousCharsInsideDoubleQuotes = []string{"$", "`", "\\", "!"}
+// quoteContext represents the quoting state at a position in the command.
+type quoteContext int
+
+const (
+	noQuote quoteContext = iota
+	singleQuote
+	doubleQuote
 )
 
-func isSafelyEncapsulated(command, userInput string) bool {
-	segments := getCurrentAndNextSegments(strings.Split(command, userInput))
+// quoteStatesAt returns the quote context active just before each byte of
+// command, plus one trailing entry for the context once the string ends.
+func quoteStatesAt(command string) []quoteContext {
+	states := make([]quoteContext, len(command)+1)
+	context := noQuote
+	escaped := false
 
-	for _, segment := range segments {
-		currentSegment := segment["currentSegment"]
-		nextSegment := segment["nextSegment"]
+	for i := 0; i < len(command); i++ {
+		states[i] = context
+		ch := command[i]
 
-		// Get the character before and after the user input
-		charBeforeUserInput := ""
-		if currentSegment != "" {
-			charBeforeUserInput = currentSegment[len(currentSegment)-1:]
+		if escaped {
+			escaped = false
+			continue
 		}
 
-		charAfterUserInput := ""
-		if nextSegment != "" {
-			charAfterUserInput = nextSegment[:1]
-		}
-
-		// Check if the character before the user input is an escape character
-		isEscapeChar := slices.Contains(escapeChars, charBeforeUserInput)
-
-		if !isEscapeChar {
-			return false
-		}
-
-		// Check if the character before and after the user input are the same
-		if charBeforeUserInput != charAfterUserInput {
-			return false
-		}
-
-		// Check if the user input contains the escape character itself
-		if strings.Contains(userInput, charBeforeUserInput) {
-			return false
-		}
-
-		// Check for dangerous characters inside double quotes
-		// https://www.gnu.org/software/bash/manual/html_node/Single-Quotes.html
-		// https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
-		if charBeforeUserInput == `"` {
-			for _, dangerousChar := range dangerousCharsInsideDoubleQuotes {
-				if strings.Contains(userInput, dangerousChar) {
-					return false
-				}
+		if ch == '\\' {
+			if context != singleQuote {
+				escaped = true
 			}
+			continue
+		}
+
+		switch ch {
+		case '\'':
+			switch context {
+			case noQuote:
+				context = singleQuote
+			case singleQuote:
+				context = noQuote
+			}
+			// Inside double quotes, single quote is literal
+		case '"':
+			switch context {
+			case noQuote:
+				context = doubleQuote
+			case doubleQuote:
+				context = noQuote
+			}
+			// Inside single quotes, double quote is literal
 		}
 	}
 
-	return true
+	states[len(command)] = context
+	return states
 }
 
-func getCurrentAndNextSegments[T any](array []T) []map[string]T {
-	var segments []map[string]T
-	for i := 0; i < len(array)-1; i++ {
-		segment := map[string]T{
-			"currentSegment": array[i],
-			"nextSegment":    array[i+1],
+// quoteClosesAfter reports whether context is exited again at or after
+// position start. An unterminated quote must not be treated as safe.
+func quoteClosesAfter(states []quoteContext, start int, context quoteContext) bool {
+	for _, state := range states[start:] {
+		if state != context {
+			return true
 		}
-		segments = append(segments, segment)
 	}
-	return segments
+	return false
+}
+
+func isSafelyEncapsulated(command, userInput string) bool {
+	if userInput == "" {
+		return true
+	}
+	states := quoteStatesAt(command)
+
+	for start := 0; ; {
+		idx := strings.Index(command[start:], userInput)
+		if idx == -1 {
+			return true
+		}
+		occStart := start + idx
+		occEnd := occStart + len(userInput)
+		start = occEnd
+
+		context := states[occStart]
+		// Characters in userInput that would break out of the surrounding quote.
+		var breakoutChars string
+		switch context {
+		case noQuote:
+			return false
+		case singleQuote:
+			breakoutChars = "'"
+		case doubleQuote:
+			// https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
+			breakoutChars = "$`\\!\""
+		}
+		if strings.ContainsAny(userInput, breakoutChars) {
+			return false
+		}
+		if !quoteClosesAfter(states, occEnd, context) {
+			return false
+		}
+	}
 }

--- a/vulnerabilities/shellinjection/is_safely_encapsulated_test.go
+++ b/vulnerabilities/shellinjection/is_safely_encapsulated_test.go
@@ -1,7 +1,12 @@
 package shellinjection
 
 import (
+	"fmt"
+	"os/exec"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsSafelyEncapsulated(t *testing.T) {
@@ -76,4 +81,171 @@ func TestIsSafelyEncapsulated(t *testing.T) {
 			t.Errorf("isSafelyEncapsulated('echo \"USER\"', '$USER') = %v; want true", got)
 		}
 	})
+
+	t.Run("empty user input", func(t *testing.T) {
+		if got := isSafelyEncapsulated("echo hello", ""); got != true {
+			t.Errorf("isSafelyEncapsulated('echo hello', '') = %v; want true", got)
+		}
+	})
+}
+
+func TestIsSafelyEncapsulated_NestedQuoting(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		userInput string
+		expected  bool
+	}{
+		{
+			name:      "safe inside single quotes",
+			command:   `echo '$USER'`,
+			userInput: "$USER",
+			expected:  true,
+		},
+		{
+			name:      "unquoted is unsafe",
+			command:   `echo $USER`,
+			userInput: "$USER",
+			expected:  false,
+		},
+		{
+			name:      "dangerous char inside double quotes is unsafe",
+			command:   `echo "$USER"`,
+			userInput: "$USER",
+			expected:  false,
+		},
+		{
+			name:      "user input not present is safe",
+			command:   `echo 'USER'`,
+			userInput: "$USER",
+			expected:  true,
+		},
+		// Nested quoting bypass: single quotes are literal inside double
+		// quotes, so they don't stop command/variable substitution.
+		{
+			name:      "command substitution nested in single-in-double quotes",
+			command:   `echo "'$(id)'"`,
+			userInput: "$(id)",
+			expected:  false,
+		},
+		{
+			name:      "variable expansion nested in single-in-double quotes",
+			command:   `echo "'$USER'"`,
+			userInput: "$USER",
+			expected:  false,
+		},
+		{
+			name:      "backtick command substitution nested in single-in-double quotes",
+			command:   "echo \"'`id`'\"",
+			userInput: "`id`",
+			expected:  false,
+		},
+		{
+			name:      "triple nested single quotes inside double quotes",
+			command:   `echo "'''$(id)'''"`,
+			userInput: "$(id)",
+			expected:  false,
+		},
+		{
+			name:      "escaped double quotes still count as double-quote context",
+			command:   `echo "\"'$(id)'\""`,
+			userInput: "$(id)",
+			expected:  false,
+		},
+		// The reverse nesting is genuinely safe: double quotes are literal
+		// inside single quotes.
+		{
+			name:      "double quotes nested inside single quotes stay safe",
+			command:   `echo '"$USER"'`,
+			userInput: "$USER",
+			expected:  true,
+		},
+		{
+			name:      "double quotes with backtick nested inside single quotes stay safe",
+			command:   "echo '\"`id`\"'",
+			userInput: "`id`",
+			expected:  true,
+		},
+		// Malformed/unterminated quoting must not be reported safe just
+		// because the last-seen quote type happened to be single or double.
+		{
+			name:      "unterminated single quote before double quote is unsafe",
+			command:   `echo '$USER"`,
+			userInput: "$USER",
+			expected:  false,
+		},
+		{
+			name:      "unterminated double quote before single quote is unsafe",
+			command:   `echo "$USER'`,
+			userInput: "$USER",
+			expected:  false,
+		},
+		// Multiple occurrences: all must be safe for the whole thing to be safe.
+		{
+			name:      "same input safe in both occurrences",
+			command:   `echo '$USER' '$USER'`,
+			userInput: "$USER",
+			expected:  true,
+		},
+		{
+			name:      "one unsafe occurrence makes the whole thing unsafe",
+			command:   `echo "$USER" '$USER'`,
+			userInput: "$USER",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSafelyEncapsulated(tt.command, tt.userInput)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// Hand-picked expected values can all pass while still diverging from real shell behavior.
+func TestIsSafelyEncapsulated_DifferentialAgainstRealBash(t *testing.T) {
+	marker := `$(id)`
+
+	templates := []string{
+		"echo %s",
+		"echo '%s'",
+		"echo \"%s\"",
+		"echo \"'%s'\"",
+		"echo '\"%s\"'",
+		"echo \"\\\"'%s'\\\"\"",
+		"echo \"'''%s'''\"",
+		"echo '\"\"\"%s\"\"\"'",
+		"echo \"a\\\\\\\"'%s'\\\"\"",
+		"echo \"a\\\\\\\\\"'%s'",
+		"echo '%s' \"%s\"",
+		"echo \"%s\" '%s'",
+		"echo \"pre'mid%spost'end\"",
+		"echo 'pre\"mid%spost\"end'",
+		"echo \"a'b'%s'c'd\"",
+		"echo '\\''%s'\\''",
+		"echo \"\\$%s\"",
+		"echo \"%s\\\\\"",
+		"echo '%s\"",
+		"echo \"%s'",
+	}
+
+	for _, tmpl := range templates {
+		t.Run(tmpl, func(t *testing.T) {
+			var command string
+			if strings.Count(tmpl, "%s") == 2 {
+				command = fmt.Sprintf(tmpl, marker, marker)
+			} else {
+				command = fmt.Sprintf(tmpl, marker)
+			}
+
+			verdict := isSafelyEncapsulated(command, marker)
+
+			out, _ := exec.Command("sh", "-c", command).CombinedOutput()
+			executed := strings.Contains(string(out), "uid=")
+
+			assert.False(t, verdict && executed,
+				"bypass: verdict=safe but real sh executed the payload. command=%q output=%q", command, string(out))
+		})
+	}
 }


### PR DESCRIPTION
Fixed, more complete version of:
- https://github.com/AikidoSec/firewall-go/pull/499

Some of the existing tests are not using testify, will update separately.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added precise escape and quote-closing checks for user occurrences

**🐛 Bugfixes**
* Fixed shell injection bypass caused by nested quoting in validation

**🔧 Refactors**
* Rewrote quote handling using explicit state machine and helpers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152823455?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->