### PR TITLE
Preserve custom Dial and ensure Dial is protected

### DIFF
--- a/instrumentation/sinks/net/http/dialtlscontext_test.go
+++ b/instrumentation/sinks/net/http/dialtlscontext_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -122,4 +123,29 @@ func TestSSRFDialTLS(t *testing.T) {
 	defer inbound.Close()
 
 	assertSSRFBlocked(t, inbound.URL, "/fetch-tls-custom", targetURL)
+}
+
+func TestSSRFDial(t *testing.T) {
+	require.NoError(t, zen.Protect())
+	require.True(t, zen.ShouldProtect())
+	config.SetBlocking(true)
+
+	internal, pool := newInternalTLSServer(t)
+	targetURL := internal.URL + "/"
+
+	var dialCalled atomic.Bool
+	trCustom := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}
+	trCustom.Dial = func(network, addr string) (net.Conn, error) { //nolint:staticcheck // asserting the deprecated field is preserved
+		dialCalled.Store(true)
+		return net.Dial(network, addr)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /fetch-dial", fetchHandler(trCustom))
+
+	inbound := httptest.NewServer(mux)
+	defer inbound.Close()
+
+	assertSSRFBlocked(t, inbound.URL, "/fetch-dial", targetURL)
+	assert.True(t, dialCalled.Load(), "custom Dial should still be used for the connection")
 }

--- a/instrumentation/sinks/net/http/wrap_transport.go
+++ b/instrumentation/sinks/net/http/wrap_transport.go
@@ -124,8 +124,15 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	originalDialContext := t.DialContext
 	hadCustomDialContext := originalDialContext != nil
 	if originalDialContext == nil {
-		var d net.Dialer
-		originalDialContext = d.DialContext
+		// Injecting DialContext makes Transport.dial stop consulting Dial, so keep using it here.
+		if userDial := t.Dial; userDial != nil { //nolint:staticcheck // intentionally preserving deprecated field
+			originalDialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
+				return userDial(network, addr)
+			}
+		} else {
+			var d net.Dialer
+			originalDialContext = d.DialContext
+		}
 	}
 	t.DialContext = ssrfDialContext(originalDialContext)
 


### PR DESCRIPTION
`Dial` was already protected, but we were overriding any custom `Dial` that was provided as Go gives priority to `DialContext`