### PR TITLE
Fix package level net/http Handle/HandlerFunc not being instrumented

### DIFF
--- a/instrumentation/sources/net/http/integration_test.go
+++ b/instrumentation/sources/net/http/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServeMuxIsAutomaticallyInstrumented(t *testing.T) {
+func TestServeMuxHandleFuncIsAutomaticallyInstrumented(t *testing.T) {
 	require.NoError(t, zen.Protect())
 
 	mux := http.NewServeMux()
@@ -37,4 +37,79 @@ func TestServeMuxIsAutomaticallyInstrumented(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	mux.ServeHTTP(w, r)
+}
+
+func TestServeMuxHandleIsAutomaticallyInstrumented(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	mux := http.NewServeMux()
+
+	mux.Handle("GET /handle-route/{id}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := request.GetContext(r.Context())
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "http.ServeMux", ctx.Source)
+		assert.Equal(t, "/handle-route/{id}", ctx.Route)
+		assert.Equal(t, map[string][]string{
+			"query": {"value"},
+		}, ctx.Query)
+		assert.Equal(t, map[string]string{
+			"id": "abc",
+		}, ctx.RouteParams)
+	}))
+
+	r := httptest.NewRequest("GET", "/handle-route/abc?query=value", http.NoBody)
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, r)
+}
+
+// http.HandleFunc also registers on DefaultServeMux, so it must get the same instrumentation as (*ServeMux).HandleFunc.
+func TestPackageLevelHandleFuncIsAutomaticallyInstrumented(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	var ctx *request.Context
+	http.HandleFunc("/package-handlefunc-route/{id}", func(w http.ResponseWriter, r *http.Request) {
+		ctx = request.GetContext(r.Context())
+	})
+
+	r := httptest.NewRequest("GET", "/package-handlefunc-route/abc?query=value", http.NoBody)
+	w := httptest.NewRecorder()
+
+	http.DefaultServeMux.ServeHTTP(w, r)
+
+	require.NotNil(t, ctx, "request context should be set for routes registered with package-level http.HandleFunc")
+	assert.Equal(t, "http.ServeMux", ctx.Source)
+	assert.Equal(t, "/package-handlefunc-route/{id}", ctx.Route)
+	assert.Equal(t, map[string][]string{
+		"query": {"value"},
+	}, ctx.Query)
+	assert.Equal(t, map[string]string{
+		"id": "abc",
+	}, ctx.RouteParams)
+}
+
+// http.Handle also registers on DefaultServeMux, so it must get the same instrumentation as (*ServeMux).Handle.
+func TestPackageLevelHandleIsAutomaticallyInstrumented(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	var ctx *request.Context
+	http.Handle("/package-handle-route/{id}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx = request.GetContext(r.Context())
+	}))
+
+	r := httptest.NewRequest("GET", "/package-handle-route/abc?query=value", http.NoBody)
+	w := httptest.NewRecorder()
+
+	http.DefaultServeMux.ServeHTTP(w, r)
+
+	require.NotNil(t, ctx, "request context should be set for routes registered with package-level http.Handle")
+	assert.Equal(t, "http.ServeMux", ctx.Source)
+	assert.Equal(t, "/package-handle-route/{id}", ctx.Route)
+	assert.Equal(t, map[string][]string{
+		"query": {"value"},
+	}, ctx.Query)
+	assert.Equal(t, map[string]string{
+		"id": "abc",
+	}, ctx.RouteParams)
 }

--- a/instrumentation/sources/net/http/zen.instrument.yml
+++ b/instrumentation/sources/net/http/zen.instrument.yml
@@ -40,3 +40,19 @@ rules:
     function: HandleFunc
     template: |
       {{ .Function.Argument 1 }} = __aikido_http_middleware({{ .Function.Argument 1 }})
+
+  # Prepend to package-level Handle (registers on DefaultServeMux directly, not via (*ServeMux).Handle)
+  - id: net/http.Handle
+    type: prepend
+    package: net/http
+    function: Handle
+    template: |
+      {{ .Function.Argument 1 }} = __aikido_http_wrapHandler({{ .Function.Argument 1 }})
+
+  # Prepend to package-level HandleFunc (registers on DefaultServeMux directly, not via (*ServeMux).HandleFunc)
+  - id: net/http.HandleFunc
+    type: prepend
+    package: net/http
+    function: HandleFunc
+    template: |
+      {{ .Function.Argument 1 }} = __aikido_http_middleware({{ .Function.Argument 1 }})


### PR DESCRIPTION
The package level methods call internal methods instead of the public Handle/HandlerFunc on the default serve mux:
https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/server.go;l=2862