### PR TITLE
Prevent proxing recently committed firewall-go through proxy

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -24,6 +24,8 @@ jobs:
           go-version: 1.25
 
       - name: Use local firewall-go
+        env:
+          GOPRIVATE: github.com/AikidoSec/*
         run: |
           cd zen-demo-go
           go get github.com/AikidoSec/firewall-go@$GITHUB_SHA


### PR DESCRIPTION
QAs often fail because it's pulling a commit version for `firewall-go` that's just been pushed through the proxy, we can avoid that using GOPRIVATE.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Set GOPRIVATE env to allow local firewall-go usage in workflow


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153515729?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->