### PR TITLE
Add retry after to block results when rate limited

### DIFF
--- a/docs/echo.md
+++ b/docs/echo.md
@@ -42,6 +42,7 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					c.Response().Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					return c.String(http.StatusTooManyRequests, message)
 				} else if blockResult.Type == "blocked" {
 					return c.String(http.StatusForbidden, "You are blocked by Zen.")
@@ -73,6 +74,7 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					c.Response().Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					return c.String(http.StatusTooManyRequests, message)
 				} else if blockResult.Type == "blocked" {
 					return c.String(http.StatusForbidden, "You are blocked by Zen.")
@@ -84,6 +86,8 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 	}
 }
 ```
+
+When `blockResult.Type` is `"rate-limited"`, `blockResult.RetryAfterSeconds` tells you how long to wait until the rate limit window frees up again. Sending it back as the standard `Retry-After` header (as shown above) lets well-behaved clients back off instead of retrying immediately.
 
 ## Proxy settings
 

--- a/docs/gin.md
+++ b/docs/gin.md
@@ -32,6 +32,7 @@ func AikidoMiddleware() gin.HandlerFunc {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				c.Header("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				c.String(http.StatusTooManyRequests, message)
 				c.Abort() // Stop further processing
 				return
@@ -47,6 +48,8 @@ func AikidoMiddleware() gin.HandlerFunc {
 }
 ```
 The important part here is the call to `zen.ShouldBlockRequest()` which returns whether to block the request and the reason why.
+
+When `blockResult.Type` is `"rate-limited"`, `blockResult.RetryAfterSeconds` tells you how long to wait until the rate limit window frees up again. Sending it back as the standard `Retry-After` header (as shown above) lets well-behaved clients back off instead of retrying immediately.
 
 ## Proxy settings
 

