### PR TITLE
Resolve zen-go CLI version from debug info instead of constant

### DIFF
--- a/cmd/zen-go/cmd_toolexec_compile.go
+++ b/cmd/zen-go/cmd_toolexec_compile.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/importcfg"
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/instrumentor"
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/rules"
+	zenversion "github.com/AikidoSec/firewall-go/cmd/zen-go/internal/version"
 )
 
 func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, toolArgs []string) error {
@@ -43,7 +44,7 @@ func toolexecCompileCommand(stdout io.Writer, stderr io.Writer, tool string, too
 		return err
 	}
 
-	instr, err := instrumentor.NewInstrumentor(version)
+	instr, err := instrumentor.NewInstrumentor(zenversion.Resolve(version))
 	if err != nil {
 		return err
 	}

--- a/cmd/zen-go/cmd_toolexec_version.go
+++ b/cmd/zen-go/cmd_toolexec_version.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/buildid"
 	"github.com/AikidoSec/firewall-go/cmd/zen-go/internal/instrumentor"
+	zenversion "github.com/AikidoSec/firewall-go/cmd/zen-go/internal/version"
 )
 
 // toolexecVersionQueryCommand handles the -V=full version query that Go uses to compute build IDs.
@@ -28,12 +29,14 @@ func toolexecVersionQueryCommand(stdout io.Writer, stderr io.Writer, tool string
 	}
 
 	// Compute hash of instrumentation rules
-	inst, err := instrumentor.NewInstrumentor(version)
+	resolvedVersion := zenversion.Resolve(version)
+
+	inst, err := instrumentor.NewInstrumentor(resolvedVersion)
 	if err != nil {
 		return err
 	}
 
-	rulesHash := buildid.ComputeInstrumentationHash(inst, version)
+	rulesHash := buildid.ComputeInstrumentationHash(inst, resolvedVersion)
 
 	// Append our hash to the version string
 	versionStr := strings.TrimSpace(versionOutput.String())

