### PR TITLE
Fix polling panics on multiple stop and less than 0 intervals

### DIFF
--- a/internal/polling/routine.go
+++ b/internal/polling/routine.go
@@ -1,6 +1,7 @@
 package polling
 
 import (
+	"context"
 	"sync"
 	"time"
 )
@@ -8,11 +9,10 @@ import (
 const minInterval = time.Millisecond
 
 type Routine struct {
-	ticker   *time.Ticker
-	stopChan chan struct{}
-	wg       sync.WaitGroup
-	mu       sync.Mutex
-	stopOnce sync.Once
+	ticker *time.Ticker
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	mu     sync.Mutex
 }
 
 func Start(interval time.Duration, fn func()) *Routine {
@@ -20,9 +20,11 @@ func Start(interval time.Duration, fn func()) *Routine {
 		interval = minInterval
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	r := &Routine{
-		ticker:   time.NewTicker(interval),
-		stopChan: make(chan struct{}),
+		ticker: time.NewTicker(interval),
+		cancel: cancel,
 	}
 
 	r.wg.Add(1)
@@ -33,7 +35,7 @@ func Start(interval time.Duration, fn func()) *Routine {
 			select {
 			case <-r.ticker.C:
 				fn()
-			case <-r.stopChan:
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -42,11 +44,10 @@ func Start(interval time.Duration, fn func()) *Routine {
 	return r
 }
 
-// Stop stops the polling routine and waits for the goroutine to complete
+// Stop stops the polling routine and waits for the goroutine to complete.
+// Safe to call multiple times and from multiple goroutines.
 func (r *Routine) Stop() {
-	r.stopOnce.Do(func() {
-		close(r.stopChan)
-	})
+	r.cancel()
 	r.wg.Wait()
 }
 

--- a/internal/polling/routine.go
+++ b/internal/polling/routine.go
@@ -10,6 +10,7 @@ type Routine struct {
 	stopChan chan struct{}
 	wg       sync.WaitGroup
 	mu       sync.Mutex
+	stopOnce sync.Once
 }
 
 func Start(interval time.Duration, fn func()) *Routine {
@@ -37,7 +38,9 @@ func Start(interval time.Duration, fn func()) *Routine {
 
 // Stop stops the polling routine and waits for the goroutine to complete
 func (r *Routine) Stop() {
-	close(r.stopChan)
+	r.stopOnce.Do(func() {
+		close(r.stopChan)
+	})
 	r.wg.Wait()
 }
 

--- a/internal/polling/routine.go
+++ b/internal/polling/routine.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const minInterval = time.Millisecond
+
 type Routine struct {
 	ticker   *time.Ticker
 	stopChan chan struct{}
@@ -14,6 +16,10 @@ type Routine struct {
 }
 
 func Start(interval time.Duration, fn func()) *Routine {
+	if interval <= 0 {
+		interval = minInterval
+	}
+
 	r := &Routine{
 		ticker:   time.NewTicker(interval),
 		stopChan: make(chan struct{}),
@@ -46,6 +52,10 @@ func (r *Routine) Stop() {
 
 // Reset resets the interval of the polling routine
 func (r *Routine) Reset(interval time.Duration) {
+	if interval <= 0 {
+		interval = minInterval
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.ticker.Reset(interval)

--- a/internal/polling/routine_test.go
+++ b/internal/polling/routine_test.go
@@ -1,6 +1,7 @@
 package polling
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -56,4 +57,31 @@ func TestReset(t *testing.T) {
 
 	finalCount := atomic.LoadInt64(&callCount)
 	assert.Greater(t, finalCount, int64(1), "Should have fired multiple times after reset")
+}
+
+func TestStopCalledTwice(t *testing.T) {
+	r := Start(5*time.Millisecond, func() {})
+	time.Sleep(10 * time.Millisecond)
+
+	assert.NotPanics(t, func() {
+		r.Stop()
+		r.Stop()
+	})
+}
+
+func TestStopCalledConcurrently(t *testing.T) {
+	r := Start(5*time.Millisecond, func() {})
+	time.Sleep(10 * time.Millisecond)
+
+	assert.NotPanics(t, func() {
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				r.Stop()
+			}()
+		}
+		wg.Wait()
+	})
 }

--- a/internal/polling/routine_test.go
+++ b/internal/polling/routine_test.go
@@ -69,6 +69,29 @@ func TestStopCalledTwice(t *testing.T) {
 	})
 }
 
+func TestStartWithNonPositiveInterval(t *testing.T) {
+	assert.NotPanics(t, func() {
+		Start(0, func() {}).Stop()
+	})
+
+	assert.NotPanics(t, func() {
+		Start(-1*time.Millisecond, func() {}).Stop()
+	})
+}
+
+func TestResetWithNonPositiveInterval(t *testing.T) {
+	r := Start(10*time.Millisecond, func() {})
+	defer r.Stop()
+
+	assert.NotPanics(t, func() {
+		r.Reset(0)
+	})
+
+	assert.NotPanics(t, func() {
+		r.Reset(-1 * time.Millisecond)
+	})
+}
+
 func TestStopCalledConcurrently(t *testing.T) {
 	r := Start(5*time.Millisecond, func() {})
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
Probably more defensive than necessary, but better to reduce chance of panics.