--- a/docs/net-http.md
+++ b/docs/net-http.md
@@ -36,6 +36,7 @@ func AikidoMiddleware(next http.Handler) http.Handler {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				w.Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				http.Error(w, message, http.StatusTooManyRequests)
 				return
 			case "blocked":
@@ -49,6 +50,8 @@ func AikidoMiddleware(next http.Handler) http.Handler {
 }
 ```
 The important part here is the call to `zen.ShouldBlockRequest()` which returns whether to block the request and the reason why.
+
+When `blockResult.Type` is `"rate-limited"`, `blockResult.RetryAfterSeconds` tells you how long to wait until the rate limit window frees up again. Sending it back as the standard `Retry-After` header (as shown above) lets well-behaved clients back off instead of retrying immediately.
 
 ## Proxy settings
 

--- a/internal/agent/ratelimiting/rate_limiting.go
+++ b/internal/agent/ratelimiting/rate_limiting.go
@@ -63,8 +63,9 @@ type endpointData struct {
 
 // Status represents the result of a rate limiting check
 type Status struct {
-	Block   bool
-	Trigger string
+	Block             bool
+	Trigger           string
+	RetryAfterSeconds int
 }
 
 type RateLimiter struct {
@@ -144,6 +145,8 @@ func (rl *RateLimiter) checkEntity(method string, route string, kind entityKind,
 
 	if !counts.TryRecord(now) {
 		trigger := kind.String()
+		retryAfterMs := counts.RetryAfter(now)
+		retryAfterSeconds := int((retryAfterMs + 999) / 1000)
 
 		log.Info("Rate limited request",
 			slog.String(trigger, entityValue),
@@ -151,7 +154,7 @@ func (rl *RateLimiter) checkEntity(method string, route string, kind entityKind,
 			slog.String("route", route),
 			slog.Int("count", counts.Count(now)))
 
-		return &Status{Block: true, Trigger: trigger}
+		return &Status{Block: true, Trigger: trigger, RetryAfterSeconds: retryAfterSeconds}
 	}
 
 	return &Status{Block: false}

--- a/internal/agent/ratelimiting/rate_limiting_test.go
+++ b/internal/agent/ratelimiting/rate_limiting_test.go
@@ -84,6 +84,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 
 		assert.True(t, status.Block)
 		assert.Equal(t, "user", status.Trigger)
+		assert.InDelta(t, 300, status.RetryAfterSeconds, 1)
 	})
 
 	t.Run("IP blocked when no user provided", func(t *testing.T) {
@@ -102,6 +103,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 
 		assert.True(t, status.Block)
 		assert.Equal(t, "ip", status.Trigger)
+		assert.InDelta(t, 300, status.RetryAfterSeconds, 1)
 	})
 
 	t.Run("IP below threshold not blocked", func(t *testing.T) {
@@ -135,6 +137,7 @@ func TestShouldRateLimitRequest(t *testing.T) {
 
 		assert.True(t, status.Block)
 		assert.Equal(t, "group", status.Trigger)
+		assert.InDelta(t, 300, status.RetryAfterSeconds, 1)
 	})
 
 	t.Run("group below threshold not blocked", func(t *testing.T) {

--- a/internal/slidingwindow/window.go
+++ b/internal/slidingwindow/window.go
@@ -44,6 +44,25 @@ func (w *Window) Count(currentTimestamp int64) int {
 	return len(w.timestamps)
 }
 
+// RetryAfter returns how long until the oldest event in the window expires, freeing a slot.
+func (w *Window) RetryAfter(timestamp int64) int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.cleanOld(timestamp)
+
+	if len(w.timestamps) == 0 {
+		return 0
+	}
+
+	retryAfter := w.timestamps[0] + w.windowSize - timestamp
+	if retryAfter < 0 {
+		return 0
+	}
+
+	return retryAfter
+}
+
 // cleanOld removes timestamps outside the window (must be called with a lock)
 func (w *Window) cleanOld(currentTime int64) {
 	windowStart := currentTime - w.windowSize

--- a/internal/slidingwindow/window_test.go
+++ b/internal/slidingwindow/window_test.go
@@ -101,6 +101,29 @@ func TestWindow_CountIsIdempotent(t *testing.T) {
 	assert.Equal(t, 5, window.Count(now))
 }
 
+func TestWindow_RetryAfter(t *testing.T) {
+	window := slidingwindow.New(10, 3)
+	baseTime := time.Now().Unix()
+
+	require.True(t, window.TryRecord(baseTime))
+	require.True(t, window.TryRecord(baseTime+2))
+	require.True(t, window.TryRecord(baseTime+4))
+
+	// At capacity: retry after is when the oldest timestamp leaves the window.
+	assert.False(t, window.TryRecord(baseTime+5))
+	assert.Equal(t, int64(5), window.RetryAfter(baseTime+5))
+
+	// Past the window: nothing to wait for.
+	assert.Equal(t, int64(0), window.RetryAfter(baseTime+20))
+}
+
+func TestWindow_RetryAfter_EmptyWindow(t *testing.T) {
+	window := slidingwindow.New(10, 3)
+	now := time.Now().Unix()
+
+	assert.Equal(t, int64(0), window.RetryAfter(now))
+}
+
 func TestWindow_ConcurrentAccess(t *testing.T) {
 	window := slidingwindow.New(60, 100)
 	now := time.Now().Unix()

--- a/sample-apps/chi-postgres/main.go
+++ b/sample-apps/chi-postgres/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/AikidoSec/firewall-go/zen"
@@ -69,6 +70,7 @@ func RateLimitMiddleware() func(next http.Handler) http.Handler {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					w.Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					http.Error(w, message, http.StatusTooManyRequests)
 					return
 				case "blocked":

--- a/sample-apps/echo-pgx-sql/main.go
+++ b/sample-apps/echo-pgx-sql/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v4"
@@ -58,6 +59,7 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					c.Response().Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					return c.String(http.StatusTooManyRequests, message)
 				case "blocked":
 					return c.String(http.StatusForbidden, "You are blocked by Zen.")

--- a/sample-apps/echo-postgres/main.go
+++ b/sample-apps/echo-postgres/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v4"
@@ -58,6 +59,7 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					c.Response().Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					return c.String(http.StatusTooManyRequests, message)
 				case "blocked":
 					return c.String(http.StatusForbidden, "You are blocked by Zen.")

--- a/sample-apps/echo-v5-postgres/main.go
+++ b/sample-apps/echo-v5-postgres/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/labstack/echo/v5"
@@ -58,6 +59,7 @@ func AikidoMiddleware() echo.MiddlewareFunc {
 					if blockResult.Trigger == "ip" {
 						message += " (Your IP: " + *blockResult.IP + ")"
 					}
+					c.Response().Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 					return c.String(http.StatusTooManyRequests, message)
 				case "blocked":
 					return c.String(http.StatusForbidden, "You are blocked by Zen.")

--- a/sample-apps/gin-pgx-native/main.go
+++ b/sample-apps/gin-pgx-native/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
@@ -57,6 +58,7 @@ func RateLimitMiddleware() gin.HandlerFunc {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				c.Header("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				c.String(http.StatusTooManyRequests, message)
 				c.Abort() // Stop further processing
 				return

--- a/sample-apps/gin-postgres/main.go
+++ b/sample-apps/gin-postgres/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
@@ -57,6 +58,7 @@ func RateLimitMiddleware() gin.HandlerFunc {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				c.Header("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				c.String(http.StatusTooManyRequests, message)
 				c.Abort() // Stop further processing
 				return

--- a/sample-apps/gin-sqlx/main.go
+++ b/sample-apps/gin-sqlx/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
@@ -57,6 +58,7 @@ func RateLimitMiddleware() gin.HandlerFunc {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				c.Header("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				c.String(http.StatusTooManyRequests, message)
 				c.Abort() // Stop further processing
 				return

--- a/sample-apps/http-postgres/main.go
+++ b/sample-apps/http-postgres/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/AikidoSec/firewall-go/zen"
@@ -73,6 +74,7 @@ func RateLimitMiddleware(next http.Handler) http.Handler {
 				if blockResult.Trigger == "ip" {
 					message += " (Your IP: " + *blockResult.IP + ")"
 				}
+				w.Header().Set("Retry-After", strconv.Itoa(blockResult.RetryAfterSeconds))
 				http.Error(w, message, http.StatusTooManyRequests)
 				return
 			case "blocked":

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -25,7 +25,7 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 	userID := reqCtx.GetUserID()
 	if config.IsUserBlocked(userID) {
 		log.Info("User is blocked!", slog.String("user", userID))
-		return &BlockResponse{"blocked", "user", nil, 0}
+		return &BlockResponse{Type: "blocked", Trigger: "user", IP: nil, RetryAfterSeconds: 0}
 	}
 
 	rateLimitingStatus := agent.GetRateLimitingStatus(
@@ -39,11 +39,11 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 
 		if rateLimitingStatus.Trigger == "ip" {
 			return &BlockResponse{
-				"rate-limited", rateLimitingStatus.Trigger, reqCtx.RemoteAddress, rateLimitingStatus.RetryAfterSeconds,
+				Type: "rate-limited", Trigger: rateLimitingStatus.Trigger, IP: reqCtx.RemoteAddress, RetryAfterSeconds: rateLimitingStatus.RetryAfterSeconds,
 			}
 		}
 		return &BlockResponse{
-			"rate-limited", rateLimitingStatus.Trigger, nil, rateLimitingStatus.RetryAfterSeconds,
+			Type: "rate-limited", Trigger: rateLimitingStatus.Trigger, IP: nil, RetryAfterSeconds: rateLimitingStatus.RetryAfterSeconds,
 		}
 	}
 

--- a/zen/should_block_request.go
+++ b/zen/should_block_request.go
@@ -25,7 +25,7 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 	userID := reqCtx.GetUserID()
 	if config.IsUserBlocked(userID) {
 		log.Info("User is blocked!", slog.String("user", userID))
-		return &BlockResponse{"blocked", "user", nil}
+		return &BlockResponse{"blocked", "user", nil, 0}
 	}
 
 	rateLimitingStatus := agent.GetRateLimitingStatus(
@@ -39,11 +39,11 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 
 		if rateLimitingStatus.Trigger == "ip" {
 			return &BlockResponse{
-				"rate-limited", rateLimitingStatus.Trigger, reqCtx.RemoteAddress,
+				"rate-limited", rateLimitingStatus.Trigger, reqCtx.RemoteAddress, rateLimitingStatus.RetryAfterSeconds,
 			}
 		}
 		return &BlockResponse{
-			"rate-limited", rateLimitingStatus.Trigger, nil,
+			"rate-limited", rateLimitingStatus.Trigger, nil, rateLimitingStatus.RetryAfterSeconds,
 		}
 	}
 
@@ -51,7 +51,8 @@ func ShouldBlockRequest(ctx context.Context) *BlockResponse {
 }
 
 type BlockResponse struct {
-	Type    string  // e.g. rate-limited
-	Trigger string  // e.g. user, ip, ...
-	IP      *string // (Optional) IP Address in case of IP rate-limiting
+	Type              string  // e.g. rate-limited
+	Trigger           string  // e.g. user, ip, ...
+	IP                *string // (Optional) IP Address in case of IP rate-limiting
+	RetryAfterSeconds int     // (Only for rate-limited) seconds until the client may retry
 }

--- a/zen/should_block_request_test.go
+++ b/zen/should_block_request_test.go
@@ -146,6 +146,7 @@ func TestShouldBlockRequest_RateLimitedByUser(t *testing.T) {
 	assert.Equal(t, "rate-limited", response.Type)
 	assert.Equal(t, "user", response.Trigger)
 	assert.Nil(t, response.IP)
+	assert.InDelta(t, 100, response.RetryAfterSeconds, 1)
 }
 
 func TestShouldBlockRequest_RateLimitedByIP(t *testing.T) {
@@ -167,6 +168,7 @@ func TestShouldBlockRequest_RateLimitedByIP(t *testing.T) {
 	assert.Equal(t, "ip", response.Trigger)
 	assert.NotNil(t, response.IP)
 	assert.Equal(t, "10.0.0.1", *response.IP)
+	assert.InDelta(t, 100, response.RetryAfterSeconds, 1)
 }
 
 func TestShouldBlockRequest_NotRateLimited(t *testing.T) {
@@ -197,6 +199,7 @@ func TestShouldBlockRequest_RateLimitedByGroup(t *testing.T) {
 	assert.Equal(t, "rate-limited", response.Type)
 	assert.Equal(t, "group", response.Trigger)
 	assert.Nil(t, response.IP)
+	assert.InDelta(t, 100, response.RetryAfterSeconds, 1)
 }
 
 // ExampleShouldBlockRequest demonstrates the complete middleware pattern with auth and Zen middleware.


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included RetryAfterSeconds in rate limit responses to clients
* Calculated retry-after from sliding window and exposed in Status

**🔧 Refactors**
* Switched BlockResponse and struct literals to use keyed field initializers


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152837316?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->