### PR TITLE
Add context to sending cloud requests

### DIFF
--- a/instrumentation/http/on_post_request_test.go
+++ b/instrumentation/http/on_post_request_test.go
@@ -80,7 +80,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/instrumentation/sinks/database/sql/instrumentation_test.go
+++ b/instrumentation/sinks/database/sql/instrumentation_test.go
@@ -784,7 +784,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
+++ b/instrumentation/sinks/jackc/pgx.v5/instrumentation_test.go
@@ -496,7 +496,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/instrumentation/sinks/os/integration_test.go
+++ b/instrumentation/sinks/os/integration_test.go
@@ -35,7 +35,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/instrumentation/sinks/path/filepath/integration_test.go
+++ b/instrumentation/sinks/path/filepath/integration_test.go
@@ -38,7 +38,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/instrumentation/sinks/path/integration_test.go
+++ b/instrumentation/sinks/path/integration_test.go
@@ -38,7 +38,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -39,7 +39,7 @@ var (
 
 type CloudClient interface {
 	SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error)
-	SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error)
+	SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error)
 	FetchConfigUpdatedAt() time.Time
 	FetchConfig() (*aikido_types.CloudConfigData, error)
 	FetchListsConfig() (*aikido_types.ListsConfigData, error)

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -258,7 +258,7 @@ func (m *internalMockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*ai
 	return nil, nil
 }
 
-func (m *internalMockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *internalMockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	return nil, nil
 }
 func (m *internalMockCloudClient) FetchConfigUpdatedAt() time.Time { return time.Time{} }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -18,7 +18,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 