--- a/cmd/zen-go/internal/rules/version.go
+++ b/cmd/zen-go/internal/rules/version.go
@@ -48,6 +48,9 @@ type semver struct {
 
 func parseSemver(s string) (semver, error) {
 	raw := strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(raw, "-+"); i != -1 {
+		raw = raw[:i]
+	}
 	parts := strings.SplitN(raw, ".", 3)
 	if len(parts) != 3 {
 		return semver{}, fmt.Errorf("expected format major.minor.patch, got %q", s)

--- a/cmd/zen-go/internal/rules/version.go
+++ b/cmd/zen-go/internal/rules/version.go
@@ -5,11 +5,23 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"golang.org/x/mod/module"
 )
+
+// isUnverifiableVersion covers devel builds and pseudo-versions (including the
+// zero pseudo-version from a local filesystem `replace`, per CheckModuleVersionSync).
+func isUnverifiableVersion(v string) bool {
+	return v == "(devel)" || module.IsPseudoVersion(v)
+}
 
 // CheckMinVersions checks that currentVersion satisfies all minimum version requirements.
 // Returns an error listing the first unsatisfied requirement.
 func CheckMinVersions(minVersions []MinVersionEntry, currentVersion string) error {
+	if isUnverifiableVersion(currentVersion) {
+		return nil
+	}
+
 	cur, err := parseSemver(currentVersion)
 	if err != nil {
 		return fmt.Errorf("zen-go: failed to parse current version %q: %w", currentVersion, err)

--- a/cmd/zen-go/internal/rules/version_test.go
+++ b/cmd/zen-go/internal/rules/version_test.go
@@ -92,6 +92,36 @@ func TestParseSemver(t *testing.T) {
 
 	_, err = parseSemver("0.0.x")
 	assert.ErrorContains(t, err, "invalid patch version")
+
+	v, err = parseSemver("1.2.7-beta.1")
+	require.NoError(t, err)
+	assert.Equal(t, semver{1, 2, 7}, v)
+
+	v, err = parseSemver("v1.2.7-beta.1")
+	require.NoError(t, err)
+	assert.Equal(t, semver{1, 2, 7}, v)
+
+	v, err = parseSemver("v0.0.0-20240101000000-abcdef123456")
+	require.NoError(t, err)
+	assert.Equal(t, semver{0, 0, 0}, v)
+
+	v, err = parseSemver("1.2.7+buildmeta")
+	require.NoError(t, err)
+	assert.Equal(t, semver{1, 2, 7}, v)
+}
+
+func TestCheckMinVersions_BetaCurrentVersion(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "sinks/sql/zen.instrument.yml", Version: "1.2.6"},
+	}
+	require.NoError(t, CheckMinVersions(entries, "v1.2.7-beta.1"))
+
+	entries = []MinVersionEntry{
+		{File: "sinks/sql/zen.instrument.yml", Version: "1.2.8"},
+	}
+	err := CheckMinVersions(entries, "v1.2.7-beta.1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires zen-go >= v1.2.8")
 }
 
 func TestShortPath(t *testing.T) {

--- a/cmd/zen-go/internal/rules/version_test.go
+++ b/cmd/zen-go/internal/rules/version_test.go
@@ -44,6 +44,16 @@ func TestCheckMinVersions_MultipleEntries(t *testing.T) {
 	assert.Contains(t, err.Error(), "b.yml")
 }
 
+func TestCheckMinVersions_UnverifiableCurrentVersion(t *testing.T) {
+	entries := []MinVersionEntry{
+		{File: "a.yml", Version: "99.0.0"},
+	}
+
+	require.NoError(t, CheckMinVersions(entries, "(devel)"))
+	require.NoError(t, CheckMinVersions(entries, "v0.0.0-20240101000000-abcdef123456"))
+	require.NoError(t, CheckMinVersions(entries, "v0.0.0-00010101000000-000000000000")) // zero pseudo-version from a local replace
+}
+
 func TestCheckMinVersions_InvalidCurrentVersion(t *testing.T) {
 	entries := []MinVersionEntry{
 		{File: "a.yml", Version: "0.1.0"},

--- a/cmd/zen-go/internal/version/version.go
+++ b/cmd/zen-go/internal/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+import "runtime/debug"
+
+func Resolve(fallback string) string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return fallback
+	}
+
+	return resolveFromBuildInfo(bi, fallback)
+}
+
+func resolveFromBuildInfo(bi *debug.BuildInfo, fallback string) string {
+	if bi.Main.Version == "" || bi.Main.Version == "(devel)" {
+		return fallback
+	}
+
+	return bi.Main.Version
+}

--- a/cmd/zen-go/internal/version/version_test.go
+++ b/cmd/zen-go/internal/version/version_test.go
@@ -1,0 +1,44 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveFromBuildInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		bi       *debug.BuildInfo
+		expected string
+	}{
+		{
+			name:     "uses the version go install resolved",
+			bi:       &debug.BuildInfo{Main: debug.Module{Version: "v1.2.7-beta.1"}},
+			expected: "v1.2.7-beta.1",
+		},
+		{
+			name:     "falls back to fallback for a local dev build",
+			bi:       &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}},
+			expected: "1.2.7",
+		},
+		{
+			name:     "falls back to fallback when version is empty",
+			bi:       &debug.BuildInfo{Main: debug.Module{Version: ""}},
+			expected: "1.2.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, resolveFromBuildInfo(tt.bi, "1.2.7"))
+		})
+	}
+}
+
+func TestResolveFallsBackDuringLocalBuild(t *testing.T) {
+	// The test binary is built locally (not via `go install ...@version`), so
+	// build info reports "(devel)" and Resolve falls back to the fallback.
+	require.Equal(t, "1.2.7", Resolve("1.2.7"))
+}

--- a/cmd/zen-go/main.go
+++ b/cmd/zen-go/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	zenversion "github.com/AikidoSec/firewall-go/cmd/zen-go/internal/version"
 	"github.com/urfave/cli/v3"
 )
 
@@ -19,7 +20,7 @@ func newCommand() *cli.Command {
 		Name:    "zen-go",
 		Usage:   "Aikido Zen CLI tool for Go",
 		Suggest: true,
-		Version: version,
+		Version: zenversion.Resolve(version),
 
 		Commands: []*cli.Command{
 			{


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added version resolver to read CLI version from build info
* Ignored prerelease and build metadata when parsing semantic versions

**🔧 Refactors**
* Replaced direct constant usage with Resolve(version) in CLI
* Updated toolexec version query and compile to use resolved version
* Used resolved version when computing instrumentation build ID hash


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153447290?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->