### PR TITLE
Split WrapWithGLS into enter/exit funcs

### DIFF
--- a/instrumentation/request/context.go
+++ b/instrumentation/request/context.go
@@ -24,3 +24,8 @@ func HasContext(ctx context.Context) bool {
 func Wrap(ctx context.Context, fn func()) {
 	request.WrapWithGLS(ctx, fn)
 }
+
+// EnterGLS is Wrap split into enter/exit, for callers that can't scope the call with a closure.
+func EnterGLS(ctx context.Context) func() {
+	return request.EnterGLS(ctx)
+}

--- a/internal/request/gls.go
+++ b/internal/request/gls.go
@@ -59,19 +59,23 @@ func glsStateFor(ctx context.Context) *glsState {
 
 // WrapWithGLS keeps the context alive in the GLS until the given function has finished executing.
 func WrapWithGLS(ctx context.Context, fn func()) {
+	restore := EnterGLS(ctx)
+	defer restore()
+	fn()
+}
+
+// EnterGLS is WrapWithGLS split into enter/exit, for callers that can't scope the call with a closure.
+func EnterGLS(ctx context.Context) func() {
 	if glsSet == nil {
-		fn()
-		return
+		return func() {}
 	}
 
 	state := glsStateFor(ctx)
 	if state == nil {
-		fn()
-		return
+		return func() {}
 	}
 
 	prev := glsGet()
 	glsSet(state)
-	defer glsSet(prev)
-	fn()
+	return func() { glsSet(prev) }
 }

--- a/internal/request/gls_test.go
+++ b/internal/request/gls_test.go
@@ -79,6 +79,30 @@ func TestWrapWithGLS(t *testing.T) {
 	}
 }
 
+func TestEnterGLS(t *testing.T) {
+	remoteAddr := "192.168.1.1:8080"
+	ctx := SetContext(context.Background(), ContextData{
+		Source:        "test-source",
+		Route:         "/test",
+		RemoteAddress: &remoteAddr,
+		URL:           "https://example.com/test",
+		Path:          "/test",
+		Method:        "GET",
+	})
+
+	assert.Nil(t, getLocalContext(), "GLS should be empty before EnterGLS is called")
+
+	restore := EnterGLS(ctx)
+
+	captured := getLocalContext()
+	require.NotNil(t, captured, "context should be visible via GLS as soon as EnterGLS returns, without needing a wrapping closure")
+	assert.Equal(t, "test-source", captured.Source)
+
+	restore()
+
+	assert.Nil(t, getLocalContext(), "GLS should be restored to its previous state once restore is called")
+}
+
 func TestWrapWithGLS_BypassedContext(t *testing.T) {
 	block := true
 	config.UpdateServiceConfig(&aikido_types.CloudConfigData{


### PR DESCRIPTION
To allow for funcs to use GLS which can't wrap everything in a closure.