--- a/internal/agent/cloud/config.go
+++ b/internal/agent/cloud/config.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"time"
@@ -22,7 +23,7 @@ var ErrParsingConfig = errors.New("failed to parse cloud config")
 
 // FetchConfigUpdatedAt returns the time at which the cloud config was last updated
 func (c *Client) FetchConfigUpdatedAt() time.Time {
-	response, err := c.sendCloudRequest(c.realtimeEndpoint, configUpdatedAtAPIRoute, configUpdatedAtMethod, nil)
+	response, err := c.sendCloudRequest(context.Background(), c.realtimeEndpoint, configUpdatedAtAPIRoute, configUpdatedAtMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending polling config request: ", err)
 		return time.Time{}
@@ -38,7 +39,7 @@ func (c *Client) FetchConfigUpdatedAt() time.Time {
 }
 
 func (c *Client) FetchConfig() (*aikido_types.CloudConfigData, error) {
-	configResponse, err := c.sendCloudRequest(c.apiEndpoint, configAPIRoute, configAPIMethod, nil)
+	configResponse, err := c.sendCloudRequest(context.Background(), c.apiEndpoint, configAPIRoute, configAPIMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending config request: ", err)
 		return nil, err
@@ -59,7 +60,7 @@ func parseCloudConfigResponse(resp []byte) (*aikido_types.CloudConfigData, error
 
 // FetchListsConfig fetches firewall blocklists to keep local security rules synchronized with cloud configuration.
 func (c *Client) FetchListsConfig() (*aikido_types.ListsConfigData, error) {
-	response, err := c.sendCloudRequest(c.apiEndpoint, listsAPIRoute, listsAPIMethod, nil)
+	response, err := c.sendCloudRequest(context.Background(), c.apiEndpoint, listsAPIRoute, listsAPIMethod, nil)
 	if err != nil {
 		logCloudRequestError("Error in sending lists request: ", err)
 		return nil, err

--- a/internal/agent/cloud/event.go
+++ b/internal/agent/cloud/event.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -43,7 +44,7 @@ type PlatformInfo struct {
 	Version string `json:"version"`
 }
 
-func (c *Client) sendCloudRequest(endpoint string, route string, method string, payload any) ([]byte, error) {
+func (c *Client) sendCloudRequest(ctx context.Context, endpoint string, route string, method string, payload any) ([]byte, error) {
 	if c.token == "" {
 		return nil, ErrNoTokenSet
 	}
@@ -66,7 +67,7 @@ func (c *Client) sendCloudRequest(endpoint string, route string, method string, 
 	}
 
 	log.Debug("Sending request", slog.String("method", method), slog.String("endpoint", apiEndpoint))
-	req, err = http.NewRequest(method, apiEndpoint, body)
+	req, err = http.NewRequestWithContext(ctx, method, apiEndpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}

--- a/internal/agent/cloud/event_detected_attack.go
+++ b/internal/agent/cloud/event_detected_attack.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 )
@@ -25,7 +27,7 @@ func (c *Client) SendAttackDetectedEvent(agentInfo AgentInfo, request aikido_typ
 		Time:    utils.GetTime(),
 	}
 
-	_, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, detectedAttackEvent)
+	_, err := c.sendCloudRequest(context.Background(), c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, detectedAttackEvent)
 	if err != nil {
 		logCloudRequestError("Error in sending detected attack event: ", err)
 		return

--- a/internal/agent/cloud/event_detected_attack_wave.go
+++ b/internal/agent/cloud/event_detected_attack_wave.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
 )
@@ -33,7 +35,7 @@ func (c *Client) SendAttackWaveDetectedEvent(agentInfo AgentInfo, request Attack
 		Time:    utils.GetTime(),
 	}
 
-	_, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, detectedAttackWaveEvent)
+	_, err := c.sendCloudRequest(context.Background(), c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, detectedAttackWaveEvent)
 	if err != nil {
 		logCloudRequestError("Error in sending detected attack wave event: ", err)
 		return

--- a/internal/agent/cloud/event_heartbeat.go
+++ b/internal/agent/cloud/event_heartbeat.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/state/stats"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
@@ -26,7 +28,7 @@ type HeartbeatData struct {
 }
 
 // SendHeartbeatEvent sends a heartbeat to the cloud and returns the latest configuration.
-func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (c *Client) SendHeartbeatEvent(ctx context.Context, agentInfo AgentInfo, data HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	heartbeatEvent := HeartbeatEvent{
 		Type:                "heartbeat",
 		Agent:               agentInfo,
@@ -38,7 +40,7 @@ func (c *Client) SendHeartbeatEvent(agentInfo AgentInfo, data HeartbeatData) (*a
 		MiddlewareInstalled: data.MiddlewareInstalled,
 	}
 
-	response, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, heartbeatEvent)
+	response, err := c.sendCloudRequest(ctx, c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, heartbeatEvent)
 	if err != nil {
 		logCloudRequestError("Error in sending heartbeat event: ", err)
 		return nil, err

--- a/internal/agent/cloud/event_started.go
+++ b/internal/agent/cloud/event_started.go
@@ -1,6 +1,8 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/AikidoSec/firewall-go/internal/agent/aikido_types"
 	"github.com/AikidoSec/firewall-go/internal/agent/packages"
 	"github.com/AikidoSec/firewall-go/internal/agent/utils"
@@ -21,7 +23,7 @@ func (c *Client) SendStartEvent(agentInfo AgentInfo) (*aikido_types.CloudConfigD
 		Packages: packages.Get(),
 	}
 
-	response, err := c.sendCloudRequest(c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, startedEvent)
+	response, err := c.sendCloudRequest(context.Background(), c.apiEndpoint, eventsAPIRoute, eventsAPIMethod, startedEvent)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/cloud/event_test.go
+++ b/internal/agent/cloud/event_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -58,7 +59,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 					token:      "test-token",
 				}
 
-				result, err := client.sendCloudRequest(server.URL, "/api/test", tt.method, tt.payload)
+				result, err := client.sendCloudRequest(context.Background(), server.URL, "/api/test", tt.method, tt.payload)
 
 				require.NoError(t, err)
 				assert.JSONEq(t, string(responseBody), string(result))
@@ -103,7 +104,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 					token:      tt.token,
 				}
 
-				result, err := client.sendCloudRequest(tt.endpoint, tt.route, "POST", tt.payload)
+				result, err := client.sendCloudRequest(context.Background(), tt.endpoint, tt.route, "POST", tt.payload)
 
 				assert.Nil(t, result)
 				require.Error(t, err)
@@ -155,7 +156,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 					token:      "test-token",
 				}
 
-				result, err := client.sendCloudRequest(server.URL, "/api/test", "POST", nil)
+				result, err := client.sendCloudRequest(context.Background(), server.URL, "/api/test", "POST", nil)
 
 				assert.Nil(t, result)
 				require.Error(t, err)
@@ -177,7 +178,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 				token:      "test-token",
 			}
 
-			result, err := client.sendCloudRequest(serverURL, "/api/test", "POST", nil)
+			result, err := client.sendCloudRequest(context.Background(), serverURL, "/api/test", "POST", nil)
 
 			assert.Nil(t, result)
 			require.Error(t, err)
@@ -219,7 +220,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 					token:      tt.token,
 				}
 
-				_, err := client.sendCloudRequest(server.URL, "/api/test", "POST", nil)
+				_, err := client.sendCloudRequest(context.Background(), server.URL, "/api/test", "POST", nil)
 
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedToken, capturedToken)
@@ -242,7 +243,7 @@ func TestClient_sendCloudRequest(t *testing.T) {
 			token:      "test-token",
 		}
 
-		_, err := client.sendCloudRequest(server.URL, "/api/runtime/events", "POST", nil)
+		_, err := client.sendCloudRequest(context.Background(), server.URL, "/api/runtime/events", "POST", nil)
 
 		require.NoError(t, err)
 		assert.Equal(t, "/api/runtime/events", capturedPath)

--- a/internal/agent/cloud_config_test.go
+++ b/internal/agent/cloud_config_test.go
@@ -20,7 +20,7 @@ type configTestCloudClient struct {
 func (m *configTestCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error) {
 	return nil, nil
 }
-func (m *configTestCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *configTestCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	return nil, nil
 }
 func (m *configTestCloudClient) FetchConfigUpdatedAt() time.Time { return time.Time{} }

--- a/internal/agent/updating.go
+++ b/internal/agent/updating.go
@@ -162,7 +162,7 @@ func sendHeartbeatEvent() {
 		return
 	}
 
-	cloudConfig, err := client.SendHeartbeatEvent(getAgentInfo(),
+	cloudConfig, err := client.SendHeartbeatEvent(agentCtx, getAgentInfo(),
 		cloud.HeartbeatData{
 			Hostnames:           stateCollector.GetAndClearHostnames(),
 			Routes:              stateCollector.GetRoutesAndClear(),

--- a/internal/agent/updating_test.go
+++ b/internal/agent/updating_test.go
@@ -30,7 +30,7 @@ type updatingMockCloudClient struct {
 func (m *updatingMockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_types.CloudConfigData, error) {
 	return nil, nil
 }
-func (m *updatingMockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *updatingMockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	m.heartbeatCalled = true
 	return m.heartbeatResult, m.heartbeatErr
 }

--- a/internal/testutil/mock_cloud_client.go
+++ b/internal/testutil/mock_cloud_client.go
@@ -29,7 +29,7 @@ func (m *MockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	return nil, nil
 }
 
-func (m *MockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *MockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	return nil, nil
 }
 

--- a/vulnerabilities/attack_test.go
+++ b/vulnerabilities/attack_test.go
@@ -480,7 +480,7 @@ func (m *mockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*aikido_typ
 	panic("not implemented")
 }
 
-func (m *mockCloudClient) SendHeartbeatEvent(agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
+func (m *mockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
To be used for passing context from `zen.Shutdown`.