### PR TITLE
Pass shutdown context to send heartbeat

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -113,8 +113,8 @@ func isRealtimeEnabled(cloudConfig *aikido_types.CloudConfigData) bool {
 
 // AgentUninit flushes any stats collected since the last heartbeat to the
 // Aikido cloud and stops agent-lifetime background work.
-func AgentUninit() error {
-	sendHeartbeatEvent()
+func AgentUninit(ctx context.Context) error {
+	sendHeartbeatEvent(ctx)
 
 	agentCancel()
 	ratelimiting.Uninit()

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -229,11 +230,11 @@ func TestAgentUninit(t *testing.T) {
 			initAgentForTest(t)
 			resetAgentCtxForTest(t)
 
-			flushAborted := false
+			var flushAborted atomic.Bool
 			mock := &updatingMockCloudClient{
 				heartbeatFn: func(ctx context.Context) (*aikido_types.CloudConfigData, error) {
 					<-ctx.Done()
-					flushAborted = true
+					flushAborted.Store(true)
 					return nil, ctx.Err()
 				},
 			}
@@ -248,12 +249,12 @@ func TestAgentUninit(t *testing.T) {
 			go func() { done <- AgentUninit(ctx) }()
 
 			synctest.Wait()
-			assert.False(t, flushAborted, "flush should still be pending before the deadline")
+			assert.False(t, flushAborted.Load(), "flush should still be pending before the deadline")
 
 			time.Sleep(10 * time.Second)
 			synctest.Wait()
 
-			assert.True(t, flushAborted, "flush should abort once ctx's deadline passes")
+			assert.True(t, flushAborted.Load(), "flush should abort once ctx's deadline passes")
 			require.NoError(t, <-done, "shutdown should still complete cleanly after an aborted flush")
 		})
 	})

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -205,7 +205,7 @@ func TestAgentUninit(t *testing.T) {
 		SetCloudClient(mock)
 		t.Cleanup(func() { SetCloudClient(original) })
 
-		err := AgentUninit()
+		err := AgentUninit(context.Background())
 
 		require.NoError(t, err)
 		assert.True(t, mock.heartbeatCalled)
@@ -219,8 +219,42 @@ func TestAgentUninit(t *testing.T) {
 		t.Cleanup(func() { SetCloudClient(original) })
 
 		assert.NotPanics(t, func() {
-			err := AgentUninit()
+			err := AgentUninit(context.Background())
 			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("aborts the heartbeat flush without blocking once ctx expires", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			initAgentForTest(t)
+			resetAgentCtxForTest(t)
+
+			flushAborted := false
+			mock := &updatingMockCloudClient{
+				heartbeatFn: func(ctx context.Context) (*aikido_types.CloudConfigData, error) {
+					<-ctx.Done()
+					flushAborted = true
+					return nil, ctx.Err()
+				},
+			}
+			original := GetCloudClient()
+			SetCloudClient(mock)
+			t.Cleanup(func() { SetCloudClient(original) })
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			done := make(chan error, 1)
+			go func() { done <- AgentUninit(ctx) }()
+
+			synctest.Wait()
+			assert.False(t, flushAborted, "flush should still be pending before the deadline")
+
+			time.Sleep(10 * time.Second)
+			synctest.Wait()
+
+			assert.True(t, flushAborted, "flush should abort once ctx's deadline passes")
+			require.NoError(t, <-done, "shutdown should still complete cleanly after an aborted flush")
 		})
 	})
 }

--- a/internal/agent/updating.go
+++ b/internal/agent/updating.go
@@ -38,7 +38,7 @@ func startPolling() {
 	heartbeatCounter.Store(0)
 	steadyHeartbeatInterval.Store(int64(defaultHeartbeatInterval))
 
-	heartbeatRoutine = polling.Start(agentCtx, heartbeatInterval(), sendHeartbeatEvent)
+	heartbeatRoutine = polling.Start(agentCtx, heartbeatInterval(), func() { sendHeartbeatEvent(agentCtx) })
 	configPollingRoutine = polling.Start(agentCtx, 1*time.Minute, refreshCloudConfig)
 }
 
@@ -154,7 +154,7 @@ func refreshCloudConfig() {
 	applyCloudConfig(client, cloudConfig)
 }
 
-func sendHeartbeatEvent() {
+func sendHeartbeatEvent(ctx context.Context) {
 	defer advanceHeartbeatSchedule()
 
 	client := GetCloudClient()
@@ -162,7 +162,7 @@ func sendHeartbeatEvent() {
 		return
 	}
 
-	cloudConfig, err := client.SendHeartbeatEvent(agentCtx, getAgentInfo(),
+	cloudConfig, err := client.SendHeartbeatEvent(ctx, getAgentInfo(),
 		cloud.HeartbeatData{
 			Hostnames:           stateCollector.GetAndClearHostnames(),
 			Routes:              stateCollector.GetRoutesAndClear(),

--- a/internal/agent/updating_test.go
+++ b/internal/agent/updating_test.go
@@ -24,6 +24,7 @@ type updatingMockCloudClient struct {
 	heartbeatResult      *aikido_types.CloudConfigData
 	heartbeatErr         error
 	heartbeatCalled      bool
+	heartbeatFn          func(ctx context.Context) (*aikido_types.CloudConfigData, error)
 	subscribeFn          func(ctx context.Context, onUpdate func(int64)) error
 }
 
@@ -32,6 +33,9 @@ func (m *updatingMockCloudClient) SendStartEvent(agentInfo cloud.AgentInfo) (*ai
 }
 func (m *updatingMockCloudClient) SendHeartbeatEvent(ctx context.Context, agentInfo cloud.AgentInfo, data cloud.HeartbeatData) (*aikido_types.CloudConfigData, error) {
 	m.heartbeatCalled = true
+	if m.heartbeatFn != nil {
+		return m.heartbeatFn(ctx)
+	}
 	return m.heartbeatResult, m.heartbeatErr
 }
 func (m *updatingMockCloudClient) FetchConfigUpdatedAt() time.Time {
@@ -223,7 +227,7 @@ func TestSendHeartbeatEvent(t *testing.T) {
 		t.Cleanup(func() { SetCloudClient(original) })
 
 		assert.NotPanics(t, func() {
-			sendHeartbeatEvent()
+			sendHeartbeatEvent(context.Background())
 		})
 	})
 
@@ -237,7 +241,7 @@ func TestSendHeartbeatEvent(t *testing.T) {
 		SetCloudClient(mock)
 		t.Cleanup(func() { SetCloudClient(original) })
 
-		sendHeartbeatEvent()
+		sendHeartbeatEvent(context.Background())
 		assert.True(t, mock.heartbeatCalled)
 	})
 }

--- a/zen/shutdown.go
+++ b/zen/shutdown.go
@@ -10,5 +10,5 @@ import (
 // Zen's background processes. Call this before your application exits so
 // recent data is not lost.
 func Shutdown(ctx context.Context) error {
-	return agent.AgentUninit()
+	return agent.AgentUninit(ctx)
 }


### PR DESCRIPTION
The context from shutdown is now respected, if it's cancelled, the heartbeat request will stop. The rest of the shutdown still runs, but isn't an issue here like the http request.