### PR TITLE
Decouple request context from *http.Request

### DIFF
--- a/benchmarks/runtime/bench_test.go
+++ b/benchmarks/runtime/bench_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
 
@@ -20,10 +21,16 @@ import (
 func TestCompiledWithZenGo(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/verify", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "bench-verify",
 		Route:         "/verify",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	type result struct {
@@ -86,10 +93,16 @@ func BenchmarkSpawnFanOut(b *testing.B) {
 func BenchmarkGetContext(b *testing.B) {
 	req := httptest.NewRequest(http.MethodGet, "/bench", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "bench",
 		Route:         "/bench",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {

--- a/benchmarks/runtime/bench_test.go
+++ b/benchmarks/runtime/bench_test.go
@@ -21,17 +21,11 @@ import (
 func TestCompiledWithZenGo(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/verify", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "bench-verify",
-		Route:         "/verify",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "bench-verify"
+	data.Route = "/verify"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	type result struct {
 		ctx *request.Context
@@ -93,17 +87,11 @@ func BenchmarkSpawnFanOut(b *testing.B) {
 func BenchmarkGetContext(b *testing.B) {
 	req := httptest.NewRequest(http.MethodGet, "/bench", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "bench",
-		Route:         "/bench",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "bench"
+	data.Route = "/bench"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		b.ResetTimer()

--- a/benchmarks/sinks/os/bench_test.go
+++ b/benchmarks/sinks/os/bench_test.go
@@ -62,17 +62,11 @@ func BenchmarkOpenFile(b *testing.B) {
 	b.Run("with_context", func(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "/files?name=report&id=42", http.NoBody)
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "bench",
-			Route:         "/files",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "bench"
+		data.Route = "/files"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		b.ResetTimer()
 		request.WrapWithGLS(ctx, func() {

--- a/benchmarks/sinks/os/bench_test.go
+++ b/benchmarks/sinks/os/bench_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
@@ -61,10 +62,16 @@ func BenchmarkOpenFile(b *testing.B) {
 	b.Run("with_context", func(b *testing.B) {
 		req := httptest.NewRequest(http.MethodGet, "/files?name=report&id=42", http.NoBody)
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "bench",
 			Route:         "/files",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		b.ResetTimer()

--- a/instrumentation/http/on_init_request_test.go
+++ b/instrumentation/http/on_init_request_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent"
@@ -44,10 +43,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("blocked ip", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.RemoteAddr = "10.0.0.1:1234"
 		ip := "10.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -62,14 +59,12 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("blocked user agent", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.Header.Set("User-Agent", "bot-test")
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			Headers:       map[string][]string{"user-agent": {"bot-test"}},
 		})
 
 		resp := OnInitRequest(ctx)
@@ -80,13 +75,12 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("block route with unapproved ip", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/admin", http.NoBody)
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/admin",
 			RemoteAddress: &ip,
+			Method:        "GET",
 		})
 
 		resp := OnInitRequest(ctx)
@@ -97,13 +91,12 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("allow route with approved ip", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/admin", http.NoBody)
-		req.RemoteAddr = "192.168.0.1:4321"
 		ip := "192.168.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/admin",
 			RemoteAddress: &ip,
+			Method:        "GET",
 		})
 
 		resp := OnInitRequest(ctx)
@@ -118,10 +111,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("allowed request", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -133,10 +124,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("blocked by global allow list", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", nil)
-		req.RemoteAddr = "203.0.114.1:1234"
 		ip := "203.0.114.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -153,10 +142,8 @@ func TestOnInitRequest(t *testing.T) {
 	t.Run("private IPs always allowed even when allowlist is set", func(t *testing.T) {
 		// Private IPs should always be allowed
 		for _, testIP := range []string{"127.0.0.1", "192.168.1.1", "172.16.0.1"} {
-			req, _ := http.NewRequest("GET", "/route", nil)
-			req.RemoteAddr = testIP + ":1234"
 			ip := testIP
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/route",
 				RemoteAddress: &ip,
@@ -170,10 +157,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("allowed by global allow list", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", nil)
-		req.RemoteAddr = "8.8.8.100:1234"
 		ip := "8.8.8.100"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -190,10 +175,8 @@ func TestOnInitRequest(t *testing.T) {
 	t.Run("global allow list checked before block list", func(t *testing.T) {
 		// Public IP is in both allow and block lists
 		// Allow list is checked first, so if IP is not in allow list, it's blocked before block list check
-		req, _ := http.NewRequest("GET", "/route", nil)
-		req.RemoteAddr = "8.8.4.4:1234"
 		ip := "8.8.4.4"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -208,10 +191,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("public IPv6 address in global allow list", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", nil)
-		req.RemoteAddr = "[2001:4860:4860::8888]:1234"
 		ip := "2001:4860:4860::8888"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -226,10 +207,8 @@ func TestOnInitRequest(t *testing.T) {
 	t.Run("private IPv6 addresses always allowed", func(t *testing.T) {
 		// Private IPv6 addresses should always be allowed
 		for _, testIP := range []string{"::1", "fc00::1", "fe80::1"} {
-			req, _ := http.NewRequest("GET", "/route", nil)
-			req.RemoteAddr = "[" + testIP + "]:1234"
 			ip := testIP
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/route",
 				RemoteAddress: &ip,
@@ -242,10 +221,8 @@ func TestOnInitRequest(t *testing.T) {
 	})
 
 	t.Run("IPv6 address not in global allow list", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/route", nil)
-		req.RemoteAddr = "[2001:db9::1]:1234"
 		ip := "2001:db9::1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -281,10 +258,8 @@ func TestOnInitRequestStats(t *testing.T) {
 			},
 		})
 
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -314,10 +289,8 @@ func TestOnInitRequestStats(t *testing.T) {
 			},
 		})
 
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.RemoteAddr = "10.0.0.1:1234"
 		ip := "10.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
@@ -344,14 +317,12 @@ func TestOnInitRequestStats(t *testing.T) {
 			},
 		})
 
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.Header.Set("User-Agent", "Googlebot/2.1")
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			Headers:       map[string][]string{"user-agent": {"Googlebot/2.1"}},
 		})
 
 		resp := OnInitRequest(ctx)
@@ -375,14 +346,12 @@ func TestOnInitRequestStats(t *testing.T) {
 			},
 		})
 
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.Header.Set("User-Agent", "Googlebot/2.1")
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			Headers:       map[string][]string{"user-agent": {"Googlebot/2.1"}},
 		})
 
 		resp := OnInitRequest(ctx)
@@ -406,14 +375,12 @@ func TestOnInitRequestStats(t *testing.T) {
 			},
 		})
 
-		req, _ := http.NewRequest("GET", "/route", http.NoBody)
-		req.Header.Set("User-Agent", "Mozilla/5.0 Chrome/91.0")
-		req.RemoteAddr = "192.168.1.1:1234"
 		ip := "192.168.1.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			Headers:       map[string][]string{"user-agent": {"Mozilla/5.0 Chrome/91.0"}},
 		})
 
 		resp := OnInitRequest(ctx)

--- a/instrumentation/http/on_post_request_test.go
+++ b/instrumentation/http/on_post_request_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -36,15 +35,15 @@ func TestOnPostRequest_AttackWave(t *testing.T) {
 	agent.SetCloudClient(client)
 
 	for range 100 {
-		req, _ := http.NewRequest("BADMETHOD", "/route", nil)
-		req.RemoteAddr = "10.0.0.1:1234"
-		req.Header.Set("user-agent", "user-agent")
-
 		ip := "10.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			Method:        "BADMETHOD",
+			URL:           "http://example.com/route",
+			Path:          "/route",
+			Headers:       map[string][]string{"user-agent": {"user-agent"}},
 		})
 
 		OnPostRequest(ctx, 200)

--- a/instrumentation/http/request_helpers.go
+++ b/instrumentation/http/request_helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/AikidoSec/firewall-go/internal/request"
 )
 
 func FullURL(r *http.Request) string {
@@ -31,4 +33,18 @@ func CookiesToMap(cookies []*http.Cookie) map[string][]string {
 		result[cookie.Name] = append(result[cookie.Name], cookie.Value)
 	}
 	return result
+}
+
+// ContextDataFromRequest extracts the fields request.ContextData derives from
+// an *http.Request. Callers set the remaining fields (Source, Route,
+// RouteParams, RemoteAddress, Body) before calling request.SetContext.
+func ContextDataFromRequest(r *http.Request) request.ContextData {
+	return request.ContextData{
+		URL:     FullURL(r),
+		Path:    r.URL.Path,
+		Method:  r.Method,
+		Query:   r.URL.Query(),
+		Headers: HeadersToMap(r.Header),
+		Cookies: CookiesToMap(r.Cookies()),
+	}
 }

--- a/instrumentation/http/request_helpers.go
+++ b/instrumentation/http/request_helpers.go
@@ -1,0 +1,34 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func FullURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL.RequestURI())
+}
+
+func HeadersToMap(headers http.Header) map[string][]string {
+	result := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		if strings.ToLower(key) == "cookie" {
+			continue
+		}
+		result[strings.ToLower(key)] = values
+	}
+	return result
+}
+
+func CookiesToMap(cookies []*http.Cookie) map[string][]string {
+	result := make(map[string][]string)
+	for _, cookie := range cookies {
+		result[cookie.Name] = append(result[cookie.Name], cookie.Value)
+	}
+	return result
+}

--- a/instrumentation/http/request_helpers_test.go
+++ b/instrumentation/http/request_helpers_test.go
@@ -1,0 +1,112 @@
+package http
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFullURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		host     string
+		hasTLS   bool
+		expected string
+	}{
+		{
+			name:     "HTTP request",
+			url:      "http://example.com/path",
+			host:     "example.com",
+			hasTLS:   false,
+			expected: "http://example.com/path",
+		},
+		{
+			name:     "HTTPS request",
+			url:      "https://example.com/path",
+			host:     "example.com",
+			hasTLS:   true,
+			expected: "https://example.com/path",
+		},
+		{
+			name:     "HTTP with query",
+			url:      "http://example.com/path?param=value",
+			host:     "example.com",
+			hasTLS:   false,
+			expected: "http://example.com/path?param=value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedURL, err := url.Parse(tt.url)
+			assert.NoError(t, err)
+
+			req := &http.Request{
+				Method: "GET",
+				URL:    parsedURL,
+				Host:   tt.host,
+			}
+
+			if tt.hasTLS {
+				req.TLS = &tls.ConnectionState{}
+			}
+
+			result := FullURL(req)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHeadersToMap(t *testing.T) {
+	t.Run("lowercases header names", func(t *testing.T) {
+		headers := http.Header{
+			"Content-Type": {"application/json"},
+			"User-Agent":   {"test-agent"},
+		}
+		result := HeadersToMap(headers)
+		assert.Equal(t, map[string][]string{
+			"content-type": {"application/json"},
+			"user-agent":   {"test-agent"},
+		}, result)
+	})
+
+	t.Run("excludes the cookie header", func(t *testing.T) {
+		headers := http.Header{
+			"Cookie":       {"session=abc"},
+			"Content-Type": {"application/json"},
+		}
+		result := HeadersToMap(headers)
+		assert.Equal(t, map[string][]string{
+			"content-type": {"application/json"},
+		}, result)
+	})
+}
+
+func TestCookiesToMap(t *testing.T) {
+	t.Run("single value per cookie name", func(t *testing.T) {
+		cookies := []*http.Cookie{
+			{Name: "session", Value: "abc"},
+			{Name: "token", Value: "xyz"},
+		}
+		result := CookiesToMap(cookies)
+		assert.Equal(t, map[string][]string{
+			"session": {"abc"},
+			"token":   {"xyz"},
+		}, result)
+	})
+
+	t.Run("multiple values for same cookie name are all kept", func(t *testing.T) {
+		cookies := []*http.Cookie{
+			{Name: "session", Value: "first"},
+			{Name: "session", Value: "second"},
+		}
+		result := CookiesToMap(cookies)
+		assert.Equal(t, map[string][]string{
+			"session": {"first", "second"},
+		}, result)
+	})
+}

--- a/instrumentation/request/context.go
+++ b/instrumentation/request/context.go
@@ -6,35 +6,11 @@ import (
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
 
-type ContextData struct {
-	Source        string
-	Route         string
-	RouteParams   map[string]string
-	RemoteAddress *string
-	Body          any
-	URL           string
-	Path          string
-	Method        string
-	Query         map[string][]string
-	Headers       map[string][]string
-	Cookies       map[string][]string
-}
+type ContextData = request.ContextData
 
 // SetContext sets the context for the given request.
 func SetContext(ctx context.Context, data ContextData) context.Context {
-	return request.SetContext(ctx, request.ContextData{
-		Source:        data.Source,
-		Route:         data.Route,
-		RouteParams:   data.RouteParams,
-		RemoteAddress: data.RemoteAddress,
-		Body:          data.Body,
-		URL:           data.URL,
-		Path:          data.Path,
-		Method:        data.Method,
-		Query:         data.Query,
-		Headers:       data.Headers,
-		Cookies:       data.Cookies,
-	})
+	return request.SetContext(ctx, data)
 }
 
 // HasContext returns true if the context has a request context set.

--- a/instrumentation/request/context.go
+++ b/instrumentation/request/context.go
@@ -2,7 +2,6 @@ package request
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/AikidoSec/firewall-go/internal/request"
 )
@@ -13,16 +12,28 @@ type ContextData struct {
 	RouteParams   map[string]string
 	RemoteAddress *string
 	Body          any
+	URL           string
+	Path          string
+	Method        string
+	Query         map[string][]string
+	Headers       map[string][]string
+	Cookies       map[string][]string
 }
 
 // SetContext sets the context for the given request.
-func SetContext(ctx context.Context, r *http.Request, data ContextData) context.Context {
-	return request.SetContext(ctx, r, request.ContextData{
+func SetContext(ctx context.Context, data ContextData) context.Context {
+	return request.SetContext(ctx, request.ContextData{
 		Source:        data.Source,
 		Route:         data.Route,
 		RouteParams:   data.RouteParams,
 		RemoteAddress: data.RemoteAddress,
 		Body:          data.Body,
+		URL:           data.URL,
+		Path:          data.Path,
+		Method:        data.Method,
+		Query:         data.Query,
+		Headers:       data.Headers,
+		Cookies:       data.Cookies,
 	})
 }
 

--- a/instrumentation/request/context_test.go
+++ b/instrumentation/request/context_test.go
@@ -2,7 +2,6 @@ package request
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -11,20 +10,21 @@ import (
 )
 
 func TestSetContext(t *testing.T) {
-	req, err := http.NewRequest("POST", "http://example.com/api/users?q=1", http.NoBody)
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
 	ip := "10.0.0.1"
 	routeParams := map[string]string{"id": "42"}
 	body := map[string]string{"name": "test"}
 
-	ctx := SetContext(context.Background(), req, ContextData{
+	ctx := SetContext(context.Background(), ContextData{
 		Source:        "gin",
 		Route:         "/api/users/:id",
 		RouteParams:   routeParams,
 		RemoteAddress: &ip,
 		Body:          body,
+		URL:           "http://example.com/api/users?q=1",
+		Path:          "/api/users",
+		Method:        "POST",
+		Query:         map[string][]string{"q": {"1"}},
+		Headers:       map[string][]string{"content-type": {"application/json"}},
 	})
 
 	reqCtx := request.GetContext(ctx)
@@ -44,11 +44,12 @@ func TestHasContext(t *testing.T) {
 	})
 
 	t.Run("returns true after SetContext", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://example.com/path", http.NoBody)
-		require.NoError(t, err)
-		ctx := SetContext(context.Background(), req, ContextData{
+		ctx := SetContext(context.Background(), ContextData{
 			Source: "test",
 			Route:  "/path",
+			Path:   "/path",
+			Method: "GET",
+			URL:    "http://example.com/path",
 		})
 		assert.True(t, HasContext(ctx))
 	})
@@ -61,11 +62,12 @@ func TestHasContext(t *testing.T) {
 
 func TestWrap(t *testing.T) {
 	t.Run("makes context available via GLS", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://example.com/wrapped", http.NoBody)
-		require.NoError(t, err)
-		ctx := SetContext(context.Background(), req, ContextData{
+		ctx := SetContext(context.Background(), ContextData{
 			Source: "wrap-test",
 			Route:  "/wrapped",
+			Path:   "/wrapped",
+			Method: "GET",
+			URL:    "http://example.com/wrapped",
 		})
 
 		var glsCtx *request.Context
@@ -79,11 +81,12 @@ func TestWrap(t *testing.T) {
 	})
 
 	t.Run("GLS context not available after Wrap returns", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://example.com/done", http.NoBody)
-		require.NoError(t, err)
-		ctx := SetContext(context.Background(), req, ContextData{
+		ctx := SetContext(context.Background(), ContextData{
 			Source: "test",
 			Route:  "/done",
+			Path:   "/done",
+			Method: "GET",
+			URL:    "http://example.com/done",
 		})
 
 		Wrap(ctx, func() {})

--- a/instrumentation/sinks/database/sql/disabled_test.go
+++ b/instrumentation/sinks/database/sql/disabled_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -36,10 +37,16 @@ func TestExamineContext_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	zen.SetDisabled(true)
@@ -84,10 +91,16 @@ func TestExamineContext_NotLoaded(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"

--- a/instrumentation/sinks/database/sql/disabled_test.go
+++ b/instrumentation/sinks/database/sql/disabled_test.go
@@ -37,17 +37,11 @@ func TestExamineContext_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	zen.SetDisabled(true)
 	require.True(t, zen.IsDisabled(), "zen should be disabled")
@@ -91,17 +85,11 @@ func TestExamineContext_NotLoaded(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
 

--- a/instrumentation/sinks/database/sql/examine_test.go
+++ b/instrumentation/sinks/database/sql/examine_test.go
@@ -30,17 +30,11 @@ func TestExamineContext_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Clear stats before test
 	agent.Stats().GetAndClear()

--- a/instrumentation/sinks/database/sql/examine_test.go
+++ b/instrumentation/sinks/database/sql/examine_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/database/sql"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -29,10 +30,16 @@ func TestExamineContext_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Clear stats before test

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -38,10 +39,16 @@ func setupTestWithBlocking(t *testing.T) (*mockCloudClient, context.Context, *sq
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	db, err := sql.Open("test", "")
@@ -70,10 +77,16 @@ func setupTestWithoutBlocking(t *testing.T) (*mockCloudClient, context.Context, 
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	db, err := sql.Open("test", "")
@@ -550,10 +563,16 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	db, err := sql.Open("test", "")
@@ -620,10 +639,16 @@ func TestDialectIsPassedThrough(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	db, err := sql.Open("fake-mysql", "")

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -39,17 +39,11 @@ func setupTestWithBlocking(t *testing.T) (*mockCloudClient, context.Context, *sq
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)
@@ -77,17 +71,11 @@ func setupTestWithoutBlocking(t *testing.T) (*mockCloudClient, context.Context, 
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)
@@ -563,17 +551,11 @@ func TestQueryContextIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	db, err := sql.Open("test", "")
 	require.NoError(t, err)
@@ -639,17 +621,11 @@ func TestDialectIsPassedThrough(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	db, err := sql.Open("fake-mysql", "")
 	require.NoError(t, err)

--- a/instrumentation/sinks/jackc/pgx.v5/disabled_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/disabled_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -36,10 +37,16 @@ func TestExamineContext_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	zen.SetDisabled(true)
@@ -84,10 +91,16 @@ func TestExamineContext_NotLoaded(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"

--- a/instrumentation/sinks/jackc/pgx.v5/disabled_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/disabled_test.go
@@ -37,17 +37,11 @@ func TestExamineContext_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	zen.SetDisabled(true)
 	require.True(t, zen.IsDisabled(), "zen should be disabled")
@@ -91,17 +85,11 @@ func TestExamineContext_NotLoaded(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?query=1%27%20OR%201%3D1", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	maliciousQuery := "SELECT * FROM users WHERE id = '1' OR 1=1"
 

--- a/instrumentation/sinks/jackc/pgx.v5/examine_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/examine_test.go
@@ -30,17 +30,11 @@ func TestExamineContext_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Clear stats before test
 	agent.Stats().GetAndClear()

--- a/instrumentation/sinks/jackc/pgx.v5/examine_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/examine_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/jackc/pgx.v5"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/request"
@@ -29,10 +30,16 @@ func TestExamineContext_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Clear stats before test

--- a/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
@@ -41,17 +41,11 @@ func setupTestWithBlocking(t *testing.T) (*mockCloudClient, context.Context, *pg
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Create a pool config with test database connection string
 	// The database is automatically started by 'make test-instrumentation-integration'
@@ -91,17 +85,11 @@ func setupTestWithoutBlocking(t *testing.T) (*mockCloudClient, context.Context, 
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Create a pool config with test database connection string
 	// The database is automatically started by 'make test-instrumentation-integration'
@@ -434,17 +422,11 @@ func TestQueryIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Create a pool config with test database connection string
 	// The database is automatically started by 'make test-instrumentation-integration'

--- a/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -40,10 +41,16 @@ func setupTestWithBlocking(t *testing.T) (*mockCloudClient, context.Context, *pg
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Create a pool config with test database connection string
@@ -84,10 +91,16 @@ func setupTestWithoutBlocking(t *testing.T) (*mockCloudClient, context.Context, 
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Create a pool config with test database connection string
@@ -421,10 +434,16 @@ func TestQueryIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?query=1%27%20OR%201%3D1", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Create a pool config with test database connection string

--- a/instrumentation/sinks/net/http/dial_context_test.go
+++ b/instrumentation/sinks/net/http/dial_context_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -66,10 +67,16 @@ func TestSsrfDialContext_BlocksLiteralPrivateIPFromUserInput(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	original := dialerReturning("10.0.0.1:80")
@@ -86,10 +93,16 @@ func TestSsrfDialContext_BlocksDNSResolvedPrivateIP(t *testing.T) {
 	// "localhost" resolves to 127.0.0.1
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Flocalhost%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	// Simulate the real dialer resolving localhost to 127.0.0.1
@@ -106,10 +119,16 @@ func TestSsrfDialContext_ClosesConnectionOnBlock(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	mc := &mockConn{remoteAddr: mockTCPAddr("10.0.0.1:80")}
@@ -132,10 +151,16 @@ func TestSsrfDialContext_BlocksUnicodeConfusableLocalhost(t *testing.T) {
 	// User sends URL with Unicode confusable hostname in query
 	incomingReq := httptest.NewRequest("GET", "/api/request?url=http%3A%2F%2F%E2%93%9Bocalhost%3A4000%2F", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	// Go's HTTP transport IDNA-normalizes ⓛocalhost → localhost before dialing.
@@ -153,10 +178,16 @@ func TestSsrfDialContext_AllowsPublicIP(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Fexample.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	original := dialerReturning("93.184.216.34:80")
@@ -179,10 +210,16 @@ func TestSsrfDialContext_AllowsDifferentPortThanUserInput(t *testing.T) {
 		strings.NewReader("url=http%3A%2F%2F127.0.0.1%3A4001&port=4000"))
 	incomingReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request_different_port",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	// Server rewrites URL to use port 4000, connects to 127.0.0.1:4000
@@ -204,10 +241,16 @@ func TestSsrfDialContext_BlocksRedirectToPrivateIP(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fssrf-redirects.testssandbox.com%2Fssrf-test-4", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	// Simulate the redirect chain: RoundTrip recorded that
@@ -237,10 +280,16 @@ func TestSsrfDialContext_BlocksDoubleHopRedirectToPrivateIP(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fhop1.example.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	reqCtx := request.GetContext(ctx)
@@ -302,10 +351,16 @@ func TestSsrfDialContext_BlocksRedirectWithCyclicChain(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fgateway.com%2Fredirect", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	reqCtx := request.GetContext(ctx)
@@ -366,10 +421,16 @@ func TestSsrfDialContext_BlocksRedirectWhenStaleEntryFromEarlierRequestCreatesCy
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Floopa.com%2Fredirect", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/request",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	reqCtx := request.GetContext(ctx)
@@ -492,10 +553,16 @@ func TestStoredSsrf(t *testing.T) {
 			if tt.useReqCtx {
 				incomingReq := httptest.NewRequest("GET", "/test", nil)
 				ip := "1.2.3.4"
-				ctx = request.SetContext(context.Background(), incomingReq, request.ContextData{
+				ctx = request.SetContext(context.Background(), request.ContextData{
 					Source:        "test",
 					Route:         "/test",
 					RemoteAddress: &ip,
+					URL:           zenhttp.FullURL(incomingReq),
+					Path:          incomingReq.URL.Path,
+					Method:        incomingReq.Method,
+					Query:         incomingReq.URL.Query(),
+					Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+					Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 				})
 			} else {
 				ctx = context.Background()
@@ -554,8 +621,14 @@ func bypassedContext(t *testing.T) context.Context {
 		Block:       &block,
 	}, nil)
 	incomingReq := httptest.NewRequest("GET", "/test", nil)
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 	require.True(t, request.IsBypassed(ctx))
 	return ctx
@@ -600,10 +673,16 @@ func TestSsrfDialContext_AllowsPrivateIPNotInUserInput(t *testing.T) {
 	// User input contains a different hostname
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Fexample.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	original := dialerReturning("10.0.0.1:80")
@@ -622,10 +701,16 @@ func TestSsrfDialContext_ReportsModuleName(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	original := dialerReturning("10.0.0.1:80")

--- a/instrumentation/sinks/net/http/dial_context_test.go
+++ b/instrumentation/sinks/net/http/dial_context_test.go
@@ -67,17 +67,11 @@ func TestSsrfDialContext_BlocksLiteralPrivateIPFromUserInput(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	original := dialerReturning("10.0.0.1:80")
 	wrapped := ssrfDialContext(original)
@@ -93,17 +87,11 @@ func TestSsrfDialContext_BlocksDNSResolvedPrivateIP(t *testing.T) {
 	// "localhost" resolves to 127.0.0.1
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Flocalhost%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Simulate the real dialer resolving localhost to 127.0.0.1
 	original := dialerReturning("127.0.0.1:80")
@@ -119,17 +107,11 @@ func TestSsrfDialContext_ClosesConnectionOnBlock(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	mc := &mockConn{remoteAddr: mockTCPAddr("10.0.0.1:80")}
 	original := func(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -151,17 +133,11 @@ func TestSsrfDialContext_BlocksUnicodeConfusableLocalhost(t *testing.T) {
 	// User sends URL with Unicode confusable hostname in query
 	incomingReq := httptest.NewRequest("GET", "/api/request?url=http%3A%2F%2F%E2%93%9Bocalhost%3A4000%2F", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Go's HTTP transport IDNA-normalizes ⓛocalhost → localhost before dialing.
 	// DialContext receives "localhost:4000", which resolves to 127.0.0.1.
@@ -178,17 +154,11 @@ func TestSsrfDialContext_AllowsPublicIP(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Fexample.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	original := dialerReturning("93.184.216.34:80")
 	wrapped := ssrfDialContext(original)
@@ -210,17 +180,11 @@ func TestSsrfDialContext_AllowsDifferentPortThanUserInput(t *testing.T) {
 		strings.NewReader("url=http%3A%2F%2F127.0.0.1%3A4001&port=4000"))
 	incomingReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request_different_port",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request_different_port"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Server rewrites URL to use port 4000, connects to 127.0.0.1:4000
 	original := dialerReturning("127.0.0.1:4000")
@@ -241,17 +205,11 @@ func TestSsrfDialContext_BlocksRedirectToPrivateIP(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fssrf-redirects.testssandbox.com%2Fssrf-test-4", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Simulate the redirect chain: RoundTrip recorded that
 	// ssrf-redirects.testssandbox.com:80 redirected to 127.0.0.1:4000
@@ -280,17 +238,11 @@ func TestSsrfDialContext_BlocksDoubleHopRedirectToPrivateIP(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fhop1.example.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	reqCtx := request.GetContext(ctx)
 	reqCtx.AddOutgoingRedirect(request.RedirectEntry{
@@ -351,17 +303,11 @@ func TestSsrfDialContext_BlocksRedirectWithCyclicChain(t *testing.T) {
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Fgateway.com%2Fredirect", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	reqCtx := request.GetContext(ctx)
 	reqCtx.AddOutgoingRedirect(request.RedirectEntry{
@@ -421,17 +367,11 @@ func TestSsrfDialContext_BlocksRedirectWhenStaleEntryFromEarlierRequestCreatesCy
 	incomingReq := httptest.NewRequest("GET",
 		"/api/request?url=http%3A%2F%2Floopa.com%2Fredirect", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/request",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/request"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	reqCtx := request.GetContext(ctx)
 	reqCtx.AddOutgoingRedirect(request.RedirectEntry{
@@ -553,17 +493,11 @@ func TestStoredSsrf(t *testing.T) {
 			if tt.useReqCtx {
 				incomingReq := httptest.NewRequest("GET", "/test", nil)
 				ip := "1.2.3.4"
-				ctx = request.SetContext(context.Background(), request.ContextData{
-					Source:        "test",
-					Route:         "/test",
-					RemoteAddress: &ip,
-					URL:           zenhttp.FullURL(incomingReq),
-					Path:          incomingReq.URL.Path,
-					Method:        incomingReq.Method,
-					Query:         incomingReq.URL.Query(),
-					Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-					Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-				})
+				data := zenhttp.ContextDataFromRequest(incomingReq)
+				data.Source = "test"
+				data.Route = "/test"
+				data.RemoteAddress = &ip
+				ctx = request.SetContext(context.Background(), data)
 			} else {
 				ctx = context.Background()
 			}
@@ -621,15 +555,9 @@ func bypassedContext(t *testing.T) context.Context {
 		Block:       &block,
 	}, nil)
 	incomingReq := httptest.NewRequest("GET", "/test", nil)
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 	require.True(t, request.IsBypassed(ctx))
 	return ctx
 }
@@ -673,17 +601,11 @@ func TestSsrfDialContext_AllowsPrivateIPNotInUserInput(t *testing.T) {
 	// User input contains a different hostname
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2Fexample.com", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	original := dialerReturning("10.0.0.1:80")
 	wrapped := ssrfDialContext(original)
@@ -701,17 +623,11 @@ func TestSsrfDialContext_ReportsModuleName(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/test?url=http%3A%2F%2F10.0.0.1%2Finternal", nil)
 	ip := "1.2.3.4"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	original := dialerReturning("10.0.0.1:80")
 	wrapped := ssrfDialContext(original)

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -165,32 +165,20 @@ func TestExamine_ForceProtectionOffSkipsOutboundBlocking(t *testing.T) {
 	}, nil)
 
 	incomingReq := httptest.NewRequest("GET", "/api/no-protection", nil)
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:  "test",
-		Route:   "/api/no-protection",
-		URL:     zenhttp.FullURL(incomingReq),
-		Path:    incomingReq.URL.Path,
-		Method:  incomingReq.Method,
-		Query:   incomingReq.URL.Query(),
-		Headers: zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/api/no-protection"
+	ctx := request.SetContext(context.Background(), data)
 
 	outboundReq, _ := http.NewRequestWithContext(ctx, "GET", "http://blocked.com", http.NoBody)
 	assert.NoError(t, Examine(outboundReq), "force protection off route should not block outbound connections")
 
 	// A route without force protection off should still be blocked
 	incomingReqNormal := httptest.NewRequest("GET", "/api/normal", nil)
-	ctxNormal := request.SetContext(context.Background(), request.ContextData{
-		Source:  "test",
-		Route:   "/api/normal",
-		URL:     zenhttp.FullURL(incomingReqNormal),
-		Path:    incomingReqNormal.URL.Path,
-		Method:  incomingReqNormal.Method,
-		Query:   incomingReqNormal.URL.Query(),
-		Headers: zenhttp.HeadersToMap(incomingReqNormal.Header),
-		Cookies: zenhttp.CookiesToMap(incomingReqNormal.Cookies()),
-	})
+	data = zenhttp.ContextDataFromRequest(incomingReqNormal)
+	data.Source = "test"
+	data.Route = "/api/normal"
+	ctxNormal := request.SetContext(context.Background(), data)
 	outboundReqNormal, _ := http.NewRequestWithContext(ctxNormal, "GET", "http://blocked.com", http.NoBody)
 	var blockedErr *zen.OutboundConnectionBlocked
 	require.ErrorAs(t, Examine(outboundReqNormal), &blockedErr, "normal route should still block outbound connections")
@@ -219,15 +207,9 @@ func TestExamine_BypassedIPSkipsOutboundBlocking(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/api/fetch?url=http://malicious.com", nil)
 	ip := "10.10.10.10"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(incomingReq),
-		Path:          incomingReq.URL.Path,
-		Method:        incomingReq.Method,
-		Query:         incomingReq.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 	require.True(t, request.IsBypassed(ctx), "context should be marked as bypassed")
 
 	agent.State().GetAndClearHostnames()

--- a/instrumentation/sinks/net/http/examine_test.go
+++ b/instrumentation/sinks/net/http/examine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -164,9 +165,15 @@ func TestExamine_ForceProtectionOffSkipsOutboundBlocking(t *testing.T) {
 	}, nil)
 
 	incomingReq := httptest.NewRequest("GET", "/api/no-protection", nil)
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
-		Source: "test",
-		Route:  "/api/no-protection",
+	ctx := request.SetContext(context.Background(), request.ContextData{
+		Source:  "test",
+		Route:   "/api/no-protection",
+		URL:     zenhttp.FullURL(incomingReq),
+		Path:    incomingReq.URL.Path,
+		Method:  incomingReq.Method,
+		Query:   incomingReq.URL.Query(),
+		Headers: zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	outboundReq, _ := http.NewRequestWithContext(ctx, "GET", "http://blocked.com", http.NoBody)
@@ -174,9 +181,15 @@ func TestExamine_ForceProtectionOffSkipsOutboundBlocking(t *testing.T) {
 
 	// A route without force protection off should still be blocked
 	incomingReqNormal := httptest.NewRequest("GET", "/api/normal", nil)
-	ctxNormal := request.SetContext(context.Background(), incomingReqNormal, request.ContextData{
-		Source: "test",
-		Route:  "/api/normal",
+	ctxNormal := request.SetContext(context.Background(), request.ContextData{
+		Source:  "test",
+		Route:   "/api/normal",
+		URL:     zenhttp.FullURL(incomingReqNormal),
+		Path:    incomingReqNormal.URL.Path,
+		Method:  incomingReqNormal.Method,
+		Query:   incomingReqNormal.URL.Query(),
+		Headers: zenhttp.HeadersToMap(incomingReqNormal.Header),
+		Cookies: zenhttp.CookiesToMap(incomingReqNormal.Cookies()),
 	})
 	outboundReqNormal, _ := http.NewRequestWithContext(ctxNormal, "GET", "http://blocked.com", http.NoBody)
 	var blockedErr *zen.OutboundConnectionBlocked
@@ -206,8 +219,14 @@ func TestExamine_BypassedIPSkipsOutboundBlocking(t *testing.T) {
 
 	incomingReq := httptest.NewRequest("GET", "/api/fetch?url=http://malicious.com", nil)
 	ip := "10.10.10.10"
-	ctx := request.SetContext(context.Background(), incomingReq, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(incomingReq),
+		Path:          incomingReq.URL.Path,
+		Method:        incomingReq.Method,
+		Query:         incomingReq.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies:       zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 	require.True(t, request.IsBypassed(ctx), "context should be marked as bypassed")
 

--- a/instrumentation/sinks/net/http/wrap_transport_test.go
+++ b/instrumentation/sinks/net/http/wrap_transport_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/internal/testutil"
@@ -243,9 +244,16 @@ func TestRoundTrip_RecordsRedirect(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	ctx := request.SetContext(context.TODO(), httptest.NewRequest("GET", "/test", nil), request.ContextData{
-		Source: "test",
-		Route:  "/test",
+	incomingReq := httptest.NewRequest("GET", "/test", nil)
+	ctx := request.SetContext(context.TODO(), request.ContextData{
+		Source:  "test",
+		Route:   "/test",
+		URL:     zenhttp.FullURL(incomingReq),
+		Path:    incomingReq.URL.Path,
+		Method:  incomingReq.Method,
+		Query:   incomingReq.URL.Query(),
+		Headers: zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	transport := &ssrfTransport{inner: &http.Transport{}}
@@ -268,9 +276,16 @@ func TestRoundTrip_NonRedirectDoesNotRecord(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	ctx := request.SetContext(context.TODO(), httptest.NewRequest("GET", "/test", nil), request.ContextData{
-		Source: "test",
-		Route:  "/test",
+	incomingReq := httptest.NewRequest("GET", "/test", nil)
+	ctx := request.SetContext(context.TODO(), request.ContextData{
+		Source:  "test",
+		Route:   "/test",
+		URL:     zenhttp.FullURL(incomingReq),
+		Path:    incomingReq.URL.Path,
+		Method:  incomingReq.Method,
+		Query:   incomingReq.URL.Query(),
+		Headers: zenhttp.HeadersToMap(incomingReq.Header),
+		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
 	})
 
 	transport := &ssrfTransport{inner: &http.Transport{}}

--- a/instrumentation/sinks/net/http/wrap_transport_test.go
+++ b/instrumentation/sinks/net/http/wrap_transport_test.go
@@ -245,16 +245,10 @@ func TestRoundTrip_RecordsRedirect(t *testing.T) {
 	defer ts.Close()
 
 	incomingReq := httptest.NewRequest("GET", "/test", nil)
-	ctx := request.SetContext(context.TODO(), request.ContextData{
-		Source:  "test",
-		Route:   "/test",
-		URL:     zenhttp.FullURL(incomingReq),
-		Path:    incomingReq.URL.Path,
-		Method:  incomingReq.Method,
-		Query:   incomingReq.URL.Query(),
-		Headers: zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	ctx := request.SetContext(context.TODO(), data)
 
 	transport := &ssrfTransport{inner: &http.Transport{}}
 	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api", nil)
@@ -277,16 +271,10 @@ func TestRoundTrip_NonRedirectDoesNotRecord(t *testing.T) {
 	defer ts.Close()
 
 	incomingReq := httptest.NewRequest("GET", "/test", nil)
-	ctx := request.SetContext(context.TODO(), request.ContextData{
-		Source:  "test",
-		Route:   "/test",
-		URL:     zenhttp.FullURL(incomingReq),
-		Path:    incomingReq.URL.Path,
-		Method:  incomingReq.Method,
-		Query:   incomingReq.URL.Query(),
-		Headers: zenhttp.HeadersToMap(incomingReq.Header),
-		Cookies: zenhttp.CookiesToMap(incomingReq.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(incomingReq)
+	data.Source = "test"
+	data.Route = "/test"
+	ctx := request.SetContext(context.TODO(), data)
 
 	transport := &ssrfTransport{inner: &http.Transport{}}
 	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api", nil)

--- a/instrumentation/sinks/os/exec/disabled_test.go
+++ b/instrumentation/sinks/os/exec/disabled_test.go
@@ -34,17 +34,11 @@ func TestExamine_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?cmd=rm%20-rf%20%2F", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	config.SetZenDisabled(true)
 

--- a/instrumentation/sinks/os/exec/disabled_test.go
+++ b/instrumentation/sinks/os/exec/disabled_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/os/exec"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -33,10 +34,16 @@ func TestExamine_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?cmd=rm%20-rf%20%2F", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	config.SetZenDisabled(true)

--- a/instrumentation/sinks/os/exec/examine_test.go
+++ b/instrumentation/sinks/os/exec/examine_test.go
@@ -33,17 +33,11 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	// Clear stats before test
 	agent.Stats().GetAndClear()
@@ -79,17 +73,11 @@ func TestExamine_ReportsModuleName(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?cmd=ls%20.", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	_ = exec.Examine(ctx, "os/exec.Cmd.Run", []string{"sh", "-c", "ls ."})
 

--- a/instrumentation/sinks/os/exec/examine_test.go
+++ b/instrumentation/sinks/os/exec/examine_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/sinks/os/exec"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -32,10 +33,16 @@ func TestExamine_TracksOperationStats(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// Clear stats before test
@@ -72,10 +79,16 @@ func TestExamine_ReportsModuleName(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/test?cmd=ls%20.", nil)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	_ = exec.Examine(ctx, "os/exec.Cmd.Run", []string{"sh", "-c", "ls ."})

--- a/instrumentation/sinks/os/exec/integration_test.go
+++ b/instrumentation/sinks/os/exec/integration_test.go
@@ -30,17 +30,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		// Simple test to verify each exec method is instrumented
 		req := httptest.NewRequest("GET", "/route?cmd=ls%20.", http.NoBody)
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/route",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/route"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		t.Run("Run", func(t *testing.T) {
 			request.WrapWithGLS(ctx, func() {
@@ -148,17 +142,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				req := httptest.NewRequest("GET", "/route?"+tc.queryParam, http.NoBody)
 				ip := "127.0.0.1"
-				ctx := request.SetContext(context.Background(), request.ContextData{
-					Source:        "test",
-					Route:         "/route",
-					RemoteAddress: &ip,
-					URL:           zenhttp.FullURL(req),
-					Path:          req.URL.Path,
-					Method:        req.Method,
-					Query:         req.URL.Query(),
-					Headers:       zenhttp.HeadersToMap(req.Header),
-					Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-				})
+				data := zenhttp.ContextDataFromRequest(req)
+				data.Source = "test"
+				data.Route = "/route"
+				data.RemoteAddress = &ip
+				ctx := request.SetContext(context.Background(), data)
 
 				request.WrapWithGLS(ctx, func() {
 					cmd := exec.Command(tc.command[0], tc.command[1:]...)
@@ -177,17 +165,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("shell injection via positional parameters", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?target=8.8.8.8%3Bcat%20/etc/passwd", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/route",
-				RemoteAddress: &ip,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/route"
+			data.RemoteAddress = &ip
+			ctx := request.SetContext(context.Background(), data)
 
 			request.WrapWithGLS(ctx, func() {
 				// This is vulnerable because the command uses $0 which references the next argument
@@ -203,17 +185,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("multiple positional parameters with injection", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?arg1=safe&arg2=malicious%3Brm%20-rf%20/", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/route",
-				RemoteAddress: &ip,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/route"
+			data.RemoteAddress = &ip
+			ctx := request.SetContext(context.Background(), data)
 
 			request.WrapWithGLS(ctx, func() {
 				// Command references multiple positional parameters
@@ -230,17 +206,11 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("safe positional parameter not referenced", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?unused=malicious%3Brm%20-rf%20/", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/route",
-				RemoteAddress: &ip,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/route"
+			data.RemoteAddress = &ip
+			ctx := request.SetContext(context.Background(), data)
 
 			request.WrapWithGLS(ctx, func() {
 				// Even though userInput is malicious, it's never used by the command

--- a/instrumentation/sinks/os/exec/integration_test.go
+++ b/instrumentation/sinks/os/exec/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/vulnerabilities"
@@ -29,10 +30,16 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		// Simple test to verify each exec method is instrumented
 		req := httptest.NewRequest("GET", "/route?cmd=ls%20.", http.NoBody)
 		ip := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/route",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		t.Run("Run", func(t *testing.T) {
@@ -141,10 +148,16 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				req := httptest.NewRequest("GET", "/route?"+tc.queryParam, http.NoBody)
 				ip := "127.0.0.1"
-				ctx := request.SetContext(context.Background(), req, request.ContextData{
+				ctx := request.SetContext(context.Background(), request.ContextData{
 					Source:        "test",
 					Route:         "/route",
 					RemoteAddress: &ip,
+					URL:           zenhttp.FullURL(req),
+					Path:          req.URL.Path,
+					Method:        req.Method,
+					Query:         req.URL.Query(),
+					Headers:       zenhttp.HeadersToMap(req.Header),
+					Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 				})
 
 				request.WrapWithGLS(ctx, func() {
@@ -164,10 +177,16 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("shell injection via positional parameters", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?target=8.8.8.8%3Bcat%20/etc/passwd", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/route",
 				RemoteAddress: &ip,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			request.WrapWithGLS(ctx, func() {
@@ -184,10 +203,16 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("multiple positional parameters with injection", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?arg1=safe&arg2=malicious%3Brm%20-rf%20/", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/route",
 				RemoteAddress: &ip,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			request.WrapWithGLS(ctx, func() {
@@ -205,10 +230,16 @@ func TestExecIsAutomaticallyInstrumented(t *testing.T) {
 		t.Run("safe positional parameter not referenced", func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/route?unused=malicious%3Brm%20-rf%20/", http.NoBody)
 			ip := "127.0.0.1"
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/route",
 				RemoteAddress: &ip,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			request.WrapWithGLS(ctx, func() {

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -74,10 +75,16 @@ func setupBlockingTest(t *testing.T) (*mockCloudClient, context.Context) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	return client, ctx
@@ -118,10 +125,16 @@ func TestOpenFileIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -182,10 +195,16 @@ func TestOpenFileIsNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -75,17 +75,11 @@ func setupBlockingTest(t *testing.T) (*mockCloudClient, context.Context) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	return client, ctx
 }
@@ -125,17 +119,11 @@ func TestOpenFileIsAutomaticallyInstrumented(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		_, err := os.OpenFile("/tmp/"+"../test.txt", os.O_RDONLY, 0o600)
@@ -195,17 +183,11 @@ func TestOpenFileIsNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		_, err := os.OpenFile("/tmp/"+"../test.txt", os.O_RDONLY, 0o600)

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -96,10 +97,16 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -159,10 +166,16 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -221,10 +234,16 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -258,10 +277,16 @@ func TestChainedJoinsNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -303,10 +328,16 @@ func TestChainedJoinsAttackReportedOnceWhenOpenFileCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -356,10 +387,16 @@ func TestGlobPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	dir := t.TempDir()
@@ -401,10 +438,16 @@ func TestWalkPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	dir := t.TempDir()
@@ -452,10 +495,16 @@ func TestWalkPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	dir := t.TempDir()
@@ -501,10 +550,16 @@ func TestWalkDirPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	dir := t.TempDir()
@@ -552,10 +607,16 @@ func TestWalkDirPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	dir := t.TempDir()
@@ -605,10 +666,16 @@ func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -97,17 +97,11 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")
@@ -166,17 +160,11 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")
@@ -234,17 +222,11 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		// Call filepath.Join but don't call os.OpenFile
@@ -277,17 +259,11 @@ func TestChainedJoinsNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		// First join stores a deferred attack
@@ -328,17 +304,11 @@ func TestChainedJoinsAttackReportedOnceWhenOpenFileCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		first := filepath.Join("/tmp/", "../test.txt")
@@ -387,17 +357,11 @@ func TestGlobPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -438,17 +402,11 @@ func TestWalkPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -495,17 +453,11 @@ func TestWalkPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -550,17 +502,11 @@ func TestWalkDirPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -607,17 +553,11 @@ func TestWalkDirPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../sub", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "sub")
@@ -666,17 +606,11 @@ func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := filepath.Join("/tmp/", "../test.txt")

--- a/instrumentation/sinks/path/integration_test.go
+++ b/instrumentation/sinks/path/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -96,10 +97,16 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -159,10 +166,16 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -221,10 +234,16 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {
@@ -262,10 +281,16 @@ func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	request.WrapWithGLS(ctx, func() {

--- a/instrumentation/sinks/path/integration_test.go
+++ b/instrumentation/sinks/path/integration_test.go
@@ -97,17 +97,11 @@ func TestJoinPathInjectionBlockIsDeferred(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := path.Join("/tmp/", "../test.txt")
@@ -166,17 +160,11 @@ func TestJoinPathInjectionNotBlockedWhenInMonitoringMode(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := path.Join("/tmp/", "../test.txt")
@@ -234,17 +222,11 @@ func TestJoinPathInjectionNoAttackWhenOpenFileNotCalled(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		// Call path.Join but don't call os.OpenFile
@@ -281,17 +263,11 @@ func TestJoinPathInjectionReportedOnceForMultipleFileOps(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/route?path=../test.txt", http.NoBody)
 	ip := "127.0.0.1"
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	request.WrapWithGLS(ctx, func() {
 		path := path.Join("/tmp/", "../test.txt")

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -1,7 +1,7 @@
 package gin
 
 import (
-	"github.com/AikidoSec/firewall-go/instrumentation/http"
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/instrumentation/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
@@ -32,17 +32,23 @@ func GetMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		reqCtx := request.SetContext(c.Request.Context(), c.Request, request.ContextData{
+		reqCtx := request.SetContext(c.Request.Context(), request.ContextData{
 			Source:        "gin",
 			Route:         c.FullPath(),
 			RouteParams:   routeParams,
 			RemoteAddress: &ip,
-			Body:          http.TryExtractBody(c.Request, c),
+			Body:          zenhttp.TryExtractBody(c.Request, c),
+			URL:           zenhttp.FullURL(c.Request),
+			Path:          c.Request.URL.Path,
+			Method:        c.Request.Method,
+			Query:         c.Request.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(c.Request.Header),
+			Cookies:       zenhttp.CookiesToMap(c.Request.Cookies()),
 		})
 		c.Request = c.Request.WithContext(reqCtx)
 
 		// Write a response using Gin :
-		res := http.OnInitRequest(c)
+		res := zenhttp.OnInitRequest(c)
 		if res != nil {
 			c.String(res.StatusCode, res.Message)
 			c.Abort()
@@ -53,7 +59,7 @@ func GetMiddleware() gin.HandlerFunc {
 		// It may not run depending where the recovery middleware sits in the middleware chain
 		defer func() {
 			statusCode := c.Writer.Status()
-			http.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
+			zenhttp.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
 		}()
 
 		request.Wrap(reqCtx, func() {

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -32,19 +32,14 @@ func GetMiddleware() gin.HandlerFunc {
 			}
 		}
 
-		reqCtx := request.SetContext(c.Request.Context(), request.ContextData{
-			Source:        "gin",
-			Route:         c.FullPath(),
-			RouteParams:   routeParams,
-			RemoteAddress: &ip,
-			Body:          zenhttp.TryExtractBody(c.Request, c),
-			URL:           zenhttp.FullURL(c.Request),
-			Path:          c.Request.URL.Path,
-			Method:        c.Request.Method,
-			Query:         c.Request.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(c.Request.Header),
-			Cookies:       zenhttp.CookiesToMap(c.Request.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(c.Request)
+		data.Source = "gin"
+		data.Route = c.FullPath()
+		data.RouteParams = routeParams
+		data.RemoteAddress = &ip
+		data.Body = zenhttp.TryExtractBody(c.Request, c)
+
+		reqCtx := request.SetContext(c.Request.Context(), data)
 		c.Request = c.Request.WithContext(reqCtx)
 
 		// Write a response using Gin :

--- a/instrumentation/sources/go-chi/chi.v5/middleware.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware.go
@@ -51,19 +51,14 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 				}
 			}
 
-			reqCtx := request.SetContext(r.Context(), request.ContextData{
-				Source:        "chi",
-				Route:         route,
-				RouteParams:   routeParams,
-				RemoteAddress: &ip,
-				Body:          zenhttp.TryExtractBody(r, &requestParser{req: r}),
-				URL:           zenhttp.FullURL(r),
-				Path:          r.URL.Path,
-				Method:        r.Method,
-				Query:         r.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(r.Header),
-				Cookies:       zenhttp.CookiesToMap(r.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(r)
+			data.Source = "chi"
+			data.Route = route
+			data.RouteParams = routeParams
+			data.RemoteAddress = &ip
+			data.Body = zenhttp.TryExtractBody(r, &requestParser{req: r})
+
+			reqCtx := request.SetContext(r.Context(), data)
 
 			wrappedR := r.WithContext(reqCtx)
 

--- a/instrumentation/sources/go-chi/chi.v5/middleware.go
+++ b/instrumentation/sources/go-chi/chi.v5/middleware.go
@@ -51,12 +51,18 @@ func GetMiddleware() func(next http.Handler) http.Handler {
 				}
 			}
 
-			reqCtx := request.SetContext(r.Context(), r, request.ContextData{
+			reqCtx := request.SetContext(r.Context(), request.ContextData{
 				Source:        "chi",
 				Route:         route,
 				RouteParams:   routeParams,
 				RemoteAddress: &ip,
 				Body:          zenhttp.TryExtractBody(r, &requestParser{req: r}),
+				URL:           zenhttp.FullURL(r),
+				Path:          r.URL.Path,
+				Method:        r.Method,
+				Query:         r.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(r.Header),
+				Cookies:       zenhttp.CookiesToMap(r.Cookies()),
 			})
 
 			wrappedR := r.WithContext(reqCtx)

--- a/instrumentation/sources/labstack/echo.v4/middleware.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware.go
@@ -35,19 +35,14 @@ func GetMiddleware() echo.MiddlewareFunc {
 				}
 			}
 
-			reqCtx := request.SetContext(httpRequest.Context(), request.ContextData{
-				Source:        "echo",
-				Route:         c.Path(),
-				RouteParams:   routeParams,
-				RemoteAddress: &ip,
-				Body:          http.TryExtractBody(httpRequest, c),
-				URL:           http.FullURL(httpRequest),
-				Path:          httpRequest.URL.Path,
-				Method:        httpRequest.Method,
-				Query:         httpRequest.URL.Query(),
-				Headers:       http.HeadersToMap(httpRequest.Header),
-				Cookies:       http.CookiesToMap(httpRequest.Cookies()),
-			})
+			data := http.ContextDataFromRequest(httpRequest)
+			data.Source = "echo"
+			data.Route = c.Path()
+			data.RouteParams = routeParams
+			data.RemoteAddress = &ip
+			data.Body = http.TryExtractBody(httpRequest, c)
+
+			reqCtx := request.SetContext(httpRequest.Context(), data)
 			c.SetRequest(httpRequest.WithContext(reqCtx))
 
 			// Write a possible response (i.e. geo-blocking bot blocking)

--- a/instrumentation/sources/labstack/echo.v4/middleware.go
+++ b/instrumentation/sources/labstack/echo.v4/middleware.go
@@ -35,12 +35,18 @@ func GetMiddleware() echo.MiddlewareFunc {
 				}
 			}
 
-			reqCtx := request.SetContext(httpRequest.Context(), httpRequest, request.ContextData{
+			reqCtx := request.SetContext(httpRequest.Context(), request.ContextData{
 				Source:        "echo",
 				Route:         c.Path(),
 				RouteParams:   routeParams,
 				RemoteAddress: &ip,
 				Body:          http.TryExtractBody(httpRequest, c),
+				URL:           http.FullURL(httpRequest),
+				Path:          httpRequest.URL.Path,
+				Method:        httpRequest.Method,
+				Query:         httpRequest.URL.Query(),
+				Headers:       http.HeadersToMap(httpRequest.Header),
+				Cookies:       http.CookiesToMap(httpRequest.Cookies()),
 			})
 			c.SetRequest(httpRequest.WithContext(reqCtx))
 

--- a/instrumentation/sources/labstack/echo.v5/middleware.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware.go
@@ -34,19 +34,14 @@ func GetMiddleware() echo.MiddlewareFunc {
 				}
 			}
 
-			reqCtx := request.SetContext(httpRequest.Context(), request.ContextData{
-				Source:        "echo",
-				Route:         c.Path(),
-				RouteParams:   routeParams,
-				RemoteAddress: &ip,
-				Body:          http.TryExtractBody(httpRequest, c),
-				URL:           http.FullURL(httpRequest),
-				Path:          httpRequest.URL.Path,
-				Method:        httpRequest.Method,
-				Query:         httpRequest.URL.Query(),
-				Headers:       http.HeadersToMap(httpRequest.Header),
-				Cookies:       http.CookiesToMap(httpRequest.Cookies()),
-			})
+			data := http.ContextDataFromRequest(httpRequest)
+			data.Source = "echo"
+			data.Route = c.Path()
+			data.RouteParams = routeParams
+			data.RemoteAddress = &ip
+			data.Body = http.TryExtractBody(httpRequest, c)
+
+			reqCtx := request.SetContext(httpRequest.Context(), data)
 			c.SetRequest(httpRequest.WithContext(reqCtx))
 
 			// Write a possible response (i.e. geo-blocking bot blocking)

--- a/instrumentation/sources/labstack/echo.v5/middleware.go
+++ b/instrumentation/sources/labstack/echo.v5/middleware.go
@@ -34,12 +34,18 @@ func GetMiddleware() echo.MiddlewareFunc {
 				}
 			}
 
-			reqCtx := request.SetContext(httpRequest.Context(), httpRequest, request.ContextData{
+			reqCtx := request.SetContext(httpRequest.Context(), request.ContextData{
 				Source:        "echo",
 				Route:         c.Path(),
 				RouteParams:   routeParams,
 				RemoteAddress: &ip,
 				Body:          http.TryExtractBody(httpRequest, c),
+				URL:           http.FullURL(httpRequest),
+				Path:          httpRequest.URL.Path,
+				Method:        httpRequest.Method,
+				Query:         httpRequest.URL.Query(),
+				Headers:       http.HeadersToMap(httpRequest.Header),
+				Cookies:       http.CookiesToMap(httpRequest.Cookies()),
 			})
 			c.SetRequest(httpRequest.WithContext(reqCtx))
 

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -36,19 +36,14 @@ func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.R
 			pattern = pattern[idx:]
 		}
 
-		ctx := request.SetContext(r.Context(), request.ContextData{
-			Source:        "http.ServeMux",
-			Route:         pattern,
-			RouteParams:   extractRouteParams(r, pattern),
-			RemoteAddress: &ip,
-			Body:          zenhttp.TryExtractBody(r, &requestParser{req: r}),
-			URL:           zenhttp.FullURL(r),
-			Path:          r.URL.Path,
-			Method:        r.Method,
-			Query:         r.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(r.Header),
-			Cookies:       zenhttp.CookiesToMap(r.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(r)
+		data.Source = "http.ServeMux"
+		data.Route = pattern
+		data.RouteParams = extractRouteParams(r, pattern)
+		data.RemoteAddress = &ip
+		data.Body = zenhttp.TryExtractBody(r, &requestParser{req: r})
+
+		ctx := request.SetContext(r.Context(), data)
 
 		wrappedR := r.WithContext(ctx)
 

--- a/instrumentation/sources/net/http/middleware.go
+++ b/instrumentation/sources/net/http/middleware.go
@@ -36,12 +36,18 @@ func Middleware(orig func(w http.ResponseWriter, r *http.Request)) func(w http.R
 			pattern = pattern[idx:]
 		}
 
-		ctx := request.SetContext(r.Context(), r, request.ContextData{
+		ctx := request.SetContext(r.Context(), request.ContextData{
 			Source:        "http.ServeMux",
 			Route:         pattern,
 			RouteParams:   extractRouteParams(r, pattern),
 			RemoteAddress: &ip,
 			Body:          zenhttp.TryExtractBody(r, &requestParser{req: r}),
+			URL:           zenhttp.FullURL(r),
+			Path:          r.URL.Path,
+			Method:        r.Method,
+			Query:         r.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(r.Header),
+			Cookies:       zenhttp.CookiesToMap(r.Cookies()),
 		})
 
 		wrappedR := r.WithContext(ctx)

--- a/internal/request/gls_test.go
+++ b/internal/request/gls_test.go
@@ -3,7 +3,6 @@ package request
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
@@ -21,15 +20,16 @@ func TestWrapWithGLS(t *testing.T) {
 		{
 			name: "context with request context",
 			setupCtx: func() context.Context {
-				req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
-				req.Header.Set("User-Agent", "test-agent")
-				req.RemoteAddr = "192.168.1.1:8080"
-
+				remoteAddr := "192.168.1.1:8080"
 				ctx := context.Background()
-				return SetContext(ctx, req, ContextData{
+				return SetContext(ctx, ContextData{
 					Source:        "test-source",
 					Route:         "/test",
-					RemoteAddress: &req.RemoteAddr,
+					RemoteAddress: &remoteAddr,
+					URL:           "https://example.com/test",
+					Path:          "/test",
+					Method:        "GET",
+					Headers:       map[string][]string{"user-agent": {"test-agent"}},
 				})
 			},
 			wantNil: false,
@@ -86,9 +86,8 @@ func TestWrapWithGLS_BypassedContext(t *testing.T) {
 		Block:       &block,
 	}, nil)
 
-	req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
 	ip := "10.10.10.10"
-	ctx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+	ctx := SetContext(context.Background(), ContextData{RemoteAddress: &ip})
 	require.True(t, IsBypassed(ctx))
 
 	var capturedBypassed bool
@@ -116,12 +115,14 @@ func TestWrapWithGLS_ConcurrentAccess(t *testing.T) {
 		blockers[i] = make(chan struct{})
 
 		go func(id int) {
-			req, _ := http.NewRequest("GET", fmt.Sprintf("https://example.com/req%d", id), http.NoBody)
-			req.RemoteAddr = fmt.Sprintf("192.168.1.%d:8080", id)
-			ctx := SetContext(context.Background(), req, ContextData{
+			remoteAddr := fmt.Sprintf("192.168.1.%d:8080", id)
+			ctx := SetContext(context.Background(), ContextData{
 				Source:        fmt.Sprintf("source%d", id),
 				Route:         fmt.Sprintf("/req%d", id),
-				RemoteAddress: &req.RemoteAddr,
+				RemoteAddress: &remoteAddr,
+				URL:           fmt.Sprintf("http://example.com/req%d", id),
+				Path:          fmt.Sprintf("/req%d", id),
+				Method:        "GET",
 			})
 
 			WrapWithGLS(ctx, func() {

--- a/internal/request/http_context.go
+++ b/internal/request/http_context.go
@@ -2,9 +2,7 @@ package request
 
 import (
 	"context"
-	"fmt"
 	"maps"
-	"net/http"
 	"strings"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -22,16 +20,22 @@ type ContextData struct {
 	RouteParams   map[string]string
 	RemoteAddress *string
 	Body          any
+	URL           string
+	Path          string
+	Method        string
+	Query         map[string][]string
+	Headers       map[string][]string
+	Cookies       map[string][]string
 }
 
-func SetContext(ctx context.Context, r *http.Request, data ContextData) context.Context {
+func SetContext(ctx context.Context, data ContextData) context.Context {
 	if data.RemoteAddress != nil && config.IsIPBypassed(*data.RemoteAddress) {
 		return context.WithValue(ctx, bypassedCtxKey, true)
 	}
 
 	route := data.Route
 	if route == "" {
-		route = r.URL.Path // Use path from URL as default.
+		route = data.Path // Use path as default.
 	}
 
 	// Trim the trailing slashes from route to normalise for matching with API
@@ -45,15 +49,15 @@ func SetContext(ctx context.Context, r *http.Request, data ContextData) context.
 	}
 
 	c := &Context{
-		URL:                fullURL(r),
-		Path:               r.URL.Path, // Path without the query params
-		Method:             r.Method,
-		Query:              r.URL.Query(),
-		Headers:            headersToMap(r.Header),
+		URL:                data.URL,
+		Path:               data.Path,
+		Method:             data.Method,
+		Query:              data.Query,
+		Headers:            data.Headers,
 		RouteParams:        routeParams,
 		RemoteAddress:      data.RemoteAddress,
 		Body:               data.Body,
-		Cookies:            cookiesToMap(r.Cookies()),
+		Cookies:            data.Cookies,
 		Source:             data.Source,
 		Route:              route,
 		executedMiddleware: false, // We start with no middleware executed.
@@ -99,31 +103,4 @@ func EnsureContextPropagated(ctx context.Context) context.Context {
 		return context.WithValue(ctx, bypassedCtxKey, true)
 	}
 	return ctx
-}
-
-func headersToMap(headers http.Header) map[string][]string {
-	headerInfo := make(map[string][]string)
-	for key, values := range headers {
-		if strings.ToLower(key) == "cookie" {
-			continue // Ignore cookie header, because we already extract below.
-		}
-		headerInfo[strings.ToLower(key)] = values
-	}
-	return headerInfo
-}
-
-func cookiesToMap(cookies []*http.Cookie) map[string][]string {
-	cookieInfo := make(map[string][]string)
-	for _, cookie := range cookies {
-		cookieInfo[cookie.Name] = append(cookieInfo[cookie.Name], cookie.Value)
-	}
-	return cookieInfo
-}
-
-func fullURL(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	return fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL.RequestURI())
 }

--- a/internal/request/http_context_test.go
+++ b/internal/request/http_context_test.go
@@ -2,10 +2,6 @@ package request
 
 import (
 	"context"
-	"crypto/tls"
-	"net/http"
-	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
@@ -43,7 +39,7 @@ func TestSetContext(t *testing.T) {
 			source:        "echo",
 			remoteAddress: stringPtr("127.0.0.1"),
 			body:          "test body",
-			expectedRoute: "/test/path", // Will be set from request URL
+			expectedRoute: "/test/path", // Will be set from path
 		},
 		{
 			name:          "nil remote address",
@@ -63,7 +59,7 @@ func TestSetContext(t *testing.T) {
 				"user": "1234",
 				"role": "test",
 			},
-			expectedRoute: "/test/path", // Will be set from request URL
+			expectedRoute: "/test/path",
 		},
 		{
 			name:          "trim trailing slash",
@@ -81,89 +77,49 @@ func TestSetContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a mock HTTP request
-			req, err := http.NewRequest("POST", "http://example.com/test/path?param=value", strings.NewReader("test body"))
-			if err != nil {
-				t.Fatalf("Failed to create request: %v", err)
-			}
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("User-Agent", "test-agent")
-			req.AddCookie(&http.Cookie{Name: "session", Value: "abc123"})
-
-			// Set context
 			ctx := context.Background()
-			resultCtx := SetContext(ctx, req, ContextData{
+			resultCtx := SetContext(ctx, ContextData{
 				Source:        tt.source,
 				Route:         tt.route,
 				RouteParams:   tt.routeParams,
 				RemoteAddress: tt.remoteAddress,
 				Body:          tt.body,
+				URL:           "http://example.com/test/path?param=value",
+				Path:          "/test/path",
+				Method:        "POST",
+				Query:         map[string][]string{"param": {"value"}},
+				Headers:       map[string][]string{"content-type": {"application/json"}, "user-agent": {"test-agent"}},
+				Cookies:       map[string][]string{"session": {"abc123"}},
 			})
 
-			// Get context back
 			reqCtx := GetContext(resultCtx)
 			assert.NotNil(t, reqCtx, "GetContext should not return nil")
 
-			// Light assertions - focus on ensuring context is correctly set
 			assert.Equal(t, tt.source, reqCtx.Source)
 
 			if tt.route == "" {
-				// When route is empty, it should use the request URL path
 				assert.Equal(t, "/test/path", reqCtx.Route)
 			} else {
 				assert.Equal(t, tt.expectedRoute, reqCtx.Route)
 			}
 
-			// Path should come from the URL
 			assert.Equal(t, "/test/path", reqCtx.Path)
 
 			assert.Equal(t, tt.routeParams, reqCtx.RouteParams)
 
-			// Verify basic request data is captured
 			assert.NotEmpty(t, reqCtx.URL, "URL should not be empty")
 			assert.NotNil(t, reqCtx.Method, "Method should not be nil")
 			assert.Equal(t, "POST", reqCtx.Method, "Method should be POST")
-			// Note: Body comparison removed as it can contain uncomparable types like maps
 			assert.Equal(t, tt.remoteAddress, reqCtx.RemoteAddress)
 		})
 	}
 }
 
-func TestCookiesToMap(t *testing.T) {
-	t.Run("single value per cookie name", func(t *testing.T) {
-		cookies := []*http.Cookie{
-			{Name: "session", Value: "abc"},
-			{Name: "token", Value: "xyz"},
-		}
-		result := cookiesToMap(cookies)
-		assert.Equal(t, map[string][]string{
-			"session": {"abc"},
-			"token":   {"xyz"},
-		}, result)
-	})
-
-	t.Run("multiple values for same cookie name are all kept", func(t *testing.T) {
-		cookies := []*http.Cookie{
-			{Name: "session", Value: "first"},
-			{Name: "session", Value: "second"},
-		}
-		result := cookiesToMap(cookies)
-		assert.Equal(t, map[string][]string{
-			"session": {"first", "second"},
-		}, result)
-	})
-}
-
 func TestSetContext_DuplicateCookies(t *testing.T) {
-	req, err := http.NewRequest("GET", "http://example.com/", http.NoBody)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-	// Manually set the Cookie header to include two values for the same name,
-	// since http.Request.AddCookie does not support duplicates via the API.
-	req.Header.Set("Cookie", "session=first; session=second")
-
-	resultCtx := SetContext(context.Background(), req, ContextData{Source: "test"})
+	resultCtx := SetContext(context.Background(), ContextData{
+		Source:  "test",
+		Cookies: map[string][]string{"session": {"first", "second"}},
+	})
 	reqCtx := GetContext(resultCtx)
 
 	assert.Equal(t, []string{"first", "second"}, reqCtx.Cookies["session"])
@@ -176,14 +132,9 @@ func TestSetContext_BypassedIP(t *testing.T) {
 		Block:       &block,
 	}, nil)
 
-	req, err := http.NewRequest("POST", "http://example.com/test/path?param=value", strings.NewReader("test body"))
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-
 	ctx := context.Background()
 	ip := "10.10.10.10"
-	setCtx := SetContext(ctx, req, ContextData{
+	setCtx := SetContext(ctx, ContextData{
 		RemoteAddress: &ip,
 	})
 
@@ -211,9 +162,8 @@ func TestIsBypassed(t *testing.T) {
 			Block:       &block,
 		}, nil)
 
-		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
 		ip := "10.10.10.10"
-		bypassedCtx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+		bypassedCtx := SetContext(context.Background(), ContextData{RemoteAddress: &ip})
 		require.True(t, IsBypassed(bypassedCtx))
 
 		var result bool
@@ -231,9 +181,8 @@ func TestIsBypassed(t *testing.T) {
 			Block:       &block,
 		}, nil)
 
-		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
 		ip := "10.10.10.10"
-		bypassedCtx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+		bypassedCtx := SetContext(context.Background(), ContextData{RemoteAddress: &ip})
 		require.True(t, IsBypassed(bypassedCtx))
 
 		var result bool
@@ -289,20 +238,17 @@ func TestEnsureContextPropagated(t *testing.T) {
 	})
 
 	t.Run("copies GLS data into context", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
 		ip := "1.2.3.4"
-		glsCtx := SetContext(context.Background(), req, ContextData{
+		glsCtx := SetContext(context.Background(), ContextData{
 			Source:        "test-source",
 			Route:         "/test",
 			RemoteAddress: &ip,
 		})
 
-		// Run inside GLS with the request context, but pass a bare context to EnsureContextPropagated
 		WrapWithGLS(glsCtx, func() {
 			bare := context.Background()
 			result := EnsureContextPropagated(bare)
 
-			// The returned context should contain request data (copied from GLS)
 			reqCtx := GetContext(result)
 			require.NotNil(t, reqCtx)
 			assert.Equal(t, "test-source", reqCtx.Source)
@@ -313,7 +259,6 @@ func TestEnsureContextPropagated(t *testing.T) {
 	t.Run("returns same context when no GLS and no request data", func(t *testing.T) {
 		ctx := context.Background()
 		result := EnsureContextPropagated(ctx)
-		// No GLS data and no request data in context — nothing to propagate
 		assert.Nil(t, GetContext(result), "should have no request context")
 	})
 
@@ -324,9 +269,8 @@ func TestEnsureContextPropagated(t *testing.T) {
 			Block:       &block,
 		}, nil)
 
-		req, _ := http.NewRequest("GET", "https://example.com/test", http.NoBody)
 		ip := "10.10.10.10"
-		bypassedCtx := SetContext(context.Background(), req, ContextData{RemoteAddress: &ip})
+		bypassedCtx := SetContext(context.Background(), ContextData{RemoteAddress: &ip})
 		require.True(t, IsBypassed(bypassedCtx))
 
 		WrapWithGLS(bypassedCtx, func() {
@@ -334,56 +278,4 @@ func TestEnsureContextPropagated(t *testing.T) {
 			assert.True(t, IsBypassed(result), "should propagate bypass flag from GLS into bare context")
 		})
 	})
-}
-
-func TestFullURL(t *testing.T) {
-	tests := []struct {
-		name     string
-		url      string
-		host     string
-		hasTLS   bool
-		expected string
-	}{
-		{
-			name:     "HTTP request",
-			url:      "http://example.com/path",
-			host:     "example.com",
-			hasTLS:   false,
-			expected: "http://example.com/path",
-		},
-		{
-			name:     "HTTPS request",
-			url:      "https://example.com/path",
-			host:     "example.com",
-			hasTLS:   true,
-			expected: "https://example.com/path",
-		},
-		{
-			name:     "HTTP with query",
-			url:      "http://example.com/path?param=value",
-			host:     "example.com",
-			hasTLS:   false,
-			expected: "http://example.com/path?param=value",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			parsedURL, err := url.Parse(tt.url)
-			assert.NoError(t, err)
-
-			req := &http.Request{
-				Method: "GET",
-				URL:    parsedURL,
-				Host:   tt.host,
-			}
-
-			if tt.hasTLS {
-				req.TLS = &tls.ConnectionState{}
-			}
-
-			result := fullURL(req)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/vulnerabilities/attack_test.go
+++ b/vulnerabilities/attack_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/cloud"
@@ -98,11 +99,17 @@ func TestGetAttackDetected(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/users", http.NoBody)
 	req.Header.Set("Content-Type", "application/json")
 
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/api/users",
 		RemoteAddress: &ip,
 		Body:          map[string]interface{}{"name": "test"},
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	result := interceptorResult{
@@ -165,10 +172,16 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("stores attack and error in context", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		result := &interceptorResult{
@@ -204,10 +217,16 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("does not store error when blocking is disabled", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		result := &interceptorResult{
@@ -273,10 +292,16 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		reportDeferredAttack(ctx)
@@ -304,10 +329,16 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		result := &interceptorResult{
@@ -434,10 +465,16 @@ func TestOnStoredSSRF(t *testing.T) {
 
 		ip := "1.2.3.4"
 		req := httptest.NewRequest("POST", "/api/stored_ssrf", http.NoBody)
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/api/stored_ssrf",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		err := OnStoredSSRF(ctx, "net/http", "net/http.Client.Do", "evil.com", "169.254.169.254")

--- a/vulnerabilities/attack_test.go
+++ b/vulnerabilities/attack_test.go
@@ -99,18 +99,12 @@ func TestGetAttackDetected(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/users", http.NoBody)
 	req.Header.Set("Content-Type", "application/json")
 
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/api/users",
-		RemoteAddress: &ip,
-		Body:          map[string]interface{}{"name": "test"},
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/api/users"
+	data.RemoteAddress = &ip
+	data.Body = map[string]interface{}{"name": "test"}
+	ctx := request.SetContext(context.Background(), data)
 
 	result := interceptorResult{
 		Kind:          KindSQLInjection,
@@ -172,17 +166,11 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("stores attack and error in context", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		result := &interceptorResult{
 			Kind:          KindPathTraversal,
@@ -217,17 +205,11 @@ func TestStoreDeferredAttack(t *testing.T) {
 	t.Run("does not store error when blocking is disabled", func(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		result := &interceptorResult{
 			Kind:          KindPathTraversal,
@@ -292,17 +274,11 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		reportDeferredAttack(ctx)
 
@@ -329,17 +305,11 @@ func TestReportDeferredAttack(t *testing.T) {
 
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("GET", "/test", http.NoBody)
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		result := &interceptorResult{
 			Kind:          KindPathTraversal,
@@ -465,17 +435,11 @@ func TestOnStoredSSRF(t *testing.T) {
 
 		ip := "1.2.3.4"
 		req := httptest.NewRequest("POST", "/api/stored_ssrf", http.NoBody)
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/api/stored_ssrf",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/api/stored_ssrf"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		err := OnStoredSSRF(ctx, "net/http", "net/http.Client.Do", "evil.com", "169.254.169.254")
 		assert.NoError(t, err)

--- a/vulnerabilities/scan_test.go
+++ b/vulnerabilities/scan_test.go
@@ -174,19 +174,13 @@ func TestScanWithOptions_AllSourcesChecked(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupReq()
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/test",
-				RemoteAddress: &ip,
-				RouteParams:   tt.routeParams,
-				Body:          tt.body,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/test"
+			data.RemoteAddress = &ip
+			data.RouteParams = tt.routeParams
+			data.Body = tt.body
+			ctx := request.SetContext(context.Background(), data)
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})
 			if tt.expectError {
@@ -219,19 +213,13 @@ func TestScanWithOptions_AllSourcesScannedWhenNoAttack(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test?queryParam=queryValue", http.NoBody)
 	req.Header.Set("X-Header", "headerValue")
 	req.AddCookie(&http.Cookie{Name: "cookie1", Value: "cookieValue"})
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		RouteParams:   map[string]string{"routeParam": "routeValue"},
-		Body:          map[string]any{"bodyField": "bodyValue"},
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	data.RouteParams = map[string]string{"routeParam": "routeValue"}
+	data.Body = map[string]any{"bodyField": "bodyValue"}
+	ctx := request.SetContext(context.Background(), data)
 
 	err := ScanWithOptions(ctx, "testOperation", trackingVuln, args, ScanOptions{})
 	assert.NoError(t, err)
@@ -275,18 +263,12 @@ func TestScanWithOptions_PathFallbackDetectsAttack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/api/execute/ls%3Bcat%20%2Fetc%2Fpasswd", http.NoBody)
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/api/execute/:cmd",
-				RemoteAddress: &ip,
-				RouteParams:   tt.routeParams,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/api/execute/:cmd"
+			data.RemoteAddress = &ip
+			data.RouteParams = tt.routeParams
+			ctx := request.SetContext(context.Background(), data)
 
 			err := ScanWithOptions(ctx, "testOperation", pathAttackVuln, args, ScanOptions{})
 			require.Error(t, err, "path fallback should scan extracted segments and detect attack")
@@ -320,18 +302,12 @@ func TestScanWithOptions_PathFallbackAlwaysScanned(t *testing.T) {
 			}
 
 			req := httptest.NewRequest("GET", "/api/users/user@example.com/posts", http.NoBody)
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/api/users/:user/posts",
-				RemoteAddress: &ip,
-				RouteParams:   tt.routeParams,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/api/users/:user/posts"
+			data.RemoteAddress = &ip
+			data.RouteParams = tt.routeParams
+			ctx := request.SetContext(context.Background(), data)
 
 			err := ScanWithOptions(ctx, "testOperation", trackingVuln, args, ScanOptions{})
 			assert.NoError(t, err)
@@ -449,19 +425,13 @@ func TestScanWithOptions_ForceProtectionOff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupReq()
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source: "test",
-				// Route:         tt.route,
-				RemoteAddress: &ip,
-				RouteParams:   tt.routeParams,
-				Body:          tt.body,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			// data.Route = tt.route,
+			data.RemoteAddress = &ip
+			data.RouteParams = tt.routeParams
+			data.Body = tt.body
+			ctx := request.SetContext(context.Background(), data)
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})
 			if tt.expectError {
@@ -491,17 +461,11 @@ func TestScanWithOptions_ModuleIsPassedThrough(t *testing.T) {
 	agent.SetCloudClient(client)
 
 	req := httptest.NewRequest("GET", "/test?q=attack", http.NoBody)
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	_ = ScanWithOptions(ctx, "testOp", mockVulnerability, args, ScanOptions{Module: "my-module"})
 
@@ -525,17 +489,11 @@ func TestScanWithOptions_DeferReportingReturnsNilWhenDeferredAttackExists(t *tes
 	defer config.SetBlocking(original)
 
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	reqCtx := request.GetContext(ctx)
 	reqCtx.SetDeferredAttack(&request.DeferredAttack{
@@ -561,17 +519,11 @@ func TestScanWithOptions_NonDeferredBlocksAndReportsExistingDeferredAttack(t *te
 	t.Cleanup(func() { agent.SetCloudClient(originalClient) })
 
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
-	ctx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/test",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/test"
+	data.RemoteAddress = &ip
+	ctx := request.SetContext(context.Background(), data)
 
 	blockErr := &AttackDetectedError{Kind: KindSQLInjection, Operation: "testOp"}
 	reqCtx := request.GetContext(ctx)
@@ -650,17 +602,11 @@ func TestScan_ShouldProtect(t *testing.T) {
 			config.SetZenLoaded(tt.zenLoaded)
 
 			req := httptest.NewRequest("GET", "/test?param1=attack&param2=safe", http.NoBody)
-			ctx := request.SetContext(context.Background(), request.ContextData{
-				Source:        "test",
-				Route:         "/test",
-				RemoteAddress: &ip,
-				URL:           zenhttp.FullURL(req),
-				Path:          req.URL.Path,
-				Method:        req.Method,
-				Query:         req.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(req.Header),
-				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(req)
+			data.Source = "test"
+			data.Route = "/test"
+			data.RemoteAddress = &ip
+			ctx := request.SetContext(context.Background(), data)
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})
 			if tt.expectError {

--- a/vulnerabilities/scan_test.go
+++ b/vulnerabilities/scan_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
@@ -173,12 +174,18 @@ func TestScanWithOptions_AllSourcesChecked(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupReq()
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/test",
 				RemoteAddress: &ip,
 				RouteParams:   tt.routeParams,
 				Body:          tt.body,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})
@@ -212,12 +219,18 @@ func TestScanWithOptions_AllSourcesScannedWhenNoAttack(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test?queryParam=queryValue", http.NoBody)
 	req.Header.Set("X-Header", "headerValue")
 	req.AddCookie(&http.Cookie{Name: "cookie1", Value: "cookieValue"})
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
 		RouteParams:   map[string]string{"routeParam": "routeValue"},
 		Body:          map[string]any{"bodyField": "bodyValue"},
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	err := ScanWithOptions(ctx, "testOperation", trackingVuln, args, ScanOptions{})
@@ -262,11 +275,17 @@ func TestScanWithOptions_PathFallbackDetectsAttack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest("GET", "/api/execute/ls%3Bcat%20%2Fetc%2Fpasswd", http.NoBody)
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/api/execute/:cmd",
 				RemoteAddress: &ip,
 				RouteParams:   tt.routeParams,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			err := ScanWithOptions(ctx, "testOperation", pathAttackVuln, args, ScanOptions{})
@@ -301,11 +320,17 @@ func TestScanWithOptions_PathFallbackAlwaysScanned(t *testing.T) {
 			}
 
 			req := httptest.NewRequest("GET", "/api/users/user@example.com/posts", http.NoBody)
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/api/users/:user/posts",
 				RemoteAddress: &ip,
 				RouteParams:   tt.routeParams,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			err := ScanWithOptions(ctx, "testOperation", trackingVuln, args, ScanOptions{})
@@ -424,12 +449,18 @@ func TestScanWithOptions_ForceProtectionOff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := tt.setupReq()
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source: "test",
 				// Route:         tt.route,
 				RemoteAddress: &ip,
 				RouteParams:   tt.routeParams,
 				Body:          tt.body,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})
@@ -460,10 +491,16 @@ func TestScanWithOptions_ModuleIsPassedThrough(t *testing.T) {
 	agent.SetCloudClient(client)
 
 	req := httptest.NewRequest("GET", "/test?q=attack", http.NoBody)
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	_ = ScanWithOptions(ctx, "testOp", mockVulnerability, args, ScanOptions{Module: "my-module"})
@@ -488,10 +525,16 @@ func TestScanWithOptions_DeferReportingReturnsNilWhenDeferredAttackExists(t *tes
 	defer config.SetBlocking(original)
 
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	reqCtx := request.GetContext(ctx)
@@ -518,10 +561,16 @@ func TestScanWithOptions_NonDeferredBlocksAndReportsExistingDeferredAttack(t *te
 	t.Cleanup(func() { agent.SetCloudClient(originalClient) })
 
 	req := httptest.NewRequest("GET", "/test", http.NoBody)
-	ctx := request.SetContext(context.Background(), req, request.ContextData{
+	ctx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/test",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	blockErr := &AttackDetectedError{Kind: KindSQLInjection, Operation: "testOp"}
@@ -601,10 +650,16 @@ func TestScan_ShouldProtect(t *testing.T) {
 			config.SetZenLoaded(tt.zenLoaded)
 
 			req := httptest.NewRequest("GET", "/test?param1=attack&param2=safe", http.NoBody)
-			ctx := request.SetContext(context.Background(), req, request.ContextData{
+			ctx := request.SetContext(context.Background(), request.ContextData{
 				Source:        "test",
 				Route:         "/test",
 				RemoteAddress: &ip,
+				URL:           zenhttp.FullURL(req),
+				Path:          req.URL.Path,
+				Method:        req.Method,
+				Query:         req.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(req.Header),
+				Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 			})
 
 			err := ScanWithOptions(ctx, "testOperation", mockVulnerability, args, ScanOptions{})

--- a/zen/disabled_test.go
+++ b/zen/disabled_test.go
@@ -23,17 +23,11 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("SetUser no-ops when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		resultCtx, err := SetUser(ctx, "user123", "John Doe")
 
@@ -50,17 +44,11 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("SetRateLimitGroup no-ops when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		resultCtx, err := SetRateLimitGroup(ctx, "group123")
 
@@ -77,17 +65,11 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("ShouldBlockRequest returns nil when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		result := ShouldBlockRequest(ctx)
 

--- a/zen/disabled_test.go
+++ b/zen/disabled_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/stretchr/testify/require"
 )
@@ -22,10 +23,16 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("SetUser no-ops when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		resultCtx, err := SetUser(ctx, "user123", "John Doe")
@@ -43,10 +50,16 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("SetRateLimitGroup no-ops when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		resultCtx, err := SetRateLimitGroup(ctx, "group123")
@@ -64,10 +77,16 @@ func TestDisabledAPI(t *testing.T) {
 	t.Run("ShouldBlockRequest returns nil when disabled", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "http://example.com/test", nil)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		result := ShouldBlockRequest(ctx)

--- a/zen/set_rate_limit_group_test.go
+++ b/zen/set_rate_limit_group_test.go
@@ -19,17 +19,11 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Execute
 		resultCtx, err := zen.SetRateLimitGroup(ctx, "group123")
@@ -49,17 +43,11 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Execute
 		resultCtx, err := zen.SetRateLimitGroup(ctx, "")
@@ -94,17 +82,11 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Mark middleware as executed
 		reqCtx := request.GetContext(ctx)

--- a/zen/set_rate_limit_group_test.go
+++ b/zen/set_rate_limit_group_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/stretchr/testify/assert"
@@ -18,10 +19,16 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Execute
@@ -42,10 +49,16 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Execute
@@ -81,10 +94,16 @@ func TestSetRateLimitGroup(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Mark middleware as executed

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -20,17 +20,11 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Execute
 		resultCtx, err := zen.SetUser(ctx, "user123", "John Doe")
@@ -51,17 +45,11 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Execute
 		resultCtx, err := zen.SetUser(ctx, "", "John Doe")
@@ -81,17 +69,11 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Execute
 		resultCtx, err := zen.SetUser(ctx, "user123", "")
@@ -126,17 +108,11 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &remoteAddr,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &remoteAddr
+		ctx := request.SetContext(context.Background(), data)
 
 		// Mark middleware as executed
 		reqCtx := request.GetContext(ctx)
@@ -159,17 +135,11 @@ func TestSetUser(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("POST", "/api/users", http.NoBody)
 		req.Header.Set("Content-Type", "application/json")
-		ctx := request.SetContext(context.Background(), request.ContextData{
-			Source:        "test",
-			Route:         "/test",
-			RemoteAddress: &ip,
-			URL:           zenhttp.FullURL(req),
-			Path:          req.URL.Path,
-			Method:        req.Method,
-			Query:         req.URL.Query(),
-			Headers:       zenhttp.HeadersToMap(req.Header),
-			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-		})
+		data := zenhttp.ContextDataFromRequest(req)
+		data.Source = "test"
+		data.Route = "/test"
+		data.RemoteAddress = &ip
+		ctx := request.SetContext(context.Background(), data)
 
 		userID := "user-123"
 		userName := "John Doe"

--- a/zen/set_user_test.go
+++ b/zen/set_user_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/stretchr/testify/assert"
@@ -19,10 +20,16 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Execute
@@ -44,10 +51,16 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Execute
@@ -68,10 +81,16 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Execute
@@ -107,10 +126,16 @@ func TestSetUser(t *testing.T) {
 		// Setup
 		req, _ := http.NewRequest("GET", "http://example.com/test", http.NoBody)
 		remoteAddr := "127.0.0.1"
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &remoteAddr,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		// Mark middleware as executed
@@ -134,10 +159,16 @@ func TestSetUser(t *testing.T) {
 		ip := "127.0.0.1"
 		req := httptest.NewRequest("POST", "/api/users", http.NoBody)
 		req.Header.Set("Content-Type", "application/json")
-		ctx := request.SetContext(context.Background(), req, request.ContextData{
+		ctx := request.SetContext(context.Background(), request.ContextData{
 			Source:        "test",
 			Route:         "/test",
 			RemoteAddress: &ip,
+			URL:           zenhttp.FullURL(req),
+			Path:          req.URL.Path,
+			Method:        req.Method,
+			Query:         req.URL.Query(),
+			Headers:       zenhttp.HeadersToMap(req.Header),
+			Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 		})
 
 		userID := "user-123"

--- a/zen/should_block_request_test.go
+++ b/zen/should_block_request_test.go
@@ -69,17 +69,11 @@ func createRequestContext(t *testing.T, method, route, ip string, userID, userNa
 func createRequestContextWithGroup(t *testing.T, method, route, ip string, userID, userName, groupID string) context.Context {
 	t.Helper()
 	req := httptest.NewRequest(method, route, http.NoBody)
-	reqCtx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         route,
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = route
+	data.RemoteAddress = &ip
+	reqCtx := request.SetContext(context.Background(), data)
 	if userID != "" {
 		_, err := zen.SetUser(reqCtx, userID, userName)
 		require.NoError(t, err)
@@ -102,17 +96,11 @@ func TestShouldBlockRequest(t *testing.T) {
 func TestShouldBlockRequest_MiddlewareAlreadyExecuted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/route", http.NoBody)
 	ip := "127.0.0.1"
-	reqCtx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	reqCtx := request.SetContext(context.Background(), data)
 
 	// First call: marks middleware as executed and returns nil (no block).
 	result1 := zen.ShouldBlockRequest(reqCtx)
@@ -126,17 +114,11 @@ func TestShouldBlockRequest_MiddlewareAlreadyExecuted(t *testing.T) {
 func TestShouldBlockRequest_BlockedUser(t *testing.T) {
 	req := httptest.NewRequest("GET", "/route", http.NoBody)
 	ip := "127.0.0.1"
-	reqCtx := request.SetContext(context.Background(), request.ContextData{
-		Source:        "test",
-		Route:         "/route",
-		RemoteAddress: &ip,
-		URL:           zenhttp.FullURL(req),
-		Path:          req.URL.Path,
-		Method:        req.Method,
-		Query:         req.URL.Query(),
-		Headers:       zenhttp.HeadersToMap(req.Header),
-		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
-	})
+	data := zenhttp.ContextDataFromRequest(req)
+	data.Source = "test"
+	data.Route = "/route"
+	data.RemoteAddress = &ip
+	reqCtx := request.SetContext(context.Background(), data)
 
 	_, err := zen.SetUser(reqCtx, "banned", "Banned User")
 	require.NoError(t, err)
@@ -234,17 +216,11 @@ func ExampleShouldBlockRequest() {
 			// Set up proper request context
 			ctx := context.Background()
 			remoteAddr := "127.0.0.1"
-			ctx = request.SetContext(ctx, request.ContextData{
-				Source:        "test",
-				Route:         "/test",
-				RemoteAddress: &remoteAddr,
-				URL:           zenhttp.FullURL(r),
-				Path:          r.URL.Path,
-				Method:        r.Method,
-				Query:         r.URL.Query(),
-				Headers:       zenhttp.HeadersToMap(r.Header),
-				Cookies:       zenhttp.CookiesToMap(r.Cookies()),
-			})
+			data := zenhttp.ContextDataFromRequest(r)
+			data.Source = "test"
+			data.Route = "/test"
+			data.RemoteAddress = &remoteAddr
+			ctx = request.SetContext(ctx, data)
 
 			// Set user in context
 			ctx, err = zen.SetUser(ctx, "user123", "John Doe")

--- a/zen/should_block_request_test.go
+++ b/zen/should_block_request_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	zenhttp "github.com/AikidoSec/firewall-go/instrumentation/http"
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/config"
 	"github.com/AikidoSec/firewall-go/internal/agent/ratelimiting"
@@ -68,10 +69,16 @@ func createRequestContext(t *testing.T, method, route, ip string, userID, userNa
 func createRequestContextWithGroup(t *testing.T, method, route, ip string, userID, userName, groupID string) context.Context {
 	t.Helper()
 	req := httptest.NewRequest(method, route, http.NoBody)
-	reqCtx := request.SetContext(context.Background(), req, request.ContextData{
+	reqCtx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         route,
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 	if userID != "" {
 		_, err := zen.SetUser(reqCtx, userID, userName)
@@ -95,10 +102,16 @@ func TestShouldBlockRequest(t *testing.T) {
 func TestShouldBlockRequest_MiddlewareAlreadyExecuted(t *testing.T) {
 	req := httptest.NewRequest("GET", "/route", http.NoBody)
 	ip := "127.0.0.1"
-	reqCtx := request.SetContext(context.Background(), req, request.ContextData{
+	reqCtx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	// First call: marks middleware as executed and returns nil (no block).
@@ -113,10 +126,16 @@ func TestShouldBlockRequest_MiddlewareAlreadyExecuted(t *testing.T) {
 func TestShouldBlockRequest_BlockedUser(t *testing.T) {
 	req := httptest.NewRequest("GET", "/route", http.NoBody)
 	ip := "127.0.0.1"
-	reqCtx := request.SetContext(context.Background(), req, request.ContextData{
+	reqCtx := request.SetContext(context.Background(), request.ContextData{
 		Source:        "test",
 		Route:         "/route",
 		RemoteAddress: &ip,
+		URL:           zenhttp.FullURL(req),
+		Path:          req.URL.Path,
+		Method:        req.Method,
+		Query:         req.URL.Query(),
+		Headers:       zenhttp.HeadersToMap(req.Header),
+		Cookies:       zenhttp.CookiesToMap(req.Cookies()),
 	})
 
 	_, err := zen.SetUser(reqCtx, "banned", "Banned User")
@@ -215,10 +234,16 @@ func ExampleShouldBlockRequest() {
 			// Set up proper request context
 			ctx := context.Background()
 			remoteAddr := "127.0.0.1"
-			ctx = request.SetContext(ctx, r, request.ContextData{
+			ctx = request.SetContext(ctx, request.ContextData{
 				Source:        "test",
 				Route:         "/test",
 				RemoteAddress: &remoteAddr,
+				URL:           zenhttp.FullURL(r),
+				Path:          r.URL.Path,
+				Method:        r.Method,
+				Query:         r.URL.Query(),
+				Headers:       zenhttp.HeadersToMap(r.Header),
+				Cookies:       zenhttp.CookiesToMap(r.Cookies()),
 			})
 
 			// Set user in context


### PR DESCRIPTION
Split from #537 

To be able to support frameworks that don't use `net/http`, we need to decouple our request context from it. Now passing data directly instead of processing within the request context.