### PR TITLE
Split install-tools to speed up CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: "1.25"
 
       - name: Install tools
-        run: make install-tools
+        run: make install-tools-lint
 
       - name: Run linter
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install tools
-        run: make install-tools
+        run: make install-tools-test
 
       - name: Run tests
         run: make test
@@ -81,7 +81,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install tools
-        run: make install-tools
+        run: make install-tools-test
 
       - name: Run unit tests
         run: make test-instrumentation-unit
@@ -117,7 +117,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install tools
-        run: make install-tools
+        run: make install-tools-test
 
       - name: Build Zen Go
         run: make build-zen-go

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,16 @@ define retry
 endef
 
 .PHONY: install-tools
-install-tools:
+install-tools: install-tools-test install-tools-lint
+
+.PHONY: install-tools-test
+install-tools-test:
 	@echo "Installing gotestsum"
 	@$(call retry,cd tools && GOBIN=$(TOOLS_BIN) go install gotest.tools/gotestsum)
 	@echo "✅ gotestsum installed successfully"
+
+.PHONY: install-tools-lint
+install-tools-lint:
 	@echo "Installing golangci-lint"
 	@$(call retry,GOBIN=$(TOOLS_BIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 	@echo "✅ golangci-lint installed successfully"


### PR DESCRIPTION
Currently the CI is installing the linter for test jobs and not using it. It takes a while to install the linter, so now only installing it when it will actually be used, takes around 30s off each test job.