### PR TITLE
Update Gin to use prepend instead of wrap

### DIFF
--- a/instrumentation/sources/gin-gonic/gin/integration_test.go
+++ b/instrumentation/sources/gin-gonic/gin/integration_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	_ "github.com/AikidoSec/firewall-go/instrumentation"
+	"github.com/AikidoSec/firewall-go/internal/agent"
 	"github.com/AikidoSec/firewall-go/internal/request"
 	"github.com/AikidoSec/firewall-go/zen"
 	"github.com/gin-gonic/gin"
@@ -61,10 +63,23 @@ func TestGinIsInstrumentedWhenConstructorPassedByValue(t *testing.T) {
 
 func TestGinDefaultIsInstrumentedExactlyOnce(t *testing.T) {
 	// gin.Default() calls New() internally, so this guards against the
-	// zen middleware being registered twice.
+	// zen hook running twice for the same request.
 	require.NoError(t, zen.Protect())
 
 	router := gin.Default()
+	router.ContextWithFallback = true
 
-	require.Len(t, router.Handlers, 3, "gin.Default() should register Logger, Recovery, and the zen middleware - no more")
+	router.GET("/route", func(c *gin.Context) {})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	w := httptest.NewRecorder()
+
+	agent.Stats().GetAndClear()
+
+	router.ServeHTTP(w, r)
+
+	require.Eventually(t, func() bool {
+		stats := agent.Stats().GetAndClear()
+		return stats.Requests.Total == 1
+	}, 100*time.Millisecond, 10*time.Millisecond)
 }

--- a/instrumentation/sources/gin-gonic/gin/integration_test.go
+++ b/instrumentation/sources/gin-gonic/gin/integration_test.go
@@ -38,6 +38,27 @@ func TestGinIsAutomaticallyInstrumented(t *testing.T) {
 	router.ServeHTTP(w, r)
 }
 
+func TestGinIsInstrumentedWhenConstructorPassedByValue(t *testing.T) {
+	require.NoError(t, zen.Protect())
+
+	f := gin.Default
+	router := f()
+	router.ContextWithFallback = true
+
+	router.GET("/route", func(c *gin.Context) {
+		ctx := request.GetContext(c)
+		require.NotNil(t, ctx, "request context should be set")
+
+		assert.Equal(t, "gin", ctx.Source)
+		assert.Equal(t, "/route", ctx.Route)
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
 func TestGinDefaultIsInstrumentedExactlyOnce(t *testing.T) {
 	// gin.Default() calls New() internally, so this guards against the
 	// zen middleware being registered twice.

--- a/instrumentation/sources/gin-gonic/gin/integration_test.go
+++ b/instrumentation/sources/gin-gonic/gin/integration_test.go
@@ -62,12 +62,15 @@ func TestGinIsInstrumentedWhenConstructorPassedByValue(t *testing.T) {
 }
 
 func TestGinDefaultIsInstrumentedExactlyOnce(t *testing.T) {
-	// gin.Default() calls New() internally, so this guards against the
-	// zen hook running twice for the same request.
+	// gin.Default() calls New() internally, which itself calls With() once;
+	// Default() then calls With() again directly. Both guard against the
+	// zen middleware being registered twice.
 	require.NoError(t, zen.Protect())
 
 	router := gin.Default()
 	router.ContextWithFallback = true
+
+	require.Len(t, router.Handlers, 3, "gin.Default() should register zen, Logger, and Recovery - no more")
 
 	router.GET("/route", func(c *gin.Context) {})
 
@@ -82,4 +85,69 @@ func TestGinDefaultIsInstrumentedExactlyOnce(t *testing.T) {
 		stats := agent.Stats().GetAndClear()
 		return stats.Requests.Total == 1
 	}, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestGinWithChainedAfterNew(t *testing.T) {
+	// New() already registers zen via its own internal With() call;
+	// chaining another With() must not register it a second time, and
+	// must still apply the caller's own option.
+	require.NoError(t, zen.Protect())
+
+	router := gin.New().With(func(e *gin.Engine) {
+		e.RemoveExtraSlash = true
+	})
+	router.ContextWithFallback = true
+
+	assert.True(t, router.RemoveExtraSlash, "option passed to With should still be applied")
+	require.Len(t, router.Handlers, 1, "zen middleware should be registered exactly once")
+
+	router.GET("/route", func(c *gin.Context) {
+		ctx := request.GetContext(c)
+		require.NotNil(t, ctx, "request context should be set")
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
+func TestGinWithChainedAfterDefault(t *testing.T) {
+	// Default() alone already calls With() twice; chaining a third With()
+	// call must still not register zen again.
+	require.NoError(t, zen.Protect())
+
+	var optionApplied bool
+	router := gin.Default().With(func(e *gin.Engine) {
+		optionApplied = true
+	})
+	router.ContextWithFallback = true
+
+	assert.True(t, optionApplied, "option passed to With should still be applied")
+	require.Len(t, router.Handlers, 3, "zen, Logger, and Recovery should be registered exactly once")
+
+	router.GET("/route", func(c *gin.Context) {
+		ctx := request.GetContext(c)
+		require.NotNil(t, ctx, "request context should be set")
+	})
+
+	r := httptest.NewRequest("GET", "/route", http.NoBody)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+}
+
+func TestGinWithMultipleChainedCalls(t *testing.T) {
+	// Every With() call in a long chain must still apply its own option,
+	// while zen is only ever registered once - on the very first call.
+	require.NoError(t, zen.Protect())
+
+	var calls []string
+	router := gin.New().
+		With(func(e *gin.Engine) { calls = append(calls, "a") }).
+		With(func(e *gin.Engine) { calls = append(calls, "b") }).
+		With(func(e *gin.Engine) { calls = append(calls, "c") })
+
+	assert.Equal(t, []string{"a", "b", "c"}, calls, "every chained option should still run")
+	require.Len(t, router.Handlers, 1, "zen middleware should be registered exactly once despite multiple With calls")
 }

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -9,56 +9,69 @@ import (
 
 // GetMiddleware returns middleware that will create contexts of incoming requests. If service is empty then the
 // default service name will be used.
+//
+// Automatic instrumentation calls BeforeNext directly instead of registering this via .Use();
+// GetMiddleware remains for manual wiring and tests.
 func GetMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c == nil {
-			return // Don't investigate empty requests.
-		}
-
-		if !zen.ShouldProtect() {
-			zen.WarnIfNotProtected()
-			c.Next()
+		exit, blocked := BeforeNext(c)
+		if blocked {
 			return
 		}
 
-		ip := c.ClientIP()
-
-		var routeParams map[string]string
-		if len(c.Params) > 0 {
-			routeParams = make(map[string]string, len(c.Params))
-
-			for _, v := range c.Params {
-				routeParams[v.Key] = v.Value
-			}
-		}
-
-		data := zenhttp.ContextDataFromRequest(c.Request)
-		data.Source = "gin"
-		data.Route = c.FullPath()
-		data.RouteParams = routeParams
-		data.RemoteAddress = &ip
-		data.Body = zenhttp.TryExtractBody(c.Request, c)
-
-		reqCtx := request.SetContext(c.Request.Context(), data)
-		c.Request = c.Request.WithContext(reqCtx)
-
-		// Write a response using Gin :
-		res := zenhttp.OnInitRequest(c)
-		if res != nil {
-			c.String(res.StatusCode, res.Message)
-			c.Abort()
-			return
-		}
-
-		// Run post request in defer to still trigger it on panics
-		// It may not run depending where the recovery middleware sits in the middleware chain
-		defer func() {
-			statusCode := c.Writer.Status()
-			zenhttp.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
-		}()
-
-		request.Wrap(reqCtx, func() {
-			c.Next()
-		})
+		defer exit()
+		c.Next()
 	}
+}
+
+// BeforeNext runs the zen request-context setup and blocking checks for c, once per request.
+// If blocked, a response was already written and the caller must not run any handlers.
+// Otherwise the caller must defer the returned exit func to run post-request logic.
+func BeforeNext(c *gin.Context) (exit func(), blocked bool) {
+	noop := func() {}
+
+	if c == nil {
+		return noop, false // Don't investigate empty requests.
+	}
+
+	if !zen.ShouldProtect() {
+		zen.WarnIfNotProtected()
+		return noop, false
+	}
+
+	ip := c.ClientIP()
+
+	var routeParams map[string]string
+	if len(c.Params) > 0 {
+		routeParams = make(map[string]string, len(c.Params))
+
+		for _, v := range c.Params {
+			routeParams[v.Key] = v.Value
+		}
+	}
+
+	data := zenhttp.ContextDataFromRequest(c.Request)
+	data.Source = "gin"
+	data.Route = c.FullPath()
+	data.RouteParams = routeParams
+	data.RemoteAddress = &ip
+	data.Body = zenhttp.TryExtractBody(c.Request, c)
+
+	reqCtx := request.SetContext(c.Request.Context(), data)
+	c.Request = c.Request.WithContext(reqCtx)
+
+	// Write a response using Gin :
+	res := zenhttp.OnInitRequest(c)
+	if res != nil {
+		c.String(res.StatusCode, res.Message)
+		c.Abort()
+		return noop, true
+	}
+
+	restoreGLS := request.EnterGLS(reqCtx)
+
+	return func() {
+		restoreGLS()
+		zenhttp.OnPostRequest(c, c.Writer.Status()) // Run post-request logic (should discover route, api spec,...)
+	}, false
 }

--- a/instrumentation/sources/gin-gonic/gin/middleware.go
+++ b/instrumentation/sources/gin-gonic/gin/middleware.go
@@ -9,69 +9,56 @@ import (
 
 // GetMiddleware returns middleware that will create contexts of incoming requests. If service is empty then the
 // default service name will be used.
-//
-// Automatic instrumentation calls BeforeNext directly instead of registering this via .Use();
-// GetMiddleware remains for manual wiring and tests.
 func GetMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		exit, blocked := BeforeNext(c)
-		if blocked {
+		if c == nil {
+			return // Don't investigate empty requests.
+		}
+
+		if !zen.ShouldProtect() {
+			zen.WarnIfNotProtected()
+			c.Next()
 			return
 		}
 
-		defer exit()
-		c.Next()
-	}
-}
+		ip := c.ClientIP()
 
-// BeforeNext runs the zen request-context setup and blocking checks for c, once per request.
-// If blocked, a response was already written and the caller must not run any handlers.
-// Otherwise the caller must defer the returned exit func to run post-request logic.
-func BeforeNext(c *gin.Context) (exit func(), blocked bool) {
-	noop := func() {}
+		var routeParams map[string]string
+		if len(c.Params) > 0 {
+			routeParams = make(map[string]string, len(c.Params))
 
-	if c == nil {
-		return noop, false // Don't investigate empty requests.
-	}
-
-	if !zen.ShouldProtect() {
-		zen.WarnIfNotProtected()
-		return noop, false
-	}
-
-	ip := c.ClientIP()
-
-	var routeParams map[string]string
-	if len(c.Params) > 0 {
-		routeParams = make(map[string]string, len(c.Params))
-
-		for _, v := range c.Params {
-			routeParams[v.Key] = v.Value
+			for _, v := range c.Params {
+				routeParams[v.Key] = v.Value
+			}
 		}
+
+		data := zenhttp.ContextDataFromRequest(c.Request)
+		data.Source = "gin"
+		data.Route = c.FullPath()
+		data.RouteParams = routeParams
+		data.RemoteAddress = &ip
+		data.Body = zenhttp.TryExtractBody(c.Request, c)
+
+		reqCtx := request.SetContext(c.Request.Context(), data)
+		c.Request = c.Request.WithContext(reqCtx)
+
+		// Write a response using Gin :
+		res := zenhttp.OnInitRequest(c)
+		if res != nil {
+			c.String(res.StatusCode, res.Message)
+			c.Abort()
+			return
+		}
+
+		// Run post request in defer to still trigger it on panics
+		// It may not run depending where the recovery middleware sits in the middleware chain
+		defer func() {
+			statusCode := c.Writer.Status()
+			zenhttp.OnPostRequest(c, statusCode) // Run post-request logic (should discover route, api spec,...)
+		}()
+
+		request.Wrap(reqCtx, func() {
+			c.Next()
+		})
 	}
-
-	data := zenhttp.ContextDataFromRequest(c.Request)
-	data.Source = "gin"
-	data.Route = c.FullPath()
-	data.RouteParams = routeParams
-	data.RemoteAddress = &ip
-	data.Body = zenhttp.TryExtractBody(c.Request, c)
-
-	reqCtx := request.SetContext(c.Request.Context(), data)
-	c.Request = c.Request.WithContext(reqCtx)
-
-	// Write a response using Gin :
-	res := zenhttp.OnInitRequest(c)
-	if res != nil {
-		c.String(res.StatusCode, res.Message)
-		c.Abort()
-		return noop, true
-	}
-
-	restoreGLS := request.EnterGLS(reqCtx)
-
-	return func() {
-		restoreGLS()
-		zenhttp.OnPostRequest(c, c.Writer.Status()) // Run post-request logic (should discover route, api spec,...)
-	}, false
 }

--- a/instrumentation/sources/gin-gonic/gin/zen.instrument.yml
+++ b/instrumentation/sources/gin-gonic/gin/zen.instrument.yml
@@ -3,26 +3,24 @@ meta:
   description: Gin is a web framework written in Go.
 
 rules:
-  # Declares a linkname so the prepend rule below can call BeforeNext.
-  - id: gin.Context.Next.linkname
+  # New()/Default() both funnel through With(); Handlers starts empty on a
+  # fresh Engine and With() never clears it, so len(Handlers) == 0 fires
+  # registration on the Engine's first With() call only.
+  - id: gin.Engine.With.linkname
     type: inject-decl
     package: github.com/gin-gonic/gin
     anchor: New
     links:
       - github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
     template: |
-      //go:linkname __aikido_gin_beforeNext github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin.BeforeNext
-      func __aikido_gin_beforeNext(*Context) (func(), bool)
+      //go:linkname __aikido_gin_getMiddleware github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin.GetMiddleware
+      func __aikido_gin_getMiddleware() HandlerFunc
 
-  - id: gin.Context.Next
+  - id: gin.Engine.With
     type: prepend
-    receiver: "*github.com/gin-gonic/gin.Context"
-    function: Next
+    receiver: "*github.com/gin-gonic/gin.Engine"
+    function: With
     template: |
-      if {{ .Function.Receiver }}.index == -1 {
-        _aikido_exit, _aikido_blocked := __aikido_gin_beforeNext({{ .Function.Receiver }})
-        if _aikido_blocked {
-          return
-        }
-        defer _aikido_exit()
+      if len({{ .Function.Receiver }}.Handlers) == 0 {
+        {{ .Function.Receiver }}.Use(__aikido_gin_getMiddleware())
       }

--- a/instrumentation/sources/gin-gonic/gin/zen.instrument.yml
+++ b/instrumentation/sources/gin-gonic/gin/zen.instrument.yml
@@ -3,18 +3,26 @@ meta:
   description: Gin is a web framework written in Go.
 
 rules:
-  - id: gin.Default
-    type: wrap
-    match: github.com/gin-gonic/gin.Default
-    imports:
-      zengin: github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
+  # Declares a linkname so the prepend rule below can call BeforeNext.
+  - id: gin.Context.Next.linkname
+    type: inject-decl
+    package: github.com/gin-gonic/gin
+    anchor: New
+    links:
+      - github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
     template: |
-      func() *gin.Engine { e := {{.}}; e.Use(zengin.GetMiddleware()); return e }()
+      //go:linkname __aikido_gin_beforeNext github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin.BeforeNext
+      func __aikido_gin_beforeNext(*Context) (func(), bool)
 
-  - id: gin.New
-    type: wrap
-    match: github.com/gin-gonic/gin.New
-    imports:
-      zengin: github.com/AikidoSec/firewall-go/instrumentation/sources/gin-gonic/gin
+  - id: gin.Context.Next
+    type: prepend
+    receiver: "*github.com/gin-gonic/gin.Context"
+    function: Next
     template: |
-      func() *gin.Engine { e := {{.}}; e.Use(zengin.GetMiddleware()); return e }()
+      if {{ .Function.Receiver }}.index == -1 {
+        _aikido_exit, _aikido_blocked := __aikido_gin_beforeNext({{ .Function.Receiver }})
+        if _aikido_blocked {
+          return
+        }
+        defer _aikido_exit()
+      }


### PR DESCRIPTION
The wrap instrumentation has a lot of edge cases where instrumentation may not occur. Prepend is much more reliable, switching to use it here.