### PR TITLE
Detect bare ".." path traversal in path.Join and filepath.Join

### DIFF
--- a/instrumentation/sinks/path/examine.go
+++ b/instrumentation/sinks/path/examine.go
@@ -2,7 +2,6 @@ package path
 
 import (
 	"context"
-	"strings"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/hooks"
 	"github.com/AikidoSec/firewall-go/instrumentation/operation"
@@ -18,7 +17,7 @@ func Examine(args []string) error {
 
 	hooks.OnOperationCall("path.Join", operation.KindFileSystem)
 
-	path := strings.Join(args, "")
+	path := pathtraversal.JoinElementsForDetection(args, "/")
 
 	// The error that the vulnerability scan returns is deferred with path.Join
 	// We delay blocking and reporting until the result is used in os.OpenFile

--- a/instrumentation/sinks/path/filepath/examine.go
+++ b/instrumentation/sinks/path/filepath/examine.go
@@ -2,7 +2,7 @@ package filepath
 
 import (
 	"context"
-	"strings"
+	"os"
 
 	"github.com/AikidoSec/firewall-go/instrumentation/hooks"
 	"github.com/AikidoSec/firewall-go/instrumentation/operation"
@@ -37,7 +37,7 @@ func ExamineDeferred(operationName string, elems []string) error {
 
 	hooks.OnOperationCall(operationName, operation.KindFileSystem)
 
-	path := strings.Join(elems, "")
+	path := pathtraversal.JoinElementsForDetection(elems, string(os.PathSeparator))
 
 	return vulnerabilities.ScanWithOptions(context.Background(), operationName, pathtraversal.PathTraversalVulnerability, &pathtraversal.ScanArgs{
 		FilePath:       path,

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -139,6 +139,52 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 	}
 }
 
+func TestJoinPathInjectionBareDoubleDotDetected(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=..", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	request.WrapWithGLS(ctx, func() {
+		// ".." as a whole argument must be detected, not just "../" as a substring.
+		path := filepath.Join("/var/www/uploads", "..")
+		_, err := os.OpenFile(path, os.O_RDONLY, 0o600)
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.True(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "..", client.capturedAttack.Payload)
+		assert.Equal(t, "filepath.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path/filepath", client.capturedAttack.Module)
+		assert.Contains(t, client.capturedAttack.Metadata["filename"], "..")
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
 func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 	require.NoError(t, zen.Protect())
 

--- a/instrumentation/sinks/path/integration_test.go
+++ b/instrumentation/sinks/path/integration_test.go
@@ -139,6 +139,52 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 	}
 }
 
+func TestJoinPathInjectionBareDoubleDotDetected(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	originalClient := agent.GetCloudClient()
+
+	original := config.IsBlockingEnabled()
+	config.SetBlocking(true)
+
+	t.Cleanup(func() {
+		config.SetBlocking(original)
+		agent.SetCloudClient(originalClient)
+	})
+
+	client := newMockClient()
+	agent.SetCloudClient(client)
+
+	req := httptest.NewRequest("GET", "/route?path=..", http.NoBody)
+	ip := "127.0.0.1"
+	ctx := request.SetContext(context.Background(), req, request.ContextData{
+		Source:        "test",
+		Route:         "/route",
+		RemoteAddress: &ip,
+	})
+
+	request.WrapWithGLS(ctx, func() {
+		// ".." as a whole argument must be detected, not just "../" as a substring.
+		p := path.Join("/var/www/uploads", "..")
+		_, err := os.OpenFile(p, os.O_RDONLY, 0o600)
+
+		var detectedErr *vulnerabilities.AttackDetectedError
+		require.ErrorAs(t, err, &detectedErr)
+	})
+
+	select {
+	case <-client.attackDetectedEventSent:
+		assert.Equal(t, "path_traversal", client.capturedAttack.Kind)
+		assert.True(t, client.capturedAttack.Blocked)
+		assert.Equal(t, "..", client.capturedAttack.Payload)
+		assert.Equal(t, "path.Join", client.capturedAttack.Operation)
+		assert.Equal(t, "path", client.capturedAttack.Module)
+		assert.Contains(t, client.capturedAttack.Metadata["filename"], "..")
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for attack event")
+	}
+}
+
 func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 	require.NoError(t, zen.Protect())
 

--- a/vulnerabilities/pathtraversal/contains_unsafe_path_parts.go
+++ b/vulnerabilities/pathtraversal/contains_unsafe_path_parts.go
@@ -12,5 +12,15 @@ func containsUnsafePathParts(filePath string) bool {
 			return true
 		}
 	}
+
+	parts := strings.FieldsFunc(filePath, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, part := range parts {
+		if part == ".." {
+			return true
+		}
+	}
+
 	return false
 }

--- a/vulnerabilities/pathtraversal/detect_path_traversal_test.go
+++ b/vulnerabilities/pathtraversal/detect_path_traversal_test.go
@@ -194,4 +194,16 @@ func TestDetectPathTraversal(t *testing.T) {
 	t.Run("AWS credentials protection", func(t *testing.T) {
 		assert.True(t, detectPathTraversal("/home/user/.aws/credentials", "/home/user/.aws/credentials", true))
 	})
+
+	t.Run("detects a bare .. as the whole user input", func(t *testing.T) {
+		assert.True(t, detectPathTraversal("/tmp/../etc/passwd", "..", true))
+		assert.True(t, detectPathTraversal("/base/../etc/passwd", "..", true))
+		assert.True(t, detectPathTraversal("/tmp/../../etc/passwd", "..", true))
+	})
+
+	t.Run("does not flag .. inside a filename", func(t *testing.T) {
+		assert.False(t, detectPathTraversal("/tmp/test..txt", "test..txt", true))
+		assert.False(t, detectPathTraversal("/tmp/..test.txt", "..test.txt", true))
+		assert.False(t, detectPathTraversal("/tmp/test...txt", "test...txt", true))
+	})
 }

--- a/vulnerabilities/pathtraversal/join_for_detection.go
+++ b/vulnerabilities/pathtraversal/join_for_detection.go
@@ -2,8 +2,8 @@ package pathtraversal
 
 import "strings"
 
-// JoinElementsForDetection is like strings.Join, but skips the separator between two
-// elements when one of them already ends/starts with it, avoiding doubled separators.
+// JoinElementsForDetection rebuilds the path filepath.Join/path.Join would produce, minus
+// the Clean() call that strips the ".." segments detection needs to see.
 func JoinElementsForDetection(elems []string, separator string) string {
 	var b strings.Builder
 	for i, e := range elems {

--- a/vulnerabilities/pathtraversal/join_for_detection.go
+++ b/vulnerabilities/pathtraversal/join_for_detection.go
@@ -1,0 +1,19 @@
+package pathtraversal
+
+import "strings"
+
+// JoinElementsForDetection is like strings.Join, but skips the separator between two
+// elements when one of them already ends/starts with it, avoiding doubled separators.
+func JoinElementsForDetection(elems []string, separator string) string {
+	var b strings.Builder
+	for i, e := range elems {
+		if i > 0 {
+			prev := elems[i-1]
+			if !strings.HasSuffix(prev, separator) && !strings.HasPrefix(e, separator) {
+				b.WriteString(separator)
+			}
+		}
+		b.WriteString(e)
+	}
+	return b.String()
+}

--- a/vulnerabilities/pathtraversal/join_for_detection_test.go
+++ b/vulnerabilities/pathtraversal/join_for_detection_test.go
@@ -1,0 +1,65 @@
+package pathtraversal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinElementsForDetection(t *testing.T) {
+	tests := []struct {
+		name      string
+		elems     []string
+		separator string
+		expected  string
+	}{
+		{
+			name:      "inserts separator between plain elements",
+			elems:     []string{"a", "b", "c"},
+			separator: "/",
+			expected:  "a/b/c",
+		},
+		{
+			name:      "does not double a separator already at the end of an element",
+			elems:     []string{"/tmp/", "../etc"},
+			separator: "/",
+			expected:  "/tmp/../etc",
+		},
+		{
+			name:      "does not double a separator already at the start of an element",
+			elems:     []string{"/tmp", "/../etc"},
+			separator: "/",
+			expected:  "/tmp/../etc",
+		},
+		{
+			name:      "keeps a bare .. as its own delimited segment",
+			elems:     []string{"/var/www/uploads", ".."},
+			separator: "/",
+			expected:  "/var/www/uploads/..",
+		},
+		{
+			name:      "supports non-slash separators",
+			elems:     []string{`C:\uploads`, ".."},
+			separator: `\`,
+			expected:  `C:\uploads\..`,
+		},
+		{
+			name:      "single element is returned unchanged",
+			elems:     []string{"solo"},
+			separator: "/",
+			expected:  "solo",
+		},
+		{
+			name:      "no elements returns an empty string",
+			elems:     []string{},
+			separator: "/",
+			expected:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, JoinElementsForDetection(tt.elems, tt.separator))
+		})
+	}
+}


### PR DESCRIPTION
Based on:
- https://github.com/AikidoSec/firewall-go/pull/503

Expanded to `path.Join` and `filepath.Join`, and fixed issues with tests, linter, etc.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added JoinElementsForDetection to reconstruct joined paths for detection

**⚡ Enhancements**
* Detected bare ".." path segments when checking unsafe path parts

**🔧 Refactors**
* Replaced naive strings.Join calls with JoinElementsForDetection in hooks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/154007140?